### PR TITLE
perf+fix: TQ3_4S decode tuning, MTP offload fix, empty-think parser

### DIFF
--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -218,6 +218,47 @@ std::string common_chat_peg_mapper::normalize_container_value(const std::string 
     return normalize_quotes_to_json(input);
 }
 
+static bool is_ascii_whitespace_only(const std::string & text) {
+    for (char c : text) {
+        if (c != ' ' && c != '\n' && c != '\r' && c != '\t') {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void strip_leading_empty_reasoning_prefill(common_chat_msg & result) {
+    static const std::string kThinkOpen = "<think>";
+    static const std::string kThinkClose = "</think>";
+
+    if (!result.reasoning_content.empty() || result.content.compare(0, kThinkOpen.size(), kThinkOpen) != 0) {
+        return;
+    }
+
+    const size_t close_pos = result.content.find(kThinkClose, kThinkOpen.size());
+    if (close_pos == std::string::npos) {
+        return;
+    }
+
+    const size_t body_start = kThinkOpen.size();
+    const std::string body = result.content.substr(body_start, close_pos - body_start);
+    if (!is_ascii_whitespace_only(body)) {
+        return;
+    }
+
+    const size_t suffix_start = close_pos + kThinkClose.size();
+    size_t trim_start = suffix_start;
+    while (trim_start < result.content.size()) {
+        const char c = result.content[trim_start];
+        if (c != ' ' && c != '\n' && c != '\r' && c != '\t') {
+            break;
+        }
+        ++trim_start;
+    }
+
+    result.content.erase(0, trim_start);
+}
+
 void common_chat_peg_mapper::from_ast(const common_peg_ast_arena &    arena,
                                       const common_peg_parse_result & parse_result_arg) {
     arena.visit(parse_result_arg, [this](const common_peg_ast_node & node) { map(node); });
@@ -236,17 +277,12 @@ void common_chat_peg_mapper::from_ast(const common_peg_ast_arena &    arena,
 
     // Discard whitespace-only reasoning content (e.g. from <think></think> prefill)
     if (!result.reasoning_content.empty()) {
-        bool all_whitespace = true;
-        for (char c : result.reasoning_content) {
-            if (c != ' ' && c != '\n' && c != '\r' && c != '\t') {
-                all_whitespace = false;
-                break;
-            }
-        }
-        if (all_whitespace) {
+        if (is_ascii_whitespace_only(result.reasoning_content)) {
             result.reasoning_content.clear();
         }
     }
+
+    strip_leading_empty_reasoning_prefill(result);
 }
 
 void common_chat_peg_mapper::map(const common_peg_ast_node & node) {

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -280,12 +280,15 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
     return false;
 #endif // GGML_CUDA_FORCE_CUBLAS
 
-    // TQ3_0/TQ3_1S/TQ3_4S: use MMQ for prefill (ne11 >= 64) on NVIDIA tensor-core GPUs.
+    // TQ3_4S prompt throughput improves when it can use MMQ for narrower prefill shapes.
     // Contiguity guard in ggml_cuda_mul_mat ensures KV cache views use cuBLAS.
     if ((type == GGML_TYPE_TQ3_0 || type == GGML_TYPE_TQ3_1S || type == GGML_TYPE_TQ3_4S) &&
         GGML_CUDA_CC_IS_NVIDIA(cc) &&
         fp16_mma_hardware_available(cc) &&
         n_experts == 0) {
+        if (type == GGML_TYPE_TQ3_4S) {
+            return ne11 >= 16;
+        }
         return ne11 >= 64;
     }
 

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3464,24 +3464,28 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
         const block_tq3_4s * bxi = (const block_tq3_4s *)x + kbx0 + i*stride + blk_in_row;
 
-        // Decode all 4 subgroup scales, find max for the block-level scale
-        float rms[4];
-        for (int g = 0; g < 4; g++) {
-            const uint8_t sb = bxi->d[g];
+        // Each adjacent thread pair works on one 32-weight block.
+        // Decode only the two subgroup scales used by this thread, then share
+        // the block max with the sibling thread instead of redundantly decoding all four.
+        float rms_local[2];
+#pragma unroll
+        for (int sg = 0; sg < 2; ++sg) {
+            const uint8_t sb = bxi->d[g_base + sg];
             if (sb == 0) {
-                rms[g] = 0.0f;
+                rms_local[sg] = 0.0f;
             } else {
-                rms[g] = ldexpf(1.0f + (float)(sb & 31) / 32.0f, (sb >> 5) - 9);
+                rms_local[sg] = ldexpf(1.0f + (float)(sb & 31) / 32.0f, (sb >> 5) - 9);
             }
         }
-        const float amax = fmaxf(fmaxf(rms[0], rms[1]), fmaxf(rms[2], rms[3])) * 1.996684f;
+        const float amax_pair = fmaxf(rms_local[0], rms_local[1]);
+        const float amax = fmaxf(amax_pair, __shfl_xor_sync(0xFFFFFFFF, amax_pair, 1)) * 1.996684f;
         const float d_block = amax / 127.0f;
         const float d_inv = (d_block > 0.0f) ? 127.0f / amax : 0.0f;
 
 #pragma unroll
         for (int sg = 0; sg < 2; sg++) {
             const int g = g_base + sg;
-            const float rms_g = rms[g];
+            const float rms_g = rms_local[sg];
 
             const uint8_t * qp = bxi->qs + g * 3;
             const uint32_t packed = (uint32_t)qp[0] | ((uint32_t)qp[1] << 8) | ((uint32_t)qp[2] << 16);

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3478,7 +3478,8 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
             }
         }
         const float amax_pair = fmaxf(rms_local[0], rms_local[1]);
-        const float amax = fmaxf(amax_pair, __shfl_xor_sync(0xFFFFFFFF, amax_pair, 1)) * 1.996684f;
+        const float amax_shfl = __shfl_xor_sync(0xFFFFFFFF, amax_pair, 1, WARP_SIZE);
+        const float amax = fmaxf(amax_pair, amax_shfl) * 1.996684f;
         const float d_block = amax / 127.0f;
         const float d_inv = (d_block > 0.0f) ? 127.0f / amax : 0.0f;
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -304,6 +304,12 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
     if (table_id == MMVQ_PARAMETERS_GENERIC) {
         switch (ncols_dst) {
             case 1:
+                if (type == GGML_TYPE_TQ3_4S) {
+                    // TQ3_4S has a heavier vec_dot than the simple q4/q8 paths.
+                    // On NVIDIA, 4 warps overpay in shared reduction for bs=1 decode.
+                    return 2;
+                }
+                [[fallthrough]];
             case 2:
             case 3:
             case 4:
@@ -868,6 +874,14 @@ static void mul_mat_vec_q_switch_ncols_dst(
                 (is_nvidia_pascal_older && std::find(slow_pascal.begin(), slow_pascal.end(), type) != slow_pascal.end()) ||
                 GGML_CUDA_CC_IS_RDNA(cc)) {
             use = false;
+        }
+
+        if (GGML_CUDA_CC_IS_NVIDIA(cc) && type == GGML_TYPE_TQ3_4S && c_ncols_dst == 1) {
+            // 27B-class widths benefit from 2 rows/block; smaller models do not.
+            constexpr int large_k_threshold_blocks = 144;
+            if (blocks_per_row_x >= large_k_threshold_blocks) {
+                use = true;
+            }
         }
 
         return use;

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1466,12 +1466,7 @@ static __device__ __forceinline__ float tq3_4s_dot_subgroup_q8_1(
     int sumi = ggml_cuda_dp4a(w_lo, a_lo, 0);
     sumi     = ggml_cuda_dp4a(w_hi, a_hi, sumi);
 
-    // Scale: d_weight * (centroid_scale / 127) * d_activation
-    // centroids range [-2.1519, 2.1519], levels range [-127, 127]
-    // so levels[i] = centroids[i] * (127 / 2.1519)
-    // dot = sumi * d_weight * (2.1519 / 127) * d_activation
-    const float2 ds8 = __half22float2(bq8_1->ds);
-    return (float)sumi * d * (2.1519f / 127.0f) * ds8.x;
+    return (float)sumi * d;
 }
 
 static __device__ __forceinline__ float vec_dot_tq3_4s_q8_1(
@@ -1479,6 +1474,9 @@ static __device__ __forceinline__ float vec_dot_tq3_4s_q8_1(
 
     const block_tq3_4s * bq = (const block_tq3_4s *) vbq + kbx;
     const int subgroup0 = iqs / 4;
+    const float2 ds8 = __half22float2(bq8_1->ds);
+    // Hoist the activation-side scale once per block instead of reloading it per subgroup.
+    const float scale = (2.1519f / 127.0f) * ds8.x;
     float sum = 0.0f;
 
 #pragma unroll
@@ -1486,5 +1484,5 @@ static __device__ __forceinline__ float vec_dot_tq3_4s_q8_1(
         sum += tq3_4s_dot_subgroup_q8_1(bq, bq8_1, subgroup0 + s);
     }
 
-    return sum;
+    return sum * scale;
 }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1527,19 +1527,17 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
     }
 
     if (llama_supports_gpu_offload()) {
-        const int n_gpu = std::min(n_gpu_layers, int(hparams.n_layer));
+        const int max_backend_supported_layers = hparams.n_layer + 1;
+        const int max_offloadable_layers       = hparams.n_layer + 1;
+        const int n_gpu                        = std::min(n_gpu_layers, max_offloadable_layers);
+        const int n_repeating                  = n_gpu > 0 ? n_gpu - 1 : 0;
 
-        int n_repeating = n_gpu;
-        if (n_repeating > 0) {
+        if (n_gpu > 0) {
             LLAMA_LOG_INFO("%s: offloading output layer to GPU\n", __func__);
-            n_repeating--;
         }
         LLAMA_LOG_INFO("%s: offloading %d repeating layers to GPU\n", __func__, n_repeating);
 
-        const int max_backend_supported_layers = hparams.n_layer + 1;
-        const int max_offloadable_layers       = hparams.n_layer + 1;
-
-        LLAMA_LOG_INFO("%s: offloaded %d/%d layers to GPU\n", __func__, std::min(n_gpu_layers, max_offloadable_layers), max_backend_supported_layers);
+        LLAMA_LOG_INFO("%s: offloaded %d/%d layers to GPU\n", __func__, n_gpu, max_backend_supported_layers);
     }
 
     // print memory requirements per buffer type
@@ -1606,18 +1604,7 @@ const float * llama_model::tensor_split() const {
 }
 
 uint32_t llama_model::n_gpu_layers() const {
-    uint32_t n_gpu_layers = params.n_gpu_layers >= 0 ? params.n_gpu_layers : hparams.n_layer + 1;
-
-    const bool is_qwen35_native_mtp =
-        (arch == LLM_ARCH_QWEN35 || arch == LLM_ARCH_QWEN35MOE ||
-         arch == LLM_ARCH_QWEN35_MTP || arch == LLM_ARCH_QWEN35MOE_MTP) &&
-        hparams.nextn_predict_layers > 0;
-
-    if (is_qwen35_native_mtp && n_gpu_layers > hparams.n_layer) {
-        n_gpu_layers = hparams.n_layer;
-    }
-
-    return n_gpu_layers;
+    return params.n_gpu_layers >= 0 ? params.n_gpu_layers : hparams.n_layer + 1;
 }
 
 llama_split_mode llama_model::split_mode() const {

--- a/tests/test-chat-peg-parser.cpp
+++ b/tests/test-chat-peg-parser.cpp
@@ -21,6 +21,7 @@ static void test_example_qwen3_non_coder(testing & t);
 static void test_command7_parser_compare(testing & t);
 static void test_prefix_tool_names(testing & t);
 static void test_tagged_peg_parser(testing & t);
+static void test_empty_reasoning_prefill_strip(testing & t);
 
 int main(int argc, char * argv[]) {
     testing t(std::cout);
@@ -39,6 +40,7 @@ int main(int argc, char * argv[]) {
     t.test("comparison", test_command7_parser_compare);
     t.test("prefix tool names", test_prefix_tool_names);
     t.test("tagged peg parser", test_tagged_peg_parser);
+    t.test("empty reasoning prefill strip", test_empty_reasoning_prefill_strip);
 
     return t.summary();
 }
@@ -979,5 +981,31 @@ static void test_tagged_peg_parser(testing & t) {
         t.assert_true("success", result.result.success());
         t.assert_equal("fun_pre should be '<function='", "<function=", result.tags["fun_pre"]);
         t.assert_equal("fun_post should be '>'", ">", result.tags["fun_post"]);
+    });
+}
+
+static void test_empty_reasoning_prefill_strip(testing & t) {
+    auto parser = build_chat_peg_parser([](common_chat_peg_builder & p) {
+        return p.sequence({ p.content(p.rest()), p.end() });
+    });
+
+    common_chat_parser_params params;
+    params.format = COMMON_CHAT_FORMAT_PEG_NATIVE;
+    params.reasoning_format = COMMON_REASONING_FORMAT_NONE;
+
+    t.test("strips empty qwen off-thinking prefill", [&](testing & t) {
+        const std::string input = "<think>\n\n</think>\n\n{\"name\":\"alice\"}";
+        const auto msg = common_chat_peg_parse(parser, input, /* is_partial = */ false, params);
+
+        t.assert_equal("reasoning empty", std::string(), msg.reasoning_content);
+        t.assert_equal("content stripped", std::string("{\"name\":\"alice\"}"), msg.content);
+    });
+
+    t.test("keeps non-empty reasoning in content when reasoning_format=none", [&](testing & t) {
+        const std::string input = "<think>\nplan\n</think>\n\n{\"name\":\"alice\"}";
+        const auto msg = common_chat_peg_parse(parser, input, /* is_partial = */ false, params);
+
+        t.assert_equal("reasoning empty", std::string(), msg.reasoning_content);
+        t.assert_equal("content preserved", input, msg.content);
     });
 }


### PR DESCRIPTION
## Summary

5 focused commits from the mtp-q4k runtime validation track:

### Performance (CUDA)
- **mmvq**: tighten TQ3_4S decode launch shape (ncols-aware grid)
- **mmq**: widen TQ3_4S prompt gate (better tile utilization on prompt-shaped GEMMs)
- **mmq**: trim duplicate scale decode in MMQ staging (removes redundant FMA)

### Fix
- **llama-model**: allow full GPU offload for Qwen MTP (removes incorrect n_layer guard that blocked -ngl 99 on MTP models)

### Server
- **chat-peg-parser**: strip empty thinking prefill from content — when reasoning_format=none produces an empty `<think>\n\n</think>\n\n` wrapper with no actual reasoning, strip it from the returned content. Includes 2 new regression tests (35 tests, 202 assertions, 0 failures).

## Testing
- Full BenchLoop: overall 80.1 (vs Q3_K_M 79.38) at 42 tok/s gen on RTX 3090
- Parser: test-chat-peg-parser passes (35 tests, 202 assertions)
- coding 12/12, toolcall 13/15, dataextract 12/15