### PR TITLE
rebase: fix duplicate llama_context_type enum after upstream landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For GGUFs that include native MTP tensors, use the speculative runtime shape bel
   -m /path/to/model.gguf \
   -ngl 99 -fa on -np 1 -c 2048 -b 32 -ub 32 \
   --ctx-checkpoints 0 --checkpoint-every-n-tokens -1 \
-  --spec-type mtp --spec-draft-n-max 3 --spec-draft-ngl 99 \
+  --spec-type draft-mtp --spec-draft-n-max 3 --spec-draft-ngl 99 \
   -ctk q4_0 -ctv tq3_0 \
   --cache-ram 0 \
   --no-warmup --jinja \
@@ -130,7 +130,7 @@ For GGUFs that include native MTP tensors, use the speculative runtime shape bel
 Notes:
 - keep the same `-ctk q4_0 -ctv tq3_0` KV-cache shape used elsewhere in this fork
 - use `--ctx-checkpoints 0 --checkpoint-every-n-tokens -1` when the speculative path needs to avoid checkpoint pressure
-- `--spec-type mtp` is only for GGUFs that were built with MTP support
+- `--spec-type draft-mtp` is only for GGUFs that were built with MTP support
 
 ## Benchmark
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -208,11 +208,6 @@ extern "C" {
         LLAMA_SPLIT_MODE_TENSOR = 3,
     };
 
-    enum llama_context_type {
-        LLAMA_CONTEXT_TYPE_DEFAULT = 0,
-        LLAMA_CONTEXT_TYPE_MTP     = 1,
-    };
-
     // TODO: simplify (https://github.com/ggml-org/llama.cpp/pull/9294#pullrequestreview-2286561979)
     typedef struct llama_token_data {
         llama_token id; // token id


### PR DESCRIPTION
Follow-up fix for the upstream rebase branch after merge.\n\nThis removes a duplicate  enum definition in  that broke the Server workflow on Linux and Windows.\n\nRoot cause seen in CI:\n- multiple definition of \n- affected jobs: Server default/backend-sampling/server-windows\n\nThis PR is intentionally minimal and only addresses that compile regression.