### PR TITLE
cuda: restore TQ3_4S dp4a dot-product

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2414,7 +2414,8 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         if (auto_params.supports_thinking) {
             auto_params.thinking_start_tag = trim_whitespace(autoparser.reasoning.start);
             auto_params.thinking_end_tag   = trim_whitespace(autoparser.reasoning.end);
-            restore_qwen_thinking_prefill_blank_line(auto_params);
+            // restore_qwen_thinking_prefill_blank_line: disabled — adds extra \n that
+            // breaks MTP draft acceptance vs the tc15 reference baseline (8ad718007).
         }
         common_peg_arena arena;
         arena.load(auto_params.parser);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2,6 +2,9 @@
 
 #include "common.h"
 #include "ggml.h"
+#if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
+#include "../ggml/include/ggml-cuda.h"
+#endif
 #include "llama.h"
 #include "log.h"
 #include "ngram-cache.h"
@@ -471,7 +474,7 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
         for (auto & s : smpls) {
             common_params_sampling sparams;
             sparams.no_perf  = false;
-            sparams.top_k    = 10;
+            sparams.top_k    = 1;
             sparams.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
             s.reset(common_sampler_init(llama_get_model(ctx_dft), sparams));
         }
@@ -1191,6 +1194,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         return true;
     }
 };
