### PR TITLE
fix: correct stride and dimension bugs in embeddings_nextn

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -144,6 +144,9 @@ struct common_speculative_impl {
 
     virtual ~common_speculative_impl() = default;
 
+    // true if this implementation requires the target context to extract nextn embeddings
+    virtual bool need_embd_nextn() const { return false; }
+
     virtual void begin(llama_seq_id seq_id, const llama_tokens & prompt) = 0;
 
     virtual bool process(const llama_batch & batch) = 0;
@@ -422,6 +425,10 @@ struct common_speculative_state_mtp : public common_speculative_impl {
         batch.logits[0]    = 1;
 
         llama_set_mtp(ctx_tgt, ctx_dft);
+
+        // Enable extraction of nextn hidden states for MTP drafters (gemma4, etc.)
+        llama_set_embeddings_nextn(ctx_tgt, true, /*masked*/ false);
+        llama_set_embeddings_nextn(ctx_dft, true, /*masked*/ true);
     }
 
     ~common_speculative_state_mtp() override {
@@ -508,32 +515,69 @@ struct common_speculative_state_mtp : public common_speculative_impl {
                 wait_prefetch();
             }
 
-            ggml_tensor * src;
-            int32_t src_row;
+            ggml_tensor * src = nullptr;
+            int32_t src_row = 0;
+            bool use_nextn_fallback = false;
+
             if (k == 0) {
                 src = llama_context_get_t_h_pre_norm(ctx_tgt);
-                if (last_n_accepted < 0) {
-                    src_row = (src && src->ne[1] > 0) ? (int32_t) src->ne[1] - 1 : 0;
+                if (src) {
+                    if (last_n_accepted < 0) {
+                        src_row = src->ne[1] > 0 ? (int32_t) src->ne[1] - 1 : 0;
+                    } else {
+                        src_row = last_n_accepted;
+                    }
                 } else {
-                    src_row = last_n_accepted;
+                    // nextn fallback for target (gemma4 backbone, etc.)
+                    use_nextn_fallback = true;
+                    if (last_n_accepted < 0) {
+                        src_row = 0;
+                    } else {
+                        src_row = last_n_accepted;
+                    }
                 }
             } else {
                 src = llama_context_get_t_mtp_out(ctx_dft);
                 if (src == nullptr) {
                     src = llama_context_get_t_h_pre_norm(ctx_dft);
                 }
-                src_row = src ? (int32_t) src->ne[1] - 1 : 0;
+                if (src) {
+                    src_row = (int32_t) src->ne[1] - 1;
+                } else {
+                    // nextn fallback for draft (gemma4 assistant, etc.)
+                    use_nextn_fallback = true;
+                    src_row = 0;
+                }
             }
-            if (!src) {
+
+            if (!src && !use_nextn_fallback) {
                 break;
             }
 
             llama_context * src_ctx = k == 0 ? ctx_tgt : ctx_dft;
 
-            if (next_src != src || next_ctx != src_ctx || next_src_row != src_row) {
-                wait_prefetch();
-                prefetch_src_row(src_ctx, src, src_row);
-                wait_prefetch();
+            if (use_nextn_fallback) {
+                // Copy hidden state from pre-extracted nextn buffer to batch.embd
+                // NOTE: row_bytes is based on ctx_dft's n_embd, which matches the nextn
+                // row dimension for the draft model (n_embd == n_embd_out). If the k==0
+                // (target) fallback is ever taken with a model where target n_embd_out
+                // differs from draft n_embd, the copy would truncate.
+                if (batch.embd) {
+                    const float * h_row = llama_get_embeddings_nextn_ith(src_ctx, src_row);
+                    if (h_row) {
+                        memcpy(batch.embd, h_row, row_bytes);
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            } else {
+                if (next_src != src || next_ctx != src_ctx || next_src_row != src_row) {
+                    wait_prefetch();
+                    prefetch_src_row(src_ctx, src, src_row);
+                    wait_prefetch();
+                }
             }
             batch.token[0] = cond_tok;
             batch.pos[0]   = pos;
@@ -588,6 +632,10 @@ struct common_speculative_state_mtp : public common_speculative_impl {
 
         last_n_drafted  = 0;
         last_n_accepted = (int32_t) n_accepted;
+    }
+
+    bool need_embd_nextn() const override {
+        return true;
     }
 };
 
@@ -1295,6 +1343,20 @@ bool common_speculative_need_embd_pre_norm(common_speculative * spec) {
 
     for (const auto & impl : spec->impls) {
         if (impl->type == COMMON_SPECULATIVE_TYPE_MTP) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool common_speculative_need_embd_nextn(common_speculative * spec) {
+    if (spec == nullptr) {
+        return false;
+    }
+
+    for (const auto & impl : spec->impls) {
+        if (impl->need_embd_nextn()) {
             return true;
         }
     }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -557,15 +557,13 @@ struct common_speculative_state_mtp : public common_speculative_impl {
             llama_context * src_ctx = k == 0 ? ctx_tgt : ctx_dft;
 
             if (use_nextn_fallback) {
-                // Copy hidden state from pre-extracted nextn buffer to batch.embd
-                // NOTE: row_bytes is based on ctx_dft's n_embd, which matches the nextn
-                // row dimension for the draft model (n_embd == n_embd_out). If the k==0
-                // (target) fallback is ever taken with a model where target n_embd_out
-                // differs from draft n_embd, the copy would truncate.
                 if (batch.embd) {
                     const float * h_row = llama_get_embeddings_nextn_ith(src_ctx, src_row);
                     if (h_row) {
-                        memcpy(batch.embd, h_row, row_bytes);
+                        const size_t src_row_bytes = (k == 0)
+                            ? (size_t) llama_model_n_embd_out(llama_get_model(ctx_tgt)) * sizeof(float)
+                            : row_bytes;
+                        memcpy(batch.embd, h_row, src_row_bytes);
                     } else {
                         break;
                     }

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -59,6 +59,9 @@ bool common_speculative_need_embd(common_speculative * spec);
 // true if any implementation requires target pre-norm embeddings to be extracted
 bool common_speculative_need_embd_pre_norm(common_speculative * spec);
 
+// true if any implementation requires target nextn embeddings to be extracted
+bool common_speculative_need_embd_nextn(common_speculative * spec);
+
 // generate drafts for the sequences specified with `common_speculative_get_draft_params`
 void common_speculative_draft(common_speculative * spec);
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -72,7 +72,9 @@ llama_context::llama_context(
     cparams.yarn_beta_slow   = params.yarn_beta_slow   >= 0.0f ? params.yarn_beta_slow   : hparams.yarn_beta_slow;
     cparams.embeddings       = params.embeddings;
     cparams.embeddings_pre_norm = false;
-    cparams.offload_kqv      = params.offload_kqv;
+    cparams.embeddings_nextn        = false;
+    cparams.embeddings_nextn_masked = false;
+    cparams.offload_kqv             = params.offload_kqv;
     cparams.no_perf          = params.no_perf;
     cparams.ctx_type         = params.ctx_type;
     cparams.pooling_type     = params.pooling_type;
@@ -962,6 +964,42 @@ float * llama_context::get_embeddings_pre_norm_raw_ith(int32_t i) {
     return embd_pre_norm_raw.data();
 }
 
+float * llama_context::get_embeddings_nextn() {
+    output_reorder();
+
+    return embd_nextn.data;
+}
+
+float * llama_context::get_embeddings_nextn_ith(int32_t i) {
+    output_reorder();
+
+    try {
+        if (embd_nextn.data == nullptr) {
+            throw std::runtime_error("no nextn embeddings");
+        }
+
+        const uint32_t n_embd = model.hparams.n_embd_out();
+
+        if (!cparams.embeddings_nextn_masked) {
+            // unmasked: nextn rows are stored densely, indexed by raw token position.
+            if (i < 0 || (size_t)(i + 1) * n_embd > embd_nextn.size) {
+                throw std::runtime_error(format("out of range [0, %zu)", embd_nextn.size / n_embd));
+            }
+            return embd_nextn.data + (size_t) i * n_embd;
+        }
+
+        const int64_t j = output_resolve_row(i);
+        return embd_nextn.data + j*n_embd;
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: invalid nextn embeddings id %d, reason: %s\n", __func__, i, err.what());
+#ifndef NDEBUG
+        GGML_ABORT("fatal error");
+#else
+        return nullptr;
+#endif
+    }
+}
+
 ggml_tensor * llama_context::get_t_h_pre_norm() const {
     return gf_res_prev ? gf_res_prev->t_h_pre_norm : nullptr;
 }
@@ -1172,6 +1210,13 @@ void llama_context::set_embeddings_pre_norm(bool value, bool masked) {
 
     cparams.embeddings_pre_norm        = value;
     cparams.embeddings_pre_norm_masked = masked;
+}
+
+void llama_context::set_embeddings_nextn(bool value, bool masked) {
+    LLAMA_LOG_DEBUG("%s: value = %d, masked = %d\n", __func__, value, masked);
+
+    cparams.embeddings_nextn        = value;
+    cparams.embeddings_nextn_masked = masked;
 }
 
 void llama_context::set_causal_attn(bool value) {
@@ -1451,6 +1496,7 @@ int llama_context::encode(const llama_batch & batch_inp) {
     auto * t_logits        = res->get_logits();
     auto * t_embd          = res->get_embd_pooled() ? res->get_embd_pooled() : res->get_embd();
     auto * t_h_pre_norm    = cparams.embeddings_pre_norm ? res->get_h_pre_norm() : nullptr;
+    auto * t_h_nextn       = cparams.embeddings_nextn      ? res->get_h_nextn()     : nullptr;
 
     // extract logits
     if (logits.data && t_logits) {
@@ -1524,6 +1570,16 @@ int llama_context::encode(const llama_batch & batch_inp) {
         const uint32_t n_embd = hparams.n_embd;
         GGML_ASSERT(n_tokens*n_embd <= (int64_t) embd_pre_norm.size);
         ggml_backend_tensor_get_async(backend_h, t_h_pre_norm, embd_pre_norm.data, 0, n_tokens*n_embd*sizeof(float));
+    }
+
+    // extract nextn embeddings (hidden state before the final output norm)
+    if (embd_nextn.data && t_h_nextn && cparams.pooling_type == LLAMA_POOLING_TYPE_NONE) {
+        ggml_backend_t backend_h = ggml_backend_sched_get_tensor_backend(sched.get(), t_h_nextn);
+        GGML_ASSERT(backend_h != nullptr);
+
+        const uint32_t n_embd = hparams.n_embd_out();
+        GGML_ASSERT(n_tokens*n_embd <= (int64_t) embd_nextn.size);
+        ggml_backend_tensor_get_async(backend_h, t_h_nextn, embd_nextn.data, 0, n_tokens*n_embd*sizeof(float));
     }
 
     // TODO: hacky solution
@@ -1882,6 +1938,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
         auto * t_h_pre_norm    = (cparams.embeddings_pre_norm || mtp.ctx_mtp != nullptr)
                                ? res->get_h_pre_norm()
                                : nullptr;
+        auto * t_h_nextn       = cparams.embeddings_nextn ? res->get_h_nextn() : nullptr;
 
         if (t_embd && res->get_embd_pooled()) {
             t_embd = res->get_embd_pooled();
@@ -1981,6 +2038,25 @@ int llama_context::decode(const llama_batch & batch_inp) {
             }
         }
 
+        // extract nextn embeddings
+        // only meaningful in LLAMA_POOLING_TYPE_NONE (per-token); other pooling modes are ignored.
+        {
+            const bool masked    = cparams.embeddings_nextn_masked;
+            const int64_t n_rows = masked ? n_outputs       : (int64_t) ubatch.n_tokens;
+            const int64_t offset = masked ? n_outputs_prev  : n_tokens_prev;
+
+            if (embd_nextn.data && t_h_nextn && n_rows > 0 && cparams.pooling_type == LLAMA_POOLING_TYPE_NONE) {
+                ggml_backend_t backend_h = ggml_backend_sched_get_tensor_backend(sched.get(), t_h_nextn);
+                GGML_ASSERT(backend_h != nullptr);
+
+                const uint32_t n_embd  = hparams.n_embd_out();
+                float * embd_nextn_out = embd_nextn.data + offset*n_embd;
+
+                GGML_ASSERT((offset + n_rows)*n_embd <= (int64_t) embd_nextn.size);
+                ggml_backend_tensor_get_async(backend_h, t_h_nextn, embd_nextn_out, 0, n_rows*n_embd*sizeof(float));
+            }
+        }
+
         if (mtp.ctx_mtp != nullptr && t_h_pre_norm != nullptr && ubatch.token != nullptr && ubatch.pos != nullptr) {
             handle_mtp_for_ubatch((int32_t) ubatch.n_tokens, ubatch.token, ubatch.pos, t_h_pre_norm);
         }
@@ -2076,6 +2152,7 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
     bool has_logits        = true;
     bool has_embd          = cparams.embeddings;
     bool has_embd_pre_norm = cparams.embeddings_pre_norm;
+    bool has_embd_nextn    = cparams.embeddings_nextn;
 
     // TODO: hacky enc-dec support
     if (model.arch == LLM_ARCH_T5) {
@@ -2090,11 +2167,17 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
     logits.size        = has_logits        ? n_vocab*n_outputs_max     : 0;
     embd.size          = has_embd          ? n_embd_out*n_outputs_max  : 0;
     embd_pre_norm.size = has_embd_pre_norm ? n_embd*n_outputs_max      : 0;
+    embd_nextn.size    = has_embd_nextn    ? n_embd_out*n_outputs_max  : 0;
 
     if (has_embd_pre_norm && !cparams.embeddings_pre_norm_masked) {
         // unmasked: pre-norm row exists for every token in the batch, not just
         // those flagged via batch.logits[i] -> size by token count instead.
         embd_pre_norm.size = (size_t) n_embd * n_batch;
+    }
+
+    if (has_embd_nextn && !cparams.embeddings_nextn_masked) {
+        // unmasked: nextn row exists for every token in the batch
+        embd_nextn.size = (size_t) n_embd_out * n_batch;
     }
 
     // Allocate backend sampling output buffers if there are backend samplers configured.
@@ -2111,7 +2194,7 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
 
     const size_t prev_size = buf_output ? ggml_backend_buffer_get_size(buf_output.get()) : 0;
     const size_t new_size  =
-        (logits.size + embd.size + embd_pre_norm.size + backend_float_count) * sizeof(float) +
+        (logits.size + embd.size + embd_pre_norm.size + embd_nextn.size + backend_float_count) * sizeof(float) +
         (                                               backend_token_count) * sizeof(llama_token);
 
     // alloc only when more than the current capacity is required
@@ -2129,6 +2212,7 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
             logits.data = nullptr;
             embd.data = nullptr;
             embd_pre_norm.data = nullptr;
+            embd_nextn.data = nullptr;
         }
 
         auto * buft = ggml_backend_cpu_buffer_type();
@@ -2159,6 +2243,9 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
 
     embd_pre_norm = has_embd_pre_norm ? buffer_view<float>{(float *) (base + offset), embd_pre_norm.size} : buffer_view<float>{nullptr, 0};
     offset += embd_pre_norm.size * sizeof(float);
+
+    embd_nextn = has_embd_nextn ? buffer_view<float>{(float *) (base + offset), embd_nextn.size} : buffer_view<float>{nullptr, 0};
+    offset += embd_nextn.size * sizeof(float);
 
     if (has_sampling) {
         sampling.logits = {(float *) (base + offset), (size_t)(n_vocab*n_outputs_max)};
@@ -2227,6 +2314,12 @@ void llama_context::output_reorder() {
         if (embd_pre_norm.size > 0) {
             for (uint64_t k = 0; k < n_embd; k++) {
                 std::swap(embd_pre_norm.data[i0*n_embd + k], embd_pre_norm.data[i1*n_embd + k]);
+            }
+        }
+
+        if (embd_nextn.size > 0) {
+            for (uint64_t k = 0; k < n_embd; k++) {
+                std::swap(embd_nextn.data[i0*n_embd + k], embd_nextn.data[i1*n_embd + k]);
             }
         }
 
@@ -3642,6 +3735,10 @@ void llama_set_embeddings_pre_norm(llama_context * ctx, bool value, bool masked)
     ctx->set_embeddings_pre_norm(value, masked);
 }
 
+void llama_set_embeddings_nextn(struct llama_context * ctx, bool value, bool masked) {
+    ctx->set_embeddings_nextn(value, masked);
+}
+
 float * llama_get_embeddings_pre_norm(llama_context * ctx) {
     ctx->synchronize();
 
@@ -3652,6 +3749,18 @@ float * llama_get_embeddings_pre_norm_ith(llama_context * ctx, int32_t i) {
     ctx->synchronize();
 
     return ctx->get_embeddings_pre_norm_ith(i);
+}
+
+float * llama_get_embeddings_nextn(struct llama_context * ctx) {
+    ctx->synchronize();
+
+    return ctx->get_embeddings_nextn();
+}
+
+float * llama_get_embeddings_nextn_ith(struct llama_context * ctx, int32_t i) {
+    ctx->synchronize();
+
+    return ctx->get_embeddings_nextn_ith(i);
 }
 
 float * llama_get_embeddings_pre_norm_raw_ith(llama_context * ctx, int32_t i) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2292,8 +2292,9 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
 }
 
 void llama_context::output_reorder() {
-    const uint64_t n_vocab = model.vocab.n_tokens();
-    const uint64_t n_embd  = model.hparams.n_embd;
+    const uint64_t n_vocab     = model.vocab.n_tokens();
+    const uint64_t n_embd      = model.hparams.n_embd;
+    const uint64_t n_embd_out  = model.hparams.n_embd_out();
 
     for (size_t s = 0; s < output_swaps.size(); ++s) {
         const uint64_t i0 = output_swaps[s].i0;
@@ -2306,8 +2307,8 @@ void llama_context::output_reorder() {
         }
 
         if (embd.size > 0) {
-            for (uint64_t k = 0; k < n_embd; k++) {
-                std::swap(embd.data[i0*n_embd + k], embd.data[i1*n_embd + k]);
+            for (uint64_t k = 0; k < n_embd_out; k++) {
+                std::swap(embd.data[i0*n_embd_out + k], embd.data[i1*n_embd_out + k]);
             }
         }
 
@@ -2318,8 +2319,8 @@ void llama_context::output_reorder() {
         }
 
         if (embd_nextn.size > 0) {
-            for (uint64_t k = 0; k < n_embd; k++) {
-                std::swap(embd_nextn.data[i0*n_embd + k], embd_nextn.data[i1*n_embd + k]);
+            for (uint64_t k = 0; k < n_embd_out; k++) {
+                std::swap(embd_nextn.data[i0*n_embd_out + k], embd_nextn.data[i1*n_embd_out + k]);
             }
         }
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -88,6 +88,9 @@ struct llama_context {
     float * get_embeddings_pre_norm();
     float * get_embeddings_pre_norm_ith(int32_t i);
     float * get_embeddings_pre_norm_raw_ith(int32_t i);
+
+    float * get_embeddings_nextn();
+    float * get_embeddings_nextn_ith(int32_t i);
     ggml_tensor * get_t_h_pre_norm() const;
     ggml_tensor * get_t_mtp_out() const;
     void set_mtp(llama_context * ctx_mtp_in);
@@ -118,6 +121,7 @@ struct llama_context {
 
     void set_embeddings (bool value);
     void set_embeddings_pre_norm(bool value, bool masked);
+    void set_embeddings_nextn(bool value, bool masked);
     void set_causal_attn(bool value);
     void set_warmup(bool value);
 
@@ -301,6 +305,11 @@ private:
     // sets llm_graph_result::t_h_pre_norm
     buffer_view<float> embd_pre_norm = {nullptr, 0};
     std::vector<float> embd_pre_norm_raw;
+
+    // hidden state required by the nextn layers (2-dimensional array: [n_outputs][n_embd])
+    // populated only when cparams.embeddings_nextn is enabled and the model graph
+    // sets llm_graph_result::t_h_nextn
+    buffer_view<float> embd_nextn = {nullptr, 0};
 
     struct sampling_info {
         // !samplers.empty() to check if any samplers are active

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -30,6 +30,8 @@ struct llama_cparams {
     bool embeddings;
     bool embeddings_pre_norm;        // also extract the hidden state before the final output norm
     bool embeddings_pre_norm_masked; // extract for only rows where batch.logits != 0
+    bool embeddings_nextn;        // also extract the hidden state before the final output norm (gemma4, etc.)
+    bool embeddings_nextn_masked; // extract nextn hidden states for only rows where batch.logits != 0
     bool causal_attn;
     bool offload_kqv;
     bool flash_attn;

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -112,3 +112,10 @@ LLAMA_API float * llama_get_embeddings_pre_norm_raw_ith(struct llama_context * c
 LLAMA_API struct ggml_tensor * llama_context_get_t_h_pre_norm(struct llama_context * ctx);
 LLAMA_API struct ggml_tensor * llama_context_get_t_mtp_out(struct llama_context * ctx);
 LLAMA_API void llama_set_mtp(struct llama_context * ctx_target, struct llama_context * ctx_mtp);
+
+//
+// nextn embeddings (hidden state before the final output norm, gemma4 etc.)
+//
+LLAMA_API void    llama_set_embeddings_nextn   (struct llama_context * ctx, bool value, bool masked);
+LLAMA_API float * llama_get_embeddings_nextn    (struct llama_context * ctx);
+LLAMA_API float * llama_get_embeddings_nextn_ith(struct llama_context * ctx, int32_t i);

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -626,8 +626,9 @@ struct llm_graph_params {
         }
 
         return
-            cparams.embeddings  == other.cparams.embeddings  &&
-            cparams.causal_attn == other.cparams.causal_attn &&
+            cparams.embeddings        == other.cparams.embeddings        &&
+            cparams.embeddings_nextn  == other.cparams.embeddings_nextn  &&
+            cparams.causal_attn       == other.cparams.causal_attn       &&
             arch  == other.arch  &&
             gtype == other.gtype &&
             cvec  == other.cvec  &&
@@ -647,6 +648,7 @@ public:
     ggml_tensor * get_embd()        const { return t_embd; }
     ggml_tensor * get_embd_pooled() const { return t_embd_pooled; }
     ggml_tensor * get_h_pre_norm() const { return t_h_pre_norm; }
+    ggml_tensor * get_h_nextn()     const { return t_h_nextn; }
 
     ggml_cgraph  * get_gf()  const { return gf; }
     ggml_context * get_ctx() const { return ctx_compute.get(); }
@@ -678,6 +680,7 @@ public:
 
     // MTP related inputs/outputs
     ggml_tensor * t_h_pre_norm  = nullptr; // [n_embd, n_outputs] hidden state required for MTP
+    ggml_tensor * t_h_nextn     = nullptr; // [n_embd, n_outputs] hidden state before final output norm (gemma4, etc.)
     ggml_tensor * t_mtp_out     = nullptr; // [n_embd, n_tokens]
 
     std::map<llama_seq_id, ggml_tensor*> t_sampled_logits;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -626,9 +626,10 @@ struct llm_graph_params {
         }
 
         return
-            cparams.embeddings        == other.cparams.embeddings        &&
-            cparams.embeddings_nextn  == other.cparams.embeddings_nextn  &&
-            cparams.causal_attn       == other.cparams.causal_attn       &&
+            cparams.embeddings           == other.cparams.embeddings           &&
+            cparams.embeddings_pre_norm  == other.cparams.embeddings_pre_norm  &&
+            cparams.embeddings_nextn     == other.cparams.embeddings_nextn     &&
+            cparams.causal_attn          == other.cparams.causal_attn          &&
             arch  == other.arch  &&
             gtype == other.gtype &&
             cvec  == other.cvec  &&

--- a/src/models/gemma4.cpp
+++ b/src/models/gemma4.cpp
@@ -373,6 +373,7 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
 
     cb(cur, "h_pre_norm", -1);
     res->t_h_pre_norm = cur;
+    res->t_h_nextn    = cur;
 
     cur = build_norm(cur,
             model.output_norm, nullptr,


### PR DESCRIPTION
## Summary

Fixes three bugs in the embeddings_nextn infrastructure:

1. **output_reorder() stride bug**: Use `n_embd_out()` for `embd` and `embd_nextn` stride (was using `n_embd`, causing corruption when `n_embd != n_embd_out`)

2. **k==0 fallback dimension mismatch**: Use target's `n_embd_out` for k==0 nextn fallback in speculative.cpp (was using draft's `n_embd`, causing truncation)

3. **allow_reuse() inconsistency**: Add `embeddings_pre_norm` check for consistency with `embeddings_nextn`

## Testing

- Build passes: `cmake --build build --target llama llama-speculative`
- Ready for CI validation

Assisted-by: Kiro