### PR TITLE
tests: fix missing parameter in test-backend-ops.cpp

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3871,7 +3871,7 @@ struct test_gated_delta_net : public test_case {
         // q/k are L2-normalised in qwen35/kimi-linear before delta_net
         q = ggml_l2_norm(ctx, q, 1e-6f);
         k = ggml_l2_norm(ctx, k, 1e-6f);
-        ggml_tensor * out   = ggml_gated_delta_net(ctx, q, k, v, g, beta, state);
+        ggml_tensor * out   = ggml_gated_delta_net(ctx, q, k, v, g, beta, state, K > 1);
         return out;
     }
 


### PR DESCRIPTION
## Overview

The build broke because of a signature mismatch. ggml_gated_delta_net was updated to take an 8th argument, bool keep_intermediates (ggml.h:2559, ggml.c:6211), but the test call site at tests/test-backend-ops.cpp:3874 still passed only 7 arguments.

**Fix**

I passed K > 1 as the keep_intermediates flag:

```
tests/test-backend-ops.cpp:
        // q/k are L2-normalised in qwen35/kimi-linear before delta_net
        q = ggml_l2_norm(ctx, q, 1e-6f);
        k = ggml_l2_norm(ctx, k, 1e-6f);
      - ggml_tensor * out   = ggml_gated_delta_net(ctx, q, k, v, g, beta, state);
      + ggml_tensor * out   = ggml_gated_delta_net(ctx, q, k, v, g, beta, state, K > 1);
        return out;
    }
```

K is the test's snapshot-slot count. This matches the real callers in `src/models/delta-net-base.cpp`, which pass false for the K=1 (final-state-only) path and true for the snapshot paths — so the test now exercises the op with the semantically correct flag for whatever K the test case uses.

Tested locally & was able to successfully run a TQ3_0 model afterwards.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Claude used to diagnose the fault, but did not use Claude to create the fix.