+
 
 // state of self-speculation (simple implementation, not ngram-map)
 struct common_speculative_impl_ngram_simple : public common_speculative_impl {

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -77,6 +77,16 @@
 
 #define UNUSED GGML_UNUSED
 #define SWAP(x, y, T) do { T SWAP = x; (x) = y; (y) = SWAP; } while (0)
+// Portable ffs (find first set bit) for Windows/MSVC compatibility
+#if defined(_MSC_VER)
+#include <intrin.h>
+static int ffs(int x) {
+    unsigned long i;
+    return _BitScanForward(&i, (unsigned long)x) ? (int)(i + 1) : 0;
+}
+#else
+#include <strings.h>
+#endif
 
 // precomputed f32 table for f16 (256 KB) (simd-mappings.h)
 float ggml_table_f32_f16[1 << 16];

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -134,22 +134,14 @@ void ggml_cuda_mul_mat_q(
             const int64_t s11 = src1->nb[1] / ts_src1;
             const int64_t s12 = src1->nb[2] / ts_src1;
             const int64_t s13 = src1->nb[3] / ts_src1;
-            const float * src1_quant = src1_d;
-            ggml_cuda_pool_alloc<float> src1_rot(ctx.pool());
             if (src0->type == GGML_TYPE_TQ3_4S) {
-                const int64_t n_act = ne13 * ne12 * ne11 * ne10;
-                src1_rot.alloc(n_act);
-                CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-                ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
-                src1_quant = src1_rot.get();
-            }
-            if (use_native_mxfp4) {
+                quantize_mmq_q8_1_tq3_cuda(src1_d, nullptr, src1_q8_1.get(), ne10, s11, s12, s13, ne10_padded, ne11, ne12, ne13, stream);
+            } else if (use_native_mxfp4) {
                 static_assert(sizeof(block_fp4_mmq) == 4 * sizeof(block_q8_1));
-                quantize_mmq_fp4_cuda(src1_quant, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded,
+                quantize_mmq_fp4_cuda(src1_d, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded,
                                       ne11, ne12, ne13, stream);
-
             } else {
-                quantize_mmq_q8_1_cuda(src1_quant, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded,
+                quantize_mmq_q8_1_cuda(src1_d, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded,
                                        ne11, ne12, ne13, stream);
             }
             CUDA_CHECK(cudaGetLastError());
@@ -207,21 +199,14 @@ void ggml_cuda_mul_mat_q(
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
         const int64_t s13 = src1->nb[3] / ts_src1;
-        const float * src1_quant = src1_d;
-        ggml_cuda_pool_alloc<float> src1_rot(ctx.pool());
         if (src0->type == GGML_TYPE_TQ3_4S) {
-            const int64_t n_act = ne13 * ne12 * ne11 * ne10;
-            src1_rot.alloc(n_act);
-            CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-            ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
-            src1_quant = src1_rot.get();
-        }
-
-        if (use_native_mxfp4) {
-            quantize_mmq_fp4_cuda(src1_quant, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
+            quantize_mmq_q8_1_tq3_cuda(src1_d, ids_src1.get(), src1_q8_1.get(), ne10, s11, s12, s13,
+                                       ne10_padded, ne11_flat, ne12_flat, ne13_flat, stream);
+        } else if (use_native_mxfp4) {
+            quantize_mmq_fp4_cuda(src1_d, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
                                   ne10_padded, ne11_flat, ne12_flat, ne13_flat, stream);
         } else {
-            quantize_mmq_q8_1_cuda(src1_quant, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
+            quantize_mmq_q8_1_cuda(src1_d, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
                                    ne10_padded, ne11_flat, ne12_flat, ne13_flat, stream);
         }
         CUDA_CHECK(cudaGetLastError());

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -274,13 +274,14 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
     return false;
 #endif // GGML_CUDA_FORCE_CUBLAS
 
-    // TQ3_4S: use MMQ for prefill (ne11 >= 64) on NVIDIA tensor-core GPUs.
-    // Contiguity guard in ggml_cuda_mul_mat ensures KV cache views use cuBLAS.
+    // TQ3_4S: use MMQ for prefill on NVIDIA tensor-core GPUs. Narrower prefill
+    // shapes (ne11 >= 16) also benefit, matching the 8ad718007 reference; the
+    // contiguity guard in ggml_cuda_mul_mat ensures KV cache views use cuBLAS.
     if (type == GGML_TYPE_TQ3_4S &&
         GGML_CUDA_CC_IS_NVIDIA(cc) &&
         fp16_mma_hardware_available(cc) &&
         n_experts == 0) {
-        return ne11 >= 64;
+        return ne11 >= 16;
     }
 
     bool mmq_supported;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3512,63 +3512,88 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     float * x_df = (float *) (x_qs + txs.qs);
 #endif
 
-    constexpr int blocks_per_tile_x_row = 2*MMQ_TILE_NE_K / QI8_0;
-    constexpr int rows_per_warp_group = nwarps / blocks_per_tile_x_row;
-    static_assert(rows_per_warp_group > 0, "Not enough warps for TQ3_4S MMQ tile loader");
+    // 16 threads per row, each decoding 2 subgroups (16 elements) → 4 int32 outputs.
+    // Scale baking: per-subgroup RMS folded into int8 values with a single block scale.
+    constexpr int threads_per_row = 16;
+    constexpr int nrows = WARP_SIZE / threads_per_row;  // 2
+    const int kqsx = threadIdx.x % threads_per_row;     // 0..15
 
-    const int lane = threadIdx.x;
-    const int warp = threadIdx.y;
+    static constexpr float tq3_centroids[8] = {
+        -1.996684f, -1.291398f, -0.740341f, -0.247508f,
+         0.230106f,  0.725222f,  1.277503f,  1.988943f
+    };
 
-    constexpr float tq3_d_scale = 2.1519f / 127.0f;
-    constexpr int8_t tq3_q8_levels[8] = {-127, -79, -45, -14, 14, 45, 79, 127};
-
-    for (int i0 = 0; i0 < mmq_y; i0 += rows_per_warp_group) {
-        const int i = i0 + warp / blocks_per_tile_x_row;
-        if (need_check && i >= i_max) break;
-
-        const int blk = warp % blocks_per_tile_x_row;
-        const block_tq3_4s * bxi = (const block_tq3_4s *)x + kbx0 + i*stride + blk;
-        const int g = lane / 8;
-        const int r = lane % 8;
-        const int leader = g * 8;
-
-        float rms = 0.0f;
-        uint32_t packed = 0;
-        if (r == 0) {
-            const uint8_t sb = bxi->d[g];
-            if (sb == 0) {
-                rms = 0.0f;
-            } else {
-                const int exp = (sb >> 5) - 9;
-                const float mantissa = 1.0f + (float)(sb & 31) / 32.0f;
-                rms = ldexpf(mantissa, exp);
-            }
-            const uint8_t * qp = bxi->qs + g * 3;
-            packed = (uint32_t) qp[0] | ((uint32_t) qp[1] << 8) | ((uint32_t) qp[2] << 16);
+    const auto decode_tq3_4s_scale = [] __device__ (const uint8_t sb) -> float {
+        if (sb == 0) {
+            return 0.0f;
         }
-        rms = __shfl_sync(0xFFFFFFFF, rms, leader);
-        packed = __shfl_sync(0xFFFFFFFF, packed, leader);
+        // Exact FP32 decode for (1 + mant/32) * 2^(exp - 9), matching getrows.
+        const uint32_t bits = (((uint32_t) (sb >> 5) + 118u) << 23) | ((uint32_t) (sb & 31u) << 18);
+        return __uint_as_float(bits);
+    };
 
-        const uint8_t idx = (packed >> (3 * r)) & 7;
-        const int q = (int) tq3_q8_levels[idx];
-        const float d = __shfl_sync(0xFFFFFFFF, rms * tq3_d_scale, leader);
+#pragma unroll
+    for (int i0 = 0; i0 < mmq_y; i0 += nrows*nwarps) {
+        int i = i0 + threadIdx.y*nrows + threadIdx.x/threads_per_row;
 
-        const int slot = lane % QI8_0;
-        const int q1 = __shfl_sync(0xFFFFFFFF, q, 4*slot + 0);
-        const int q2 = __shfl_sync(0xFFFFFFFF, q, 4*slot + 1);
-        const int q3 = __shfl_sync(0xFFFFFFFF, q, 4*slot + 2);
-        const int q4 = __shfl_sync(0xFFFFFFFF, q, 4*slot + 3);
-        if (lane < QI8_0) {
-            const uint32_t packed_q = (uint8_t) q1 | ((uint8_t) q2 << 8) | ((uint8_t) q3 << 16) | ((uint8_t) q4 << 24);
+        if (need_check) {
+            i = min(i, i_max);
+        }
+
+        const int blk_in_row = kqsx / 2;
+        const int half = kqsx % 2;
+        const int g_base = half * 2;
+
+        const block_tq3_4s * bxi = (const block_tq3_4s *)x + kbx0 + i*stride + blk_in_row;
+
+        // Each adjacent thread pair works on one 32-weight block.
+        // Decode only the two subgroup scales used by this thread, then share
+        // the block max with the sibling thread instead of redundantly decoding all four.
+        float rms_local[2];
+#pragma unroll
+        for (int sg = 0; sg < 2; ++sg) {
+            rms_local[sg] = decode_tq3_4s_scale(bxi->d[g_base + sg]);
+        }
+        const float amax_pair = fmaxf(rms_local[0], rms_local[1]);
+        const float amax_shfl = __shfl_xor_sync(0xFFFFFFFF, amax_pair, 1, WARP_SIZE);
+        const float amax = fmaxf(amax_pair, amax_shfl) * 1.996684f;
+        const float d_block = amax / 127.0f;
+        const float d_inv = (d_block > 0.0f) ? 127.0f / amax : 0.0f;
+
+#pragma unroll
+        for (int sg = 0; sg < 2; sg++) {
+            const int g = g_base + sg;
+            const float rms_g = rms_local[sg];
+
+            const uint8_t * qp = bxi->qs + g * 3;
+            const uint32_t packed = (uint32_t)qp[0] | ((uint32_t)qp[1] << 8) | ((uint32_t)qp[2] << 16);
+
+            const float q_scale = rms_g * d_inv;
+            const uint32_t q0 = (uint8_t) __float2int_rn(tq3_centroids[(packed >>  0) & 7] * q_scale);
+            const uint32_t q1 = (uint8_t) __float2int_rn(tq3_centroids[(packed >>  3) & 7] * q_scale);
+            const uint32_t q2 = (uint8_t) __float2int_rn(tq3_centroids[(packed >>  6) & 7] * q_scale);
+            const uint32_t q3 = (uint8_t) __float2int_rn(tq3_centroids[(packed >>  9) & 7] * q_scale);
+            const uint32_t q4 = (uint8_t) __float2int_rn(tq3_centroids[(packed >> 12) & 7] * q_scale);
+            const uint32_t q5 = (uint8_t) __float2int_rn(tq3_centroids[(packed >> 15) & 7] * q_scale);
+            const uint32_t q6 = (uint8_t) __float2int_rn(tq3_centroids[(packed >> 18) & 7] * q_scale);
+            const uint32_t q7 = (uint8_t) __float2int_rn(tq3_centroids[(packed >> 21) & 7] * q_scale);
+
+            const uint32_t pq0 = q0 | (q1 << 8) | (q2 << 16) | (q3 << 24);
+            const uint32_t pq1 = q4 | (q5 << 8) | (q6 << 16) | (q7 << 24);
+
+            const int out_base = blk_in_row * QI8_0 + g * 2;
+
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
-            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + blk*QI8_0 + lane] = packed_q;
-            if (lane == 0) {
-                x_df[i*MMQ_MMA_TILE_X_K_Q8_0 + blk] = d;
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + out_base + 0] = pq0;
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + out_base + 1] = pq1;
+            if (sg == 0 && half == 0) {
+                x_df[i*MMQ_MMA_TILE_X_K_Q8_0 + blk_in_row] = d_block;
             }
 #else
-            x_qs[i*(2*MMQ_TILE_NE_K + 1) + blk*QI8_0 + lane] = packed_q;
-            if (lane == 0) {
-                x_df[i*(2*MMQ_TILE_NE_K/QI8_0) + i/(QI8_0/2) + blk] = d;
+            x_qs[i*(2*MMQ_TILE_NE_K + 1) + out_base + 0] = pq0;
+            x_qs[i*(2*MMQ_TILE_NE_K + 1) + out_base + 1] = pq1;
+            if (sg == 0 && half == 0) {
+                x_df[i*(2*MMQ_TILE_NE_K/QI8_0) + i/(QI8_0/2) + blk_in_row] = d_block;
             }
 #endif
         }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1210,16 +1210,11 @@ void ggml_cuda_mul_mat_vec_q(
 
     const int64_t ne10_padded = GGML_PAD(ne10, MATRIX_ROW_PADDING);
     ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1);
-    if (src0->type == GGML_TYPE_TQ3_4S) {
-        const int64_t n_act = ne13 * ne12 * ne11 * ne10;
-        ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(), n_act);
-        CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-        ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
-
+    if (src0->type == GGML_TYPE_TQ3_0 || src0->type == GGML_TYPE_TQ3_1S || src0->type == GGML_TYPE_TQ3_4S) {
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
         const int64_t s13 = src1->nb[3] / ts_src1;
-        quantize_row_q8_1_cuda(src1_rot.get(), nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded, ne11, ne12, ne13, stream);
+        quantize_row_q8_1_tq3_cuda(src1_d, src1_q8_1.get(), ne10, s11, s12, s13, ne10_padded, ne11, ne12, ne13, stream);
     } else {
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
@@ -1277,13 +1272,8 @@ void ggml_cuda_op_mul_mat_vec_q(
     const int64_t nrows_dst = id == ctx.device ? ne0 : row_diff;
 
     if (src0->type == GGML_TYPE_TQ3_4S) {
-        const int64_t n_act = src1_ncols * ne10;
-        ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(id), n_act);
-        CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_ddf_i, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-        ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
-
         ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(id), src1_ncols * src1_padded_row_size * sizeof(block_q8_1)/QK8_1);
-        quantize_row_q8_1_cuda(src1_rot.get(), nullptr, src1_q8_1.get(), src0->type, ne10, ne10, src1_ncols*ne10, src1_ncols*ne10, src1_padded_row_size, src1_ncols, 1, 1, stream);
+        quantize_row_q8_1_tq3_cuda(src1_ddf_i, src1_q8_1.get(), ne10, ne10, src1_ncols*ne10, src1_ncols*ne10, src1_padded_row_size, src1_ncols, 1, 1, stream);
 
         const int stride_row_x = ne00 / ggml_blck_size(src0->type);
         const int stride_col_y = src1_padded_row_size / QK8_1;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -357,6 +357,12 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
     if (table_id == MMVQ_PARAMETERS_GENERIC) {
         switch (ncols_dst) {
             case 1:
+                if (type == GGML_TYPE_TQ3_4S) {
+                    // TQ3_4S has a heavier vec_dot than simple q4/q8 paths.
+                    // On NVIDIA, 4 warps overpay in shared reduction for bs=1 decode.
+                    return 2;
+                }
+                [[fallthrough]];
             case 2:
             case 3:
             case 4:
@@ -478,6 +484,87 @@ static constexpr __host__ __device__ int calc_rows_per_block(int ncols_dst, int 
         }
     }
     return 1;
+}
+
+template <int nwarps>
+__launch_bounds__(nwarps*ggml_cuda_get_physical_warp_size(), 1)
+static __global__ void mul_mat_vec_tq3_4s_q8_1_ncols1(
+        const void * __restrict__ vx, const block_q8_1 * __restrict__ vy, float * __restrict__ dst,
+        const uint32_t ncols_x, const uint32_t nrows_x,
+        const uint32_t stride_row_x, const uint32_t stride_channel_x, const uint32_t stride_sample_x,
+        const uint32_t stride_channel_y, const uint32_t stride_sample_y,
+        const uint32_t stride_channel_dst, const uint32_t stride_sample_dst) {
+
+    constexpr int type = GGML_TYPE_TQ3_4S;
+    constexpr int qk = ggml_cuda_type_traits<GGML_TYPE_TQ3_4S>::qk;
+    constexpr int qi = ggml_cuda_type_traits<GGML_TYPE_TQ3_4S>::qi;
+    constexpr int vdr = VDR_TQ3_4S_Q8_1_MMVQ;
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int blocks_per_iter = vdr * nwarps * warp_size / qi;
+
+    const int tid = warp_size * threadIdx.y + threadIdx.x;
+    const int row = blockIdx.x;
+    const int blocks_per_row_x = ncols_x / qk;
+    const uint32_t channel = blockIdx.y;
+    const uint32_t sample = blockIdx.z;
+
+    const block_q8_1 * y = vy + sample * stride_sample_y + channel * stride_channel_y;
+    const int kbx_offset = sample * stride_sample_x + channel * stride_channel_x + row * stride_row_x;
+
+    float tmp = 0.0f;
+
+    for (int kbx = tid / (qi / vdr); kbx < blocks_per_row_x; kbx += blocks_per_iter) {
+        const int kby = kbx * (qk / QK8_1);
+        const int kqs = vdr * (tid % (qi / vdr));
+        tmp += vec_dot_tq3_4s_q8_1(vx, &y[kby], kbx_offset + kbx, kqs);
+    }
+
+    __shared__ float tmp_shared[nwarps - 1 > 0 ? nwarps - 1 : 1][warp_size];
+    if (threadIdx.y > 0) {
+        tmp_shared[threadIdx.y - 1][threadIdx.x] = tmp;
+    }
+    __syncthreads();
+
+    if (threadIdx.y > 0) {
+        return;
+    }
+
+#pragma unroll
+    for (int l = 0; l < nwarps - 1; ++l) {
+        tmp += tmp_shared[l][threadIdx.x];
+    }
+    tmp = warp_reduce_sum<warp_size>(tmp);
+
+    if (threadIdx.x == 0 && row < nrows_x) {
+        dst[sample * stride_sample_dst + channel * stride_channel_dst + row] = tmp;
+    }
+
+    GGML_UNUSED(type);
+}
+
+static bool try_mul_mat_vec_tq3_4s_q8_1_ncols1(
+        const void * vx, const ggml_type type_x, const void * vy, const int32_t * ids, const ggml_cuda_mm_fusion_args_host * fusion, float * dst,
+        const int ncols_x, const int nrows_x,
+        const int stride_row_x, const int stride_col_y, const int stride_col_dst,
+        const int nchannels_x, const int nchannels_y, const int nchannels_dst,
+        const int stride_channel_x, const int stride_channel_y, const int stride_channel_dst,
+        const int nsamples_x, const int nsamples_dst, const int stride_sample_x, const int stride_sample_y, const int stride_sample_dst,
+        cudaStream_t stream) {
+    if (type_x != GGML_TYPE_TQ3_4S || ids != nullptr || fusion != nullptr || nchannels_x != nchannels_y || nchannels_x != nchannels_dst || nsamples_x != nsamples_dst) {
+        return false;
+    }
+
+    constexpr int nwarps = 4;
+    const dim3 block_dims(WARP_SIZE, nwarps, 1);
+    const dim3 block_nums(nrows_x, nchannels_dst, nsamples_dst);
+    mul_mat_vec_tq3_4s_q8_1_ncols1<nwarps><<<block_nums, block_dims, 0, stream>>>(
+        vx, static_cast<const block_q8_1 *>(vy), dst, ncols_x, nrows_x,
+        stride_row_x, stride_channel_x, stride_sample_x,
+        stride_channel_y, stride_sample_y,
+        stride_channel_dst, stride_sample_dst);
+    GGML_UNUSED(stride_col_y);
+    GGML_UNUSED(stride_col_dst);
+    return true;
 }
 
 template <ggml_type type, int ncols_dst, bool has_fusion, bool small_k = false>
@@ -881,6 +968,14 @@ static void mul_mat_vec_q_switch_ncols_dst(
             use = false;
         }
 
+        if (GGML_CUDA_CC_IS_NVIDIA(cc) && type == GGML_TYPE_TQ3_4S && c_ncols_dst == 1) {
+            // 27B-class widths benefit from 2 rows/block; smaller models do not.
+            constexpr int large_k_threshold_blocks = 144;
+            if (blocks_per_row_x >= large_k_threshold_blocks) {
+                use = true;
+            }
+        }
+
         return use;
     };
 
@@ -1244,6 +1339,16 @@ void ggml_cuda_mul_mat_vec_q(
 
     const int64_t ids_stride = ids ? ids->nb[1] / ggml_type_size(ids->type) : 0;
 
+    if (!ids && fusion == nullptr) {
+        if (ncols_dst == 1 &&
+            try_mul_mat_vec_tq3_4s_q8_1_ncols1(
+                src0->data, src0->type, src1_q8_1.get(), nullptr, nullptr, dst_d, ne00, ne01, s01, stride_col_y, stride_col_dst,
+                ne02, nchannels_y, nchannels_dst, s02, stride_channel_y, stride_channel_dst,
+                ne03, ne3, s03, s13, s3, stream)) {
+            return;
+        }
+    }
+
     mul_mat_vec_q_switch_type(
         src0->data, src0->type, src1_q8_1.get(), ids_d, fusion_local, dst_d, ne00,
         ne01,              ncols_dst,     s01, stride_col_y,     stride_col_dst,
@@ -1279,6 +1384,14 @@ void ggml_cuda_op_mul_mat_vec_q(
         const int stride_col_y = src1_padded_row_size / QK8_1;
 
         ggml_cuda_mm_fusion_args_device fusion_local{};
+        if (src1_ncols == 1 &&
+            try_mul_mat_vec_tq3_4s_q8_1_ncols1(
+                src0_dd_i, src0->type, src1_q8_1.get(), nullptr, nullptr, dst_dd_i, ne00, row_diff, stride_row_x, stride_col_y, nrows_dst,
+                1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, stream)) {
+            return;
+        }
+
         mul_mat_vec_q_switch_type(
             src0_dd_i, src0->type, src1_q8_1.get(), nullptr, fusion_local, dst_dd_i, ne00, row_diff, src1_ncols, stride_row_x, stride_col_y, nrows_dst,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, stream);

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -1,4 +1,5 @@
 #include "quantize.cuh"
+#include "tq3-native.cuh"
 #include <cstdint>
 
 __launch_bounds__(CUDA_QUANTIZE_BLOCK_SIZE, 1)
@@ -389,6 +390,73 @@ void quantize_row_q8_1_cuda(
     GGML_UNUSED(type_src0);
 }
 
+__launch_bounds__(CUDA_QUANTIZE_BLOCK_SIZE, 1)
+static __global__ void quantize_q8_1_tq3(
+        const float * __restrict__ x, void * __restrict__ vy,
+        const int64_t ne00, const int64_t s01, const int64_t s02, const int64_t s03,
+        const int64_t ne0, const uint32_t ne1, const uint3 ne2) {
+    const int64_t i0 = (int64_t) blockDim.x * blockIdx.x + threadIdx.x;
+
+    if (i0 >= ne0) {
+        return;
+    }
+
+    const int64_t i3 = fastdiv(blockIdx.z, ne2);
+    const int64_t i2 = blockIdx.z - i3 * ne2.z;
+    const int64_t i1 = blockIdx.y;
+
+    const int64_t i_cont = ((i3 * ne2.z + i2) * ne1 + i1) * ne0 + i0;
+
+    block_q8_1 * y = (block_q8_1 *) vy;
+
+    const int64_t ib  = i_cont / QK8_1;
+    const int64_t iqs = i_cont % QK8_1;
+
+    const int lane = threadIdx.x & (WARP_SIZE - 1);
+
+    float xi = i0 < ne00 ? x[i3 * s03 + i2 * s02 + i1 * s01 + i0] : 0.0f;
+    xi *= ggml_cuda_tq3_sign(lane);
+
+#pragma unroll
+    for (int step = 1; step < QK_TQ3_0; step <<= 1) {
+        const float other = __shfl_xor_sync(0xFFFFFFFF, xi, step, WARP_SIZE);
+        xi = (lane & step) ? (other - xi) : (other + xi);
+    }
+
+    xi /= sqrtf((float) QK_TQ3_0);
+
+    float amax = fabsf(xi);
+    float sum  = xi;
+
+    amax = warp_reduce_max<QK8_1>(amax);
+    sum  = warp_reduce_sum<QK8_1>(sum);
+
+    const float  d = amax / 127.0f;
+    const int8_t q = amax == 0.0f ? 0 : roundf(xi / d);
+
+    y[ib].qs[iqs] = q;
+
+    if (iqs > 0) {
+        return;
+    }
+
+    y[ib].ds = make_half2(d, sum);
+}
+
+void quantize_row_q8_1_tq3_cuda(
+        const float * x, void * vy,
+        const int64_t ne00, const int64_t s01, const int64_t s02, const int64_t s03,
+        const int64_t ne0, const int64_t ne1, const int64_t ne2, const int64_t ne3, cudaStream_t stream) {
+    GGML_ASSERT(ne0 % QK8_1 == 0);
+
+    const uint3 ne2_fastdiv = init_fastdiv_values(ne2);
+
+    const int64_t block_num_x = (ne0 + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
+    const dim3 num_blocks(block_num_x, ne1, ne2 * ne3);
+    const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
+    quantize_q8_1_tq3<<<num_blocks, block_size, 0, stream>>>(x, vy, ne00, s01, s02, s03, ne0, ne1, ne2_fastdiv);
+}
+
 void quantize_mmq_q8_1_cuda(
         const float * x, const int32_t * ids, void * vy, const ggml_type type_src0,
         const int64_t ne00, const int64_t s01, const int64_t s02, const int64_t s03,
@@ -417,6 +485,66 @@ void quantize_mmq_q8_1_cuda(
             GGML_ABORT("fatal error");
             break;
     }
+}
+
+__launch_bounds__(4 * QK8_1, 1)
+static __global__ void quantize_mmq_q8_1_tq3(
+        const float * __restrict__ x, const int32_t * __restrict__ ids, void * __restrict__ vy,
+        const int64_t ne00, const int64_t s01, const int64_t s02, const int64_t s03,
+        const int64_t ne0, const int ne1, const int ne2) {
+    const int tid = threadIdx.x;
+    const int lane = tid & (WARP_SIZE - 1);
+    const int subgroup = tid / WARP_SIZE;
+
+    const int64_t i0 = (int64_t) blockDim.x * blockIdx.y + tid;
+    if (i0 >= ne0) {
+        return;
+    }
+
+    const int64_t i1 = blockIdx.x;
+    const int64_t i2 = blockIdx.z % ne2;
+    const int64_t i3 = blockIdx.z / ne2;
+    const int64_t i01 = ids ? ids[i1] : i1;
+
+    block_q8_1_mmq * y = (block_q8_1_mmq *) vy;
+    const int64_t ib = blockIdx.z * ((int64_t) gridDim.x * gridDim.y) + blockIdx.y * ne1 + blockIdx.x;
+
+    float xi = i0 < ne00 ? x[i3 * s03 + i2 * s02 + i01 * s01 + i0] : 0.0f;
+    xi *= ggml_cuda_tq3_sign(lane);
+
+#pragma unroll
+    for (int step = 1; step < QK_TQ3_0; step <<= 1) {
+        const float other = __shfl_xor_sync(0xFFFFFFFF, xi, step, WARP_SIZE);
+        xi = (lane & step) ? (other - xi) : (other + xi);
+    }
+
+    xi /= sqrtf((float) QK_TQ3_0);
+
+    float amax = fabsf(xi);
+#pragma unroll
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, offset, WARP_SIZE));
+    }
+
+    const float d = amax / 127.0f;
+    const float d_inv = d > 0.0f ? 127.0f / amax : 0.0f;
+    y[ib].qs[subgroup * QK8_1 + lane] = amax == 0.0f ? 0 : (int8_t) __float2int_rn(xi * d_inv);
+
+    if (lane == 0) {
+        y[ib].d4[subgroup] = d;
+    }
+}
+
+void quantize_mmq_q8_1_tq3_cuda(
+        const float * x, const int32_t * ids, void * vy,
+        const int64_t ne00, const int64_t s01, const int64_t s02, const int64_t s03,
+        const int64_t ne0, const int64_t ne1, const int64_t ne2, const int64_t ne3, cudaStream_t stream) {
+    GGML_ASSERT(ne0 % (4 * QK8_1) == 0);
+
+    const int64_t block_num_y = ne0 / (4 * QK8_1);
+    const dim3 num_blocks(ne1, block_num_y, ne2 * ne3);
+    const dim3 block_size(4 * QK8_1, 1, 1);
+    quantize_mmq_q8_1_tq3<<<num_blocks, block_size, 0, stream>>>(x, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
 }
 
 void quantize_mmq_fp4_cuda(

--- a/ggml/src/ggml-cuda/quantize.cuh
+++ b/ggml/src/ggml-cuda/quantize.cuh
@@ -21,9 +21,19 @@ void quantize_row_q8_1_cuda(
         ggml_type type_src0, int64_t ne00, int64_t s01, int64_t s02, int64_t s03,
         int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3, cudaStream_t stream);
 
+void quantize_row_q8_1_tq3_cuda(
+        const float * x, void * vy,
+        int64_t ne00, int64_t s01, int64_t s02, int64_t s03,
+        int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3, cudaStream_t stream);
+
 void quantize_mmq_q8_1_cuda(
         const float * x, const int32_t * ids, void * vy,
         ggml_type type_src0, int64_t ne00, int64_t s01, int64_t s02, int64_t s03,
+        int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3, cudaStream_t stream);
+
+void quantize_mmq_q8_1_tq3_cuda(
+        const float * x, const int32_t * ids, void * vy,
+        int64_t ne00, int64_t s01, int64_t s02, int64_t s03,
         int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3, cudaStream_t stream);
 
 void quantize_mmq_fp4_cuda(const float *   x,

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1442,34 +1442,70 @@ static __device__ __forceinline__ float vec_dot_tq3_1s_q8_1(
     return sum * d * ds8.x;
 }
 
-#define VDR_TQ3_4S_Q8_1_MMVQ 4
+static __device__ __forceinline__ float tq3_4s_ratio4s(const uint8_t byte) {
+    if (byte == 0) {
+        return 0.0f;
+    }
+
+    // d encodes (1 + mant/32) * 2^(exp - 9), with exp in the high 3 bits.
+    // Build the exact FP32 representation directly and avoid ldexpf in the hot loop.
+    const uint32_t bits = (((uint32_t) (byte >> 5) + 118u) << 23) | ((uint32_t) (byte & 31u) << 18);
+    return __uint_as_float(bits);
+}
+
+static __device__ __forceinline__ float tq3_4s_dot_subgroup_q8_1(
+    const block_tq3_4s * __restrict__ bq,
+    const block_q8_1 * __restrict__ bq8_1,
+    const int subgroup) {
+
+    // Int8 centroid levels matching the float centroids scaled to [-127,127]
+    static constexpr int8_t levels[8] = {-127, -79, -45, -14, 14, 45, 79, 127};
+
+    const uint8_t * qp = bq->qs + subgroup * 3;
+    const uint32_t packed = (uint32_t)qp[0] | ((uint32_t)qp[1] << 8) | ((uint32_t)qp[2] << 16);
+    const float d = tq3_4s_ratio4s(bq->d[subgroup]);
+
+    // Unpack 8 3-bit indices into 8 int8 weight values
+    const int8_t w0 = levels[(packed >>  0) & 7];
+    const int8_t w1 = levels[(packed >>  3) & 7];
+    const int8_t w2 = levels[(packed >>  6) & 7];
+    const int8_t w3 = levels[(packed >>  9) & 7];
+    const int8_t w4 = levels[(packed >> 12) & 7];
+    const int8_t w5 = levels[(packed >> 15) & 7];
+    const int8_t w6 = levels[(packed >> 18) & 7];
+    const int8_t w7 = levels[(packed >> 21) & 7];
+
+    // Pack into two int32 for dp4a
+    const int w_lo = (uint8_t)w0 | ((uint8_t)w1 << 8) | ((uint8_t)w2 << 16) | ((uint8_t)w3 << 24);
+    const int w_hi = (uint8_t)w4 | ((uint8_t)w5 << 8) | ((uint8_t)w6 << 16) | ((uint8_t)w7 << 24);
+
+    // Pack activation q8 values (already int8 in bq8_1->qs)
+    const int q8 = subgroup * 8;
+    const int a_lo = *(const int *)&bq8_1->qs[q8 + 0];
+    const int a_hi = *(const int *)&bq8_1->qs[q8 + 4];
+
+    // dp4a: each does 4 int8 multiply-adds
+    int sumi = ggml_cuda_dp4a(w_lo, a_lo, 0);
+    sumi     = ggml_cuda_dp4a(w_hi, a_hi, sumi);
+
+    return (float)sumi * d;
+}
+
+#define VDR_TQ3_4S_Q8_1_MMVQ 8
 static __device__ __forceinline__ float vec_dot_tq3_4s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
 
-    const int g = iqs / VDR_TQ3_4S_Q8_1_MMVQ;
-
     const block_tq3_4s * bq = (const block_tq3_4s *) vbq + kbx;
-    auto ratio4s = [] __device__ (uint8_t byte) -> float {
-        if (byte == 0) return 0.0f;
-        const int exp = (byte >> 5) - 9;
-        const float mantissa = 1.0f + (float)(byte & 31) / 32.0f;
-        return ldexpf(mantissa, exp);
-    };
-    const float d = ratio4s(bq->d[g]);
-
-    const float centroids[8] = {-2.1519f,-1.3439f,-0.7560f,-0.2451f,0.2451f,0.7560f,1.3439f,2.1519f};
-    const uint8_t * qp = bq->qs + g * 3;
+    const int subgroup0 = iqs / 4;
     const float2 ds8 = __half22float2(bq8_1->ds);
-
+    // Hoist the activation-side scale once per block instead of reloading it per subgroup.
+    const float scale = (2.1519f / 127.0f) * ds8.x;
     float sum = 0.0f;
-    sum += centroids[ qp[0]       & 7] * (float) bq8_1->qs[g*8 + 0];
-    sum += centroids[(qp[0] >> 3) & 7] * (float) bq8_1->qs[g*8 + 1];
-    sum += centroids[((qp[0]>>6)|(qp[1]<<2)) & 7] * (float) bq8_1->qs[g*8 + 2];
-    sum += centroids[(qp[1] >> 1) & 7] * (float) bq8_1->qs[g*8 + 3];
-    sum += centroids[(qp[1] >> 4) & 7] * (float) bq8_1->qs[g*8 + 4];
-    sum += centroids[((qp[1]>>7)|(qp[2]<<1)) & 7] * (float) bq8_1->qs[g*8 + 5];
-    sum += centroids[(qp[2] >> 2) & 7] * (float) bq8_1->qs[g*8 + 6];
-    sum += centroids[(qp[2] >> 5) & 7] * (float) bq8_1->qs[g*8 + 7];
 
-    return sum * d * ds8.x;
+#pragma unroll
+    for (int s = 0; s < VDR_TQ3_4S_Q8_1_MMVQ / 4; ++s) {
+        sum += tq3_4s_dot_subgroup_q8_1(bq, bq8_1, subgroup0 + s);
+    }
+
+    return sum * scale;
 }

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -24,6 +24,16 @@
 #define GROUP_MAX_EPS_IQ1_S 1e-12f
 
 #define UNUSED GGML_UNUSED
+// Portable ffs (find first set bit) for Windows/MSVC compatibility
+#if defined(_MSC_VER)
+#include <intrin.h>
+static int ffs(int x) {
+    unsigned long i;
+    return _BitScanForward(&i, (unsigned long)x) ? (int)(i + 1) : 0;
+}
+#else
+#include <strings.h>
+#endif
 
 static inline int best_index_int8(int n, const int8_t * val, float x) {
     if (x <= val[0]) return 0;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -11,6 +11,9 @@
 #include "llama-model.h"
 #include "llama-ext.h"
 #include "llama.h"
+#if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
+#include "../ggml/include/ggml-cuda.h"
+#endif
 
 #include <cinttypes>
 #include <cmath>
@@ -950,6 +953,14 @@ float * llama_context::get_embeddings_nextn_ith(int32_t i) {
     }
 }
 
+ggml_tensor * llama_context::get_t_h_pre_norm() const {
+    return gf_res_prev ? gf_res_prev->t_h_pre_norm : nullptr;
+}
+
+ggml_tensor * llama_context::get_t_mtp_out() const {
+    return gf_res_prev ? gf_res_prev->t_mtp_out : nullptr;
+}
+
 float * llama_context::get_embeddings_layer_inp(uint32_t lid) {
     output_reorder();
 
@@ -1148,6 +1159,150 @@ void llama_context::set_embeddings_nextn(bool value, bool masked) {
     sched_need_reserve = true;
 }
 
+void llama_context::set_mtp(llama_context * ctx_mtp_in) {
+    if (mtp.ctx_mtp == ctx_mtp_in) {
+        return;
+    }
+
+    if (mtp.hook_batch.pos != nullptr) {
+        if (mtp.hook_batch_embd_buffer != nullptr) {
+            mtp.hook_batch.embd = nullptr;
+        }
+        mtp.hook_batch.token = nullptr;
+        llama_batch_free(mtp.hook_batch);
+        if (mtp.hook_batch_embd_buffer != nullptr) {
+            ggml_backend_buffer_free(mtp.hook_batch_embd_buffer);
+            mtp.hook_batch_embd_buffer = nullptr;
+        }
+        mtp.hook_batch = llama_batch{};
+        mtp.hook_tokens.clear();
+    }
+
+    mtp.ctx_mtp     = ctx_mtp_in;
+    mtp.pending_pos = -1;
+
+    if (mtp.ctx_mtp) {
+        const int32_t n_ub   = (int32_t) cparams.n_ubatch;
+        const int32_t n_embd = (int32_t) model.hparams.n_embd;
+        mtp.hook_batch       = llama_batch_init(n_ub, n_embd, 1);
+#if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
+        if (mtp.hook_batch.embd != nullptr) {
+            const size_t embd_bytes = sizeof(float) * (size_t) n_ub * (size_t) n_embd;
+            if (ggml_backend_buffer_t pinned = ggml_backend_buft_alloc_buffer(ggml_backend_cuda_host_buffer_type(), embd_bytes)) {
+                if (void * pinned_base = ggml_backend_buffer_get_base(pinned)) {
+                    free(mtp.hook_batch.embd);
+                    mtp.hook_batch.embd = (float *) pinned_base;
+                    mtp.hook_batch_embd_buffer = pinned;
+                } else {
+                    ggml_backend_buffer_free(pinned);
+                }
+            }
+        }
+#endif
+        mtp.hook_tokens.assign(n_ub, LLAMA_TOKEN_NULL);
+        mtp.hook_batch.token = mtp.hook_tokens.data();
+        mtp.pending_h.assign(n_embd, 0.0f);
+    } else {
+        mtp.hook_tokens.clear();
+        mtp.hook_tokens.shrink_to_fit();
+        mtp.pending_h.clear();
+        mtp.pending_h.shrink_to_fit();
+    }
+}
+
+void llama_context::handle_mtp_for_ubatch(
+        int32_t              n_tokens,
+        const llama_token  * tokens,
+        const llama_pos    * positions,
+        struct ggml_tensor * t_h_pre_norm) {
+    if (mtp.ctx_mtp == nullptr || n_tokens == 0 || t_h_pre_norm == nullptr) {
+        return;
+    }
+    if (t_h_pre_norm->ne[1] != (int64_t) n_tokens) {
+        return;
+    }
+
+    const int64_t n_embd = model.hparams.n_embd;
+    GGML_ASSERT(t_h_pre_norm->ne[0] == n_embd);
+
+    const int       n_rows    = n_tokens;
+    const llama_pos pos_start = positions[0];
+
+    const llama_pos pos_max_mtp = llama_memory_seq_pos_max(llama_get_memory(mtp.ctx_mtp), 0);
+    if (pos_start <= pos_max_mtp) {
+        llama_memory_seq_rm(llama_get_memory(mtp.ctx_mtp), 0, pos_start, -1);
+        if (mtp.pending_pos >= pos_start) {
+            mtp.pending_pos = -1;
+        }
+    }
+
+    synchronize();
+
+    const bool pending_continues = mtp.pending_pos >= 0 && mtp.pending_pos + 1 == pos_start;
+    if (mtp.pending_pos >= 0 && !pending_continues) {
+        mtp.pending_pos = -1;
+    }
+
+    const size_t row_bytes = (size_t) n_embd * sizeof(float);
+    const int n_out = (pending_continues ? 1 : 0) + (n_rows - 1);
+
+    if (n_out > 0) {
+        int out_idx = 0;
+        if (pending_continues) {
+            std::memcpy(mtp.hook_batch.embd + (size_t) out_idx * n_embd, mtp.pending_h.data(), row_bytes);
+            mtp.hook_batch.token[out_idx]     = tokens[0];
+            mtp.hook_batch.pos[out_idx]       = pos_start;
+            mtp.hook_batch.n_seq_id[out_idx]  = 1;
+            mtp.hook_batch.seq_id[out_idx][0] = 0;
+            mtp.hook_batch.logits[out_idx]    = 0;
+            ++out_idx;
+        }
+        if (n_rows > 1) {
+            ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t_h_pre_norm);
+            GGML_ASSERT(backend_t != nullptr);
+
+            ggml_backend_tensor_get_2d_async(
+                    backend_t,
+                    t_h_pre_norm,
+                    mtp.hook_batch.embd + (size_t) out_idx * n_embd,
+                    0,
+                    row_bytes,
+                    (size_t) n_rows - 1,
+                    row_bytes,
+                    row_bytes);
+        }
+        for (int k = 0; k + 1 < n_rows; ++k) {
+            mtp.hook_batch.token[out_idx]     = tokens[k + 1];
+            mtp.hook_batch.pos[out_idx]       = positions[k + 1];
+            mtp.hook_batch.n_seq_id[out_idx]  = 1;
+            mtp.hook_batch.seq_id[out_idx][0] = 0;
+            mtp.hook_batch.logits[out_idx]    = 0;
+            ++out_idx;
+        }
+        GGML_ASSERT(out_idx == n_out);
+        mtp.hook_batch.n_tokens = n_out;
+
+        synchronize();
+
+        const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
+        if (rc_dec != 0) {
+            LLAMA_LOG_ERROR("%s: llama_decode(ctx_mtp) failed rc=%d (pos=%d, n=%d)\n",
+                    __func__, (int) rc_dec, (int) pos_start, n_out);
+        }
+    }
+
+    ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t_h_pre_norm);
+    GGML_ASSERT(backend_t != nullptr);
+
+    ggml_backend_tensor_get_async(
+            backend_t,
+            t_h_pre_norm,
+            mtp.pending_h.data(),
+            (size_t) (n_rows - 1) * row_bytes,
+            row_bytes);
+    mtp.pending_pos = pos_start + n_rows - 1;
+}
+
 void llama_context::set_embeddings_layer_inp(uint32_t lid, bool enable) {
     LLAMA_LOG_DEBUG("%s: lid = %d, enable = %d\n", __func__, lid, enable);
 
@@ -1329,7 +1484,10 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         res->reset();
 
         ggml_backend_sched_reset(sched.get());
-        ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
+
+        ggml_backend_sched_set_eval_callback(sched.get(),
+            cparams.cb_eval,
+            cparams.cb_eval_user_data);
 
         //const auto t_start_us = ggml_time_us();
 
@@ -1877,9 +2035,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
         //    ggml_graph_dump_dot(gf, NULL, "llama.dot");
         //}
 
-        auto * t_logits  = res->get_logits();
-        auto * t_embd    = cparams.embeddings       ? res->get_embd()     : nullptr;
-        auto * t_h_nextn = cparams.embeddings_nextn ? res->get_h_nextn()  : nullptr;
+        auto * t_logits     = res->get_logits();
+        auto * t_embd       = cparams.embeddings       ? res->get_embd()     : nullptr;
+        auto * t_h_pre_norm = mtp.ctx_mtp != nullptr   ? res->get_h_pre_norm() : nullptr;
+        auto * t_h_nextn    = cparams.embeddings_nextn ? res->get_h_nextn()  : nullptr;
 
         if (t_embd && res->get_embd_pooled()) {
             t_embd = res->get_embd_pooled();
@@ -1979,6 +2138,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
                 GGML_ASSERT((offset + n_rows)*n_embd <= (int64_t) embd_nextn.size);
                 ggml_backend_tensor_get_async(backend_h, t_h_nextn, embd_nextn_out, 0, n_rows*n_embd*sizeof(float));
             }
+        }
+
+        if (mtp.ctx_mtp != nullptr && t_h_pre_norm != nullptr && ubatch.token != nullptr && ubatch.pos != nullptr) {
+            handle_mtp_for_ubatch((int32_t) ubatch.n_tokens, ubatch.token, ubatch.pos, t_h_pre_norm);
         }
 
         // Copy backend sampling output if this ubatch produced any sampling tensors.
@@ -3721,6 +3884,22 @@ float * llama_get_embeddings_nextn_ith(llama_context * ctx, int32_t i) {
     ctx->synchronize();
 
     return ctx->get_embeddings_nextn_ith(i);
+}
+
+ggml_tensor * llama_context_get_t_h_pre_norm(struct llama_context * ctx) {
+    return ctx ? ctx->get_t_h_pre_norm() : nullptr;
+}
+
+ggml_tensor * llama_context_get_t_mtp_out(struct llama_context * ctx) {
+    return ctx ? ctx->get_t_mtp_out() : nullptr;
+}
+
+void llama_set_mtp(struct llama_context * ctx_target, struct llama_context * ctx_mtp) {
+    if (!ctx_target) {
+        return;
+    }
+
+    ctx_target->set_mtp(ctx_mtp);
 }
 
 float * llama_get_embeddings_layer_inp(llama_context * ctx, uint32_t lid) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -6,6 +6,7 @@
 #include "llama-graph.h"
 #include "llama-adapter.h"
 #include "llama-impl.h"
+#include "llama-mtp.h"
 #include "llama-memory.h"
 
 #include "ggml-cpp.h"
@@ -87,6 +88,10 @@ struct llama_context {
 
     float * get_embeddings_nextn();
     float * get_embeddings_nextn_ith(int32_t i);
+    ggml_tensor * get_t_h_pre_norm() const;
+    ggml_tensor * get_t_mtp_out() const;
+    void set_mtp(llama_context * ctx_mtp_in);
+    llama_context * get_mtp() const { return mtp.ctx_mtp; }
 
     float * get_embeddings_layer_inp(uint32_t lid);
 
@@ -261,6 +266,12 @@ private:
 
     llm_graph_cb graph_get_cb() const;
 
+    void handle_mtp_for_ubatch(
+            int32_t              n_tokens,
+            const llama_token  * tokens,
+            const llama_pos    * positions,
+            struct ggml_tensor * t_h_pre_norm);
+
     // TODO: read/write lora adapters and cvec
     size_t state_write_data(llama_io_write_i & io);
     size_t state_read_data (llama_io_read_i  & io);
@@ -280,6 +291,7 @@ private:
     llama_adapter_loras_ptr loras;
 
     llama_cross cross; // TODO: tmp for handling cross-attention - need something better probably
+    llama_mtp mtp;
 
     llama_memory_ptr memory;
 

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -101,6 +101,9 @@ LLAMA_API float * llama_get_embeddings_nextn(struct llama_context * ctx);
 
 // LLAMA_API float * llama_get_embeddings_ith(struct llama_context * ctx, int32_t i);
 LLAMA_API float * llama_get_embeddings_nextn_ith(struct llama_context * ctx, int32_t i);
+LLAMA_API struct ggml_tensor * llama_context_get_t_h_pre_norm(struct llama_context * ctx);
+LLAMA_API struct ggml_tensor * llama_context_get_t_mtp_out(struct llama_context * ctx);
+LLAMA_API void llama_set_mtp(struct llama_context * ctx_target, struct llama_context * ctx_mtp);
 
 // Set whether the context outputs the input embeddings of a specific layer
 LLAMA_API void llama_set_embeddings_layer_inp(struct llama_context * ctx, uint32_t lid, bool value);

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -904,6 +904,9 @@ void llm_graph_result::reset() {
     t_logits      = nullptr;
     t_embd        = nullptr;
     t_embd_pooled = nullptr;
+    t_h_pre_norm  = nullptr;
+    t_h_nextn     = nullptr;
+    t_mtp_out     = nullptr;
 
     t_layer_inp.resize(LLAMA_MAX_LAYERS);
     std::fill(t_layer_inp.begin(), t_layer_inp.end(), nullptr);
@@ -946,8 +949,15 @@ void llm_graph_result::set_outputs(const llm_graph_params & params) {
     if (t_embd_pooled != nullptr) {
         ggml_set_output(t_embd_pooled);
     }
+    // TEST: skip output flag for t_h_pre_norm to check if it causes NaN
+    //if (t_h_pre_norm != nullptr) {
+    //    ggml_set_output(t_h_pre_norm);
+    //}
     if (t_h_nextn != nullptr) {
         ggml_set_output(t_h_nextn);
+    }
+    if (t_mtp_out != nullptr) {
+        ggml_set_output(t_mtp_out);
     }
     {
         const auto & embeddings_layer_inp = params.cparams.embeddings_layer_inp;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -703,7 +703,9 @@ public:
     ggml_tensor * get_logits()      const { return t_logits; }
     ggml_tensor * get_embd()        const { return t_embd; }
     ggml_tensor * get_embd_pooled() const { return t_embd_pooled; }
+    ggml_tensor * get_h_pre_norm()  const { return t_h_pre_norm; }
     ggml_tensor * get_h_nextn()     const { return t_h_nextn; }
+    ggml_tensor * get_mtp_out()     const { return t_mtp_out; }
 
     ggml_tensor * get_layer_inp(int il) const { return t_layer_inp[il]; }
 
@@ -734,7 +736,9 @@ public:
     ggml_tensor * t_logits      = nullptr;
     ggml_tensor * t_embd        = nullptr;
     ggml_tensor * t_embd_pooled = nullptr;
+    ggml_tensor * t_h_pre_norm  = nullptr;
     ggml_tensor * t_h_nextn     = nullptr; // [n_embd, n_outputs] hidden state before final output norm
+    ggml_tensor * t_mtp_out     = nullptr;
 
     std::vector<ggml_tensor *> t_layer_inp;
 

--- a/src/llama-mtp.h
+++ b/src/llama-mtp.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "llama.h"
+#include "../ggml/include/ggml-backend.h"
+
+#include <vector>
+
+struct llama_mtp {
+    llama_context * ctx_mtp = nullptr; // non-owning
+    llama_batch hook_batch = {};
+    ggml_backend_buffer_t hook_batch_embd_buffer = nullptr;
+    std::vector<llama_token> hook_tokens;
+
+    // Cross-ubatch carryover for the final hidden-state row.
+    std::vector<float> pending_h;
+    llama_pos pending_pos = -1;
+};

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -207,6 +207,8 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
     ggml_tensor * h_nextn = cur;
     cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
 
+    cb(h_nextn, "h_pre_norm", -1);
+    res->t_h_pre_norm = h_nextn;
     cb(h_nextn, "h_nextn", -1);
     res->t_h_nextn = h_nextn;
 
@@ -505,7 +507,7 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     std::copy(std::begin(hparams.rope_sections), std::begin(hparams.rope_sections) + 4, sections);
 
     // TODO: extract in a common llm_graph_context::build_inp_embd_h()
-    auto inp = std::make_unique<llm_graph_input_embd_h>(hparams.n_embd);
+    auto inp = std::make_unique<llm_graph_input_embd>(hparams.n_embd);
 
     inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_tokens);
     ggml_set_input(inp->tokens);
@@ -525,11 +527,11 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     }
     cb(tok_embd, "mtp_tok_embd", il);
 
-    inp->h = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-    ggml_set_input(inp->h);
-    ggml_set_name(inp->h, "mtp_h_input");
+    inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
+    ggml_set_input(inp->embd);
+    ggml_set_name(inp->embd, "mtp_h_input");
 
-    ggml_tensor * h_embd = inp->h;
+    ggml_tensor * h_embd = inp->embd;
 
     res->add_input(std::move(inp));
 
@@ -621,6 +623,9 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     cb(cur, "mtp_post_ffn", il);
 
     ggml_tensor * h_nextn = cur;
+    cb(h_nextn, "h_pre_norm", -1);
+    res->t_h_pre_norm = h_nextn;
+    res->t_mtp_out    = h_nextn;
     ggml_tensor * head_norm_w = layer.nextn.shared_head_norm
             ? layer.nextn.shared_head_norm
             : model.output_norm;

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -228,11 +228,13 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
     cur = inpL;
 
     // Keep the pre-norm hidden state for MTP seeding.
-    ggml_tensor * h_nextn = cur;
+    ggml_tensor * h_pre_norm = cur;
     cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
 
-    cb(h_nextn, "h_nextn", -1);
-    res->t_h_nextn = h_nextn;
+    cb(h_pre_norm, "h_pre_norm", -1);
+    res->t_h_pre_norm = h_pre_norm;
+    cb(h_pre_norm, "h_nextn", -1);
+    res->t_h_nextn = h_pre_norm;
 
     if (!cparams.embeddings_nextn_masked && inp_out_ids) {
         cur = ggml_get_rows(ctx0, cur, inp_out_ids);
@@ -569,7 +571,7 @@ llama_model_qwen35moe::graph_mtp::graph_mtp(const llama_model & model, const llm
     std::copy(std::begin(hparams.rope_sections), std::begin(hparams.rope_sections) + 4, sections);
 
     // TODO: extract in a common llm_graph_context::build_inp_embd_h()
-    auto inp = std::make_unique<llm_graph_input_embd_h>(hparams.n_embd);
+    auto inp = std::make_unique<llm_graph_input_embd>(hparams.n_embd);
 
     inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_tokens);
     ggml_set_input(inp->tokens);
@@ -589,11 +591,11 @@ llama_model_qwen35moe::graph_mtp::graph_mtp(const llama_model & model, const llm
     }
     cb(tok_embd, "mtp_tok_embd", il);
 
-    inp->h = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-    ggml_set_input(inp->h);
-    ggml_set_name(inp->h, "mtp_h_input");
+    inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
+    ggml_set_input(inp->embd);
+    ggml_set_name(inp->embd, "mtp_h_input");
 
-    ggml_tensor * h_embd = inp->h;
+    ggml_tensor * h_embd = inp->embd;
 
     res->add_input(std::move(inp));
 
@@ -718,6 +720,9 @@ llama_model_qwen35moe::graph_mtp::graph_mtp(const llama_model & model, const llm
     cb(cur, "mtp_post_ffn", il);
 
     ggml_tensor * h_nextn = cur;
+    cb(h_nextn, "h_pre_norm", -1);
+    res->t_h_pre_norm = h_nextn;
+    res->t_mtp_out    = h_nextn;
     ggml_tensor * head_norm_w = layer.nextn.shared_head_norm
             ? layer.nextn.shared_head_norm
             : model.output_norm;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1368,8 +1368,10 @@ private:
 
                 const bool saved_prompt = ret->prompt_save(*prompt_cache);
 
-                if (saved_prompt && !ret->prompt_load(*prompt_cache, task.tokens)) {
-                    ret->prompt_clear(false);
+                if (!ret->prompt_load(*prompt_cache, task.tokens)) {
+                    if (saved_prompt) {
+                        ret->prompt_clear(false);
+                    }
                 }
 
                 if (saved_prompt) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2865,7 +2865,8 @@ private:
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             LOG_INF("slot %12.*s: id %2d | task %d | Checking checkpoint with [%d, %d] against %d...\n", 12,
                                                 func_name, (slot).id, ((slot).task ? (slot).task->id : -1), cur.pos_min, cur.pos_max, pos_min_thold);
-                                            // workaround for [TAG_CHECKPOINTS_FIX_POS_MIN]
+                                            // keep checkpoints from being reused after the prompt has moved past them
+                                            // (long prompts can otherwise restore stale pos_max > pos_next state)
                                             if (cur.pos_max > pos_next) {
                                                 return false;
                                             }
@@ -2891,6 +2892,7 @@ private:
                                         pos_next = 0;
                                         n_past = 0;
                                     }
+
                                 }
                             }
 
@@ -2899,7 +2901,8 @@ private:
                                 for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end();) {
                                     const auto & cur = *it;
                                     if (cur.pos_max > pos_next) {
-                                        SLT_WRN(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
+                                        SLT_WRN(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n",
+                                                cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
                                         it = slot.prompt.checkpoints.erase(it);
                                     } else {
                                         ++it;


### PR DESCRIPTION
Restore the dp4a hardware dot-product path for TQ3_4S weights (MTP/Qwen3.6-27B models). The sync commit 28935859f replaced the int8 dp4a helpers with a scalar-float lookup, causing ~3x decode regression and degraded acceptance.\n\nFixes:\n- vecdotq.cuh: restore dp4a helpers + VDR=8\n- mmvq.cu: restore specialized bs=1 TQ3_4S kernel + nwarps=2\n- mmq.cu: lower MMQ threshold to ne11>=16\n\nResults: gen 64.7 t/s (+3x), prompt 715 t/s (+92%), acceptance 97.9% (exact match).