### PR TITLE
Fix Windows/MSVC build issues for TurboQuant runtime

### DIFF
--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -13,6 +13,16 @@
 #include <stdlib.h> // for qsort
 #include <stdio.h>  // for GGML_ASSERT
 
+#include <intrin.h>
+
+#ifdef _MSC_VER
+static inline int ffs(int x) {
+    unsigned long idx;
+    if (_BitScanForward(&idx, x)) return (int)idx + 1;
+    return 0;
+}
+#endif
+
 #define GROUP_MAX_EPS 1e-15f
 #define GROUP_MAX_EPS_IQ3_XXS 1e-8f
 #define GROUP_MAX_EPS_IQ2_S 1e-8f

--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -9,7 +9,7 @@
 #include "ggml-quants.h"
 #include "ggml-common.h"
 #include "ggml-impl.h"
-
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
This PR fixes two small Windows/MSVC build issues encountered while compiling the TurboQuant runtime.

Changes:
1. `ggml-turbo-quant.c`
- add `_USE_MATH_DEFINES` before `math.h`
- fixes `M_PI` undeclared on MSVC

2. `ggml-quants.c`
- add `intrin.h`
- add MSVC fallback implementation for `ffs()`

Result:
- successful Windows 11 build
- tested with `llama-server` in Release mode
- validated running Qwopus3.5-27B-v3-TQ3_4S on RTX 5070 Ti 16GB

This should help Windows/MSVC users build successfully without manual patching.