### PR TITLE
ci: validate ampere PR2 with Linux-only rt link

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -1015,8 +1015,8 @@ void launch_fattn(
         explicit hip_f16_alloc(cudaStream_t s) : stream(s) {}
         ~hip_f16_alloc() {
             if (ptr) {
-                cudaStreamSynchronize(stream);
-                cudaFree(ptr);
+                (void) cudaStreamSynchronize(stream);
+                (void) cudaFree(ptr);
             }
         }
         void alloc(size_t nelements) {

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -26,7 +26,7 @@ static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, con
             break;
         case GGML_TYPE_NVFP4:
             mul_mat_q_case<GGML_TYPE_NVFP4>(ctx, args, stream);
-            [[fallthrough]];
+            break;
         case GGML_TYPE_TQ3_0:
             mul_mat_q_case<GGML_TYPE_TQ3_0>(ctx, args, stream);
             break;

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -26,6 +26,7 @@ static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, con
             break;
         case GGML_TYPE_NVFP4:
             mul_mat_q_case<GGML_TYPE_NVFP4>(ctx, args, stream);
+            [[fallthrough]];
         case GGML_TYPE_TQ3_0:
             mul_mat_q_case<GGML_TYPE_TQ3_0>(ctx, args, stream);
             break;

--- a/ggml/src/ggml-cuda/turbo-wht.cu
+++ b/ggml/src/ggml-cuda/turbo-wht.cu
@@ -1,4 +1,4 @@
-#include "common.cuh"
+#include "turbo-wht.cuh"
 
 // Dynamic Walsh-Hadamard Transform — supports any power-of-2 group size
 // Group size = head_dim, passed via op_params[1]

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -61,8 +61,10 @@
 #define cudaError_t hipError_t
 #define cudaErrorPeerAccessAlreadyEnabled hipErrorPeerAccessAlreadyEnabled
 #define cudaErrorPeerAccessNotEnabled hipErrorPeerAccessNotEnabled
+#define cudaEventCreate hipEventCreate
 #define cudaEventCreateWithFlags hipEventCreateWithFlags
 #define cudaEventDisableTiming hipEventDisableTiming
+#define cudaEventElapsedTime hipEventElapsedTime
 #define cudaEventRecord hipEventRecord
 #define cudaEventSynchronize hipEventSynchronize
 #define cudaEvent_t hipEvent_t

--- a/tools/llama-bench/CMakeLists.txt
+++ b/tools/llama-bench/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(TARGET llama-bench)
 add_executable(${TARGET} llama-bench.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} rt)
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(${TARGET} PRIVATE rt)
+endif()
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
 if(LLAMA_TOOLS_INSTALL)

--- a/tools/perplexity/CMakeLists.txt
+++ b/tools/perplexity/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(TARGET llama-perplexity)
 add_executable(${TARGET} perplexity.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} rt)
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(${TARGET} PRIVATE rt)
+endif()
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
 if(LLAMA_TOOLS_INSTALL)

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -68,6 +68,9 @@ install(TARGETS ${TARGET} RUNTIME)
 
 target_include_directories(${TARGET} PRIVATE ../mtmd)
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(${TARGET} PRIVATE server-context PUBLIC common cpp-httplib ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} rt)
+target_link_libraries(${TARGET} PRIVATE server-context PUBLIC common cpp-httplib ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(${TARGET} PRIVATE rt)
+endif()
 
 target_compile_features(${TARGET} PRIVATE cxx_std_17)


### PR DESCRIPTION
Validation branch for PR #2 after current main fixes.\n\nIncludes PR #2 changes plus a CI fix that links librt only on Linux for llama-bench, perplexity, and server.\n\nLocal validation:\n\n```bash\ncmake -B build -DLLAMA_FATAL_WARNINGS=ON -DGGML_RPC=ON\ncmake --build build --config Release -j8\n```\n\nResult: full local Linux build passes, including llama-bench, llama-perplexity, llama-tts, and llama-server.