### PR TITLE
server: restore default webui route behavior after rebase

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2872,6 +2872,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         string_format("whether to enable the Web UI (default: %s)", params.webui ? "enabled" : "disabled"),
         [](common_params & params, bool value) {
             params.webui = value;
+            params.ui = value;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_WEBUI"));
     add_opt(common_arg(

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -83,6 +83,10 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    // Compatibility: this branch still exposes --webui/--no-webui in the CLI.
+    // Keep the newer `ui` field in sync until `--ui/--no-ui` is wired here too.
+    params.ui = params.webui;
+
     llama_backend_init();
     llama_numa_init(params.numa);
 


### PR DESCRIPTION
Follow-up fix after the upstream rebase landing.

This restores the expected default Web UI behavior in server tests:
- `GET /` should return the embedded UI by default
- `--no-webui` should return 404

Root cause:
- server route mounting now checks `params.ui`
- this branch still exposes the legacy `--webui/--no-webui` CLI flag
- the two fields drifted, so `/` was no longer mounted even when Web UI was expected to be enabled

Fix:
- keep `params.ui` synchronized with the legacy `params.webui`
- sync both in CLI parsing and once after parse in server startup for compatibility
