### PR TITLE
perf: TQ3_4S dp4a dot-product, MTP runtime restore, rebased on upstream/master

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1096,8 +1096,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--version"},
         "show version and build info",
         [](common_params &) {
-            fprintf(stderr, "version: %d (%s)\n", llama_build_number(), llama_commit());
-            fprintf(stderr, "built with %s for %s\n", llama_compiler(), llama_build_target());
+            fprintf(stdout, "version: %d (%s)\n", llama_build_number(), llama_commit());
+            fprintf(stdout, "built with %s for %s\n", llama_compiler(), llama_build_target());
             exit(0);
         }
     ));

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -877,7 +877,7 @@ std::string common_chat_template_generation_prompt(
     return common_chat_template_generation_prompt_impl(tmpl, inputs, std::nullopt, std::nullopt, std::nullopt);
 }
 
-static void restore_qwen_thinking_prefill_blank_line(common_chat_params & params) {
+[[maybe_unused]] static void restore_qwen_thinking_prefill_blank_line(common_chat_params & params) {
     if (!params.supports_thinking || params.thinking_start_tag != "<think>") {
         return;
     }
@@ -2414,7 +2414,11 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         if (auto_params.supports_thinking) {
             auto_params.thinking_start_tag = trim_whitespace(autoparser.reasoning.start);
             auto_params.thinking_end_tag   = trim_whitespace(autoparser.reasoning.end);
-            restore_qwen_thinking_prefill_blank_line(auto_params);
+            // restore_qwen_thinking_prefill_blank_line: disabled — the extra '\n' it
+            // appends shifts the prefill by one token, which desyncs the MTP draft seed
+            // and collapses draft acceptance from ~97.9% to ~50% (gen 57→18 t/s) on the
+            // Qwen3.6-27B-MTP TQ3_4S runtime. The (1/15) dataextract task that the '\n'
+            // helped is tracked separately; speed/acceptance take priority for the ship build.
         }
         common_peg_arena arena;
         arena.load(auto_params.parser);

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -77,6 +77,16 @@
 
 #define UNUSED GGML_UNUSED
 #define SWAP(x, y, T) do { T SWAP = x; (x) = y; (y) = SWAP; } while (0)
+// Portable ffs (find first set bit) for Windows/MSVC compatibility
+#if defined(_MSC_VER)
+#include <intrin.h>
+static int ffs(int x) {
+    unsigned long i;
+    return _BitScanForward(&i, (unsigned long)x) ? (int)(i + 1) : 0;
+}
+#else
+#include <strings.h>
+#endif
 
 // Portable ffs (find first set bit) for Windows/MSVC compatibility
 #if defined(_MSC_VER)

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -870,7 +870,7 @@ static __global__ void dequantize_block_tq3_1s(const void * __restrict__ vx, dst
 
     float val = tq3_0_centroids_cuda[idx] * (j < 16 ? d0 : d1);
     for (int step = 1; step < 32; step <<= 1) {
-        float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         if (j & step) {
             val = other - val;
         } else {
@@ -916,7 +916,7 @@ static __global__ void dequantize_block_tq3_4s(const void * __restrict__ vx, dst
 
     float val = tq3_0_centroids_cuda[idx] * ds[g];
     for (int step = 1; step < 32; step <<= 1) {
-        float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         if (j & step) {
             val = other - val;
         } else {
@@ -963,7 +963,7 @@ static __global__ void dequantize_block_tq3_4se(const void * __restrict__ vx, ds
 
     float val = tq3_0_centroids_cuda[idx] * ds[g] + shifts[h];
     for (int step = 1; step < 32; step <<= 1) {
-        float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         if (j & step) {
             val = other - val;
         } else {
@@ -1061,7 +1061,7 @@ static __global__ void dequantize_block_tq3_4sv(const void * __restrict__ vx, ds
 
     // Inverse WHT butterfly
     for (int step = 1; step < 32; step <<= 1) {
-        float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         if (j & step) {
             val = other - val;
         } else {
@@ -1131,7 +1131,7 @@ static __global__ void dequantize_block_tq3_1s_ap1(const void * __restrict__ vx,
         const float d = lane < 16 ? __half2float(x->d0) : __half2float(x->d1);
         float val = tq3_0_centroids_cuda[idx] * d;
         for (int step = 1; step < 32; step <<= 1) {
-            const float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+            const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
             val = (lane & step) ? (other - val) : (other + val);
         }
         y[lane] = (dst_t) (val * (tq3_0_signs_cuda[lane] / sqrtf(32.0f)));
@@ -1146,7 +1146,7 @@ static __global__ void dequantize_block_tq3_1s_ap1(const void * __restrict__ vx,
     const float d = lane < 16 ? __half2float(x->d0) : __half2float(x->d1);
     float val = tq3_0_centroids_cuda[idx] * d + __half2float(x->m);
     for (int step = 1; step < 32; step <<= 1) {
-        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         val = (lane & step) ? (other - val) : (other + val);
     }
     y[lane] = (dst_t) (val * (tq3_0_signs_cuda[lane] / sqrtf(32.0f)));

--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -90,7 +90,7 @@ static __global__ void flash_attn_ext_vec(
     if (use_logit_softcap && !(D == 128 || D == 256)) {
         // note: Q, K, V, etc. are in scope on both the HIP and the non-HIP paths,
         //       a preprocessor conditional inside the macro arguments breaks MSVC (C1019)
-        GGML_UNUSED_VARS(Q, K, V, mask, sinks, KV_max, dst, dst_meta, scale,
+        GGML_UNUSED_VARS(Q_ptr, K_ptr, V_ptr, mask_ptr, sinks_ptr, KV_max_ptr, dst_ptr, dst_meta_ptr, scale,
             max_bias, m0, m1, n_head_log2, logit_softcap,
             ne00, ne01, ne02, ne03,
                   nb01, nb02, nb03,
@@ -542,7 +542,7 @@ static __global__ void flash_attn_ext_vec(
         dst_meta[((sequence*int(ne01.z) + ic0 + tid)*ne02 + head)*gridDim.y + blockIdx.y] = make_float2(KQ_max[tid], KQ_sum[tid]);
     }
 #else
-    GGML_UNUSED_VARS(Q, K, V, mask, sinks, KV_max, dst, dst_meta, scale,
+    GGML_UNUSED_VARS(Q_ptr, K_ptr, V_ptr, mask_ptr, sinks_ptr, KV_max_ptr, dst_ptr, dst_meta_ptr, scale,
         max_bias, m0, m1, n_head_log2, logit_softcap,
         ne00, ne01, ne02, ne03,
               nb01, nb02, nb03,

--- a/ggml/src/ggml-cuda/getrows.cu
+++ b/ggml/src/ggml-cuda/getrows.cu
@@ -230,7 +230,7 @@ static __global__ void k_get_rows_tq3_0(
 
     float val = tq3_0_centroids_getrows_cuda[idx];
     for (int step = 1; step < 32; step <<= 1) {
-        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         val = (lane & step) ? (other - val) : (other + val);
     }
 
@@ -313,7 +313,7 @@ static __global__ void k_get_rows_tq3_1s(
     const float d = lane < 16 ? __half2float(x->d0) : __half2float(x->d1);
     float val = tq3_0_centroids_getrows_cuda[idx] * d;
     for (int step = 1; step < 32; step <<= 1) {
-        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         val = (lane & step) ? (other - val) : (other + val);
     }
 
@@ -399,7 +399,7 @@ static __global__ void k_get_rows_tq3_4s(
 
     float val = tq3_0_centroids_getrows_cuda[idx] * ds[g];
     for (int step = 1; step < 32; step <<= 1) {
-        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         val = (lane & step) ? (other - val) : (other + val);
     }
 
@@ -497,7 +497,7 @@ static __global__ void k_get_rows_tq3_1s_ap1(
         const float d = lane < 16 ? __half2float(x->d0) : __half2float(x->d1);
         val = tq3_0_centroids_getrows_cuda[idx] * d;
         for (int step = 1; step < 32; step <<= 1) {
-            const float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+            const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
             val = (lane & step) ? (other - val) : (other + val);
         }
         dst_row[block * QK_TQ3_0 + lane] = ggml_cuda_cast<dst_t>(val * (tq3_0_signs_getrows_cuda[lane] / sqrtf(32.0f)));
@@ -510,7 +510,7 @@ static __global__ void k_get_rows_tq3_1s_ap1(
     const float d = lane < 16 ? __half2float(x->d0) : __half2float(x->d1);
     val = tq3_0_centroids_getrows_cuda[idx] * d + __half2float(x->m);
     for (int step = 1; step < 32; step <<= 1) {
-        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step);
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         val = (lane & step) ? (other - val) : (other + val);
     }
     dst_row[block * QK_TQ3_0 + lane] = ggml_cuda_cast<dst_t>(val * (tq3_0_signs_getrows_cuda[lane] / sqrtf(32.0f)));

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -289,13 +289,14 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
     return false;
 #endif // GGML_CUDA_FORCE_CUBLAS
 
-    // TQ3_4S: use MMQ for prefill (ne11 >= 64) on NVIDIA tensor-core GPUs.
-    // Contiguity guard in ggml_cuda_mul_mat ensures KV cache views use cuBLAS.
+    // TQ3_4S: use MMQ for prefill on NVIDIA tensor-core GPUs. Narrower prefill
+    // shapes (ne11 >= 16) also benefit, matching the 8ad718007 reference; the
+    // contiguity guard in ggml_cuda_mul_mat ensures KV cache views use cuBLAS.
     if (type == GGML_TYPE_TQ3_4S &&
         GGML_CUDA_CC_IS_NVIDIA(cc) &&
         fp16_mma_hardware_available(cc) &&
         n_experts == 0) {
-        return ne11 >= 64;
+        return ne11 >= 16;
     }
 
     bool mmq_supported;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -357,6 +357,12 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
     if (table_id == MMVQ_PARAMETERS_GENERIC) {
         switch (ncols_dst) {
             case 1:
+                if (type == GGML_TYPE_TQ3_4S) {
+                    // TQ3_4S has a heavier vec_dot than simple q4/q8 paths.
+                    // On NVIDIA, 4 warps overpay in shared reduction for bs=1 decode.
+                    return 2;
+                }
+                [[fallthrough]];
             case 2:
             case 3:
             case 4:
@@ -478,6 +484,87 @@ static constexpr __host__ __device__ int calc_rows_per_block(int ncols_dst, int 
         }
     }
     return 1;
+}
+
+template <int nwarps>
+__launch_bounds__(nwarps*ggml_cuda_get_physical_warp_size(), 1)
+static __global__ void mul_mat_vec_tq3_4s_q8_1_ncols1(
+        const void * __restrict__ vx, const block_q8_1 * __restrict__ vy, float * __restrict__ dst,
+        const uint32_t ncols_x, const uint32_t nrows_x,
+        const uint32_t stride_row_x, const uint32_t stride_channel_x, const uint32_t stride_sample_x,
+        const uint32_t stride_channel_y, const uint32_t stride_sample_y,
+        const uint32_t stride_channel_dst, const uint32_t stride_sample_dst) {
+
+    constexpr int type = GGML_TYPE_TQ3_4S;
+    constexpr int qk = ggml_cuda_type_traits<GGML_TYPE_TQ3_4S>::qk;
+    constexpr int qi = ggml_cuda_type_traits<GGML_TYPE_TQ3_4S>::qi;
+    constexpr int vdr = VDR_TQ3_4S_Q8_1_MMVQ;
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int blocks_per_iter = vdr * nwarps * warp_size / qi;
+
+    const int tid = warp_size * threadIdx.y + threadIdx.x;
+    const int row = blockIdx.x;
+    const int blocks_per_row_x = ncols_x / qk;
+    const uint32_t channel = blockIdx.y;
+    const uint32_t sample = blockIdx.z;
+
+    const block_q8_1 * y = vy + sample * stride_sample_y + channel * stride_channel_y;
+    const int kbx_offset = sample * stride_sample_x + channel * stride_channel_x + row * stride_row_x;
+
+    float tmp = 0.0f;
+
+    for (int kbx = tid / (qi / vdr); kbx < blocks_per_row_x; kbx += blocks_per_iter) {
+        const int kby = kbx * (qk / QK8_1);
+        const int kqs = vdr * (tid % (qi / vdr));
+        tmp += vec_dot_tq3_4s_q8_1(vx, &y[kby], kbx_offset + kbx, kqs);
+    }
+
+    __shared__ float tmp_shared[nwarps - 1 > 0 ? nwarps - 1 : 1][warp_size];
+    if (threadIdx.y > 0) {
+        tmp_shared[threadIdx.y - 1][threadIdx.x] = tmp;
+    }
+    __syncthreads();
+
+    if (threadIdx.y > 0) {
+        return;
+    }
+
+#pragma unroll
+    for (int l = 0; l < nwarps - 1; ++l) {
+        tmp += tmp_shared[l][threadIdx.x];
+    }
+    tmp = warp_reduce_sum<warp_size>(tmp);
+
+    if (threadIdx.x == 0 && row < nrows_x) {
+        dst[sample * stride_sample_dst + channel * stride_channel_dst + row] = tmp;
+    }
+
+    GGML_UNUSED(type);
+}
+
+static bool try_mul_mat_vec_tq3_4s_q8_1_ncols1(
+        const void * vx, const ggml_type type_x, const void * vy, const int32_t * ids, const ggml_cuda_mm_fusion_args_host * fusion, float * dst,
+        const int ncols_x, const int nrows_x,
+        const int stride_row_x, const int stride_col_y, const int stride_col_dst,
+        const int nchannels_x, const int nchannels_y, const int nchannels_dst,
+        const int stride_channel_x, const int stride_channel_y, const int stride_channel_dst,
+        const int nsamples_x, const int nsamples_dst, const int stride_sample_x, const int stride_sample_y, const int stride_sample_dst,
+        cudaStream_t stream) {
+    if (type_x != GGML_TYPE_TQ3_4S || ids != nullptr || fusion != nullptr || nchannels_x != nchannels_y || nchannels_x != nchannels_dst || nsamples_x != nsamples_dst) {
+        return false;
+    }
+
+    constexpr int nwarps = 4;
+    const dim3 block_dims(WARP_SIZE, nwarps, 1);
+    const dim3 block_nums(nrows_x, nchannels_dst, nsamples_dst);
+    mul_mat_vec_tq3_4s_q8_1_ncols1<nwarps><<<block_nums, block_dims, 0, stream>>>(
+        vx, static_cast<const block_q8_1 *>(vy), dst, ncols_x, nrows_x,
+        stride_row_x, stride_channel_x, stride_sample_x,
+        stride_channel_y, stride_sample_y,
+        stride_channel_dst, stride_sample_dst);
+    GGML_UNUSED(stride_col_y);
+    GGML_UNUSED(stride_col_dst);
+    return true;
 }
 
 template <ggml_type type, int ncols_dst, bool has_fusion, bool small_k = false>
@@ -881,6 +968,14 @@ static void mul_mat_vec_q_switch_ncols_dst(
             use = false;
         }
 
+        if (GGML_CUDA_CC_IS_NVIDIA(cc) && type == GGML_TYPE_TQ3_4S && c_ncols_dst == 1) {
+            // 27B-class widths benefit from 2 rows/block; smaller models do not.
+            constexpr int large_k_threshold_blocks = 144;
+            if (blocks_per_row_x >= large_k_threshold_blocks) {
+                use = true;
+            }
+        }
+
         return use;
     };
 
@@ -1249,6 +1344,16 @@ void ggml_cuda_mul_mat_vec_q(
 
     const int64_t ids_stride = ids ? ids->nb[1] / ggml_type_size(ids->type) : 0;
 
+    if (!ids && fusion == nullptr) {
+        if (ncols_dst == 1 &&
+            try_mul_mat_vec_tq3_4s_q8_1_ncols1(
+                src0->data, src0->type, src1_q8_1.get(), nullptr, nullptr, dst_d, ne00, ne01, s01, stride_col_y, stride_col_dst,
+                ne02, nchannels_y, nchannels_dst, s02, stride_channel_y, stride_channel_dst,
+                ne03, ne3, s03, s13, s3, stream)) {
+            return;
+        }
+    }
+
     mul_mat_vec_q_switch_type(
         src0->data, src0->type, src1_q8_1.get(), ids_d, fusion_local, dst_d, ne00,
         ne01,              ncols_dst,     s01, stride_col_y,     stride_col_dst,
@@ -1289,6 +1394,14 @@ void ggml_cuda_op_mul_mat_vec_q(
         const int stride_col_y = src1_padded_row_size / QK8_1;
 
         ggml_cuda_mm_fusion_args_device fusion_local{};
+        if (src1_ncols == 1 &&
+            try_mul_mat_vec_tq3_4s_q8_1_ncols1(
+                src0_dd_i, src0->type, src1_q8_1.get(), nullptr, nullptr, dst_dd_i, ne00, row_diff, stride_row_x, stride_col_y, nrows_dst,
+                1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, stream)) {
+            return;
+        }
+
         mul_mat_vec_q_switch_type(
             src0_dd_i, src0->type, src1_q8_1.get(), nullptr, fusion_local, dst_dd_i, ne00, row_diff, src1_ncols, stride_row_x, stride_col_y, nrows_dst,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, stream);

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1442,34 +1442,70 @@ static __device__ __forceinline__ float vec_dot_tq3_1s_q8_1(
     return sum * d * ds8.x;
 }
 
-#define VDR_TQ3_4S_Q8_1_MMVQ 4
+static __device__ __forceinline__ float tq3_4s_ratio4s(const uint8_t byte) {
+    if (byte == 0) {
+        return 0.0f;
+    }
+
+    // d encodes (1 + mant/32) * 2^(exp - 9), with exp in the high 3 bits.
+    // Build the exact FP32 representation directly and avoid ldexpf in the hot loop.
+    const uint32_t bits = (((uint32_t) (byte >> 5) + 118u) << 23) | ((uint32_t) (byte & 31u) << 18);
+    return __uint_as_float(bits);
+}
+
+static __device__ __forceinline__ float tq3_4s_dot_subgroup_q8_1(
+    const block_tq3_4s * __restrict__ bq,
+    const block_q8_1 * __restrict__ bq8_1,
+    const int subgroup) {
+
+    // Int8 centroid levels matching the float centroids scaled to [-127,127]
+    static constexpr int8_t levels[8] = {-127, -79, -45, -14, 14, 45, 79, 127};
+
+    const uint8_t * qp = bq->qs + subgroup * 3;
+    const uint32_t packed = (uint32_t)qp[0] | ((uint32_t)qp[1] << 8) | ((uint32_t)qp[2] << 16);
+    const float d = tq3_4s_ratio4s(bq->d[subgroup]);
+
+    // Unpack 8 3-bit indices into 8 int8 weight values
+    const int8_t w0 = levels[(packed >>  0) & 7];
+    const int8_t w1 = levels[(packed >>  3) & 7];
+    const int8_t w2 = levels[(packed >>  6) & 7];
+    const int8_t w3 = levels[(packed >>  9) & 7];
+    const int8_t w4 = levels[(packed >> 12) & 7];
+    const int8_t w5 = levels[(packed >> 15) & 7];
+    const int8_t w6 = levels[(packed >> 18) & 7];
+    const int8_t w7 = levels[(packed >> 21) & 7];
+
+    // Pack into two int32 for dp4a
+    const int w_lo = (uint8_t)w0 | ((uint8_t)w1 << 8) | ((uint8_t)w2 << 16) | ((uint8_t)w3 << 24);
+    const int w_hi = (uint8_t)w4 | ((uint8_t)w5 << 8) | ((uint8_t)w6 << 16) | ((uint8_t)w7 << 24);
+
+    // Pack activation q8 values (already int8 in bq8_1->qs)
+    const int q8 = subgroup * 8;
+    const int a_lo = *(const int *)&bq8_1->qs[q8 + 0];
+    const int a_hi = *(const int *)&bq8_1->qs[q8 + 4];
+
+    // dp4a: each does 4 int8 multiply-adds
+    int sumi = ggml_cuda_dp4a(w_lo, a_lo, 0);
+    sumi     = ggml_cuda_dp4a(w_hi, a_hi, sumi);
+
+    return (float)sumi * d;
+}
+
+#define VDR_TQ3_4S_Q8_1_MMVQ 8
 static __device__ __forceinline__ float vec_dot_tq3_4s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
 
-    const int g = iqs / VDR_TQ3_4S_Q8_1_MMVQ;
-
     const block_tq3_4s * bq = (const block_tq3_4s *) vbq + kbx;
-    auto ratio4s = [] __device__ (uint8_t byte) -> float {
-        if (byte == 0) return 0.0f;
-        const int exp = (byte >> 5) - 9;
-        const float mantissa = 1.0f + (float)(byte & 31) / 32.0f;
-        return ldexpf(mantissa, exp);
-    };
-    const float d = ratio4s(bq->d[g]);
-
-    const float centroids[8] = {-2.1519f,-1.3439f,-0.7560f,-0.2451f,0.2451f,0.7560f,1.3439f,2.1519f};
-    const uint8_t * qp = bq->qs + g * 3;
+    const int subgroup0 = iqs / 4;
     const float2 ds8 = __half22float2(bq8_1->ds);
-
+    // Hoist the activation-side scale once per block instead of reloading it per subgroup.
+    const float scale = (2.1519f / 127.0f) * ds8.x;
     float sum = 0.0f;
-    sum += centroids[ qp[0]       & 7] * (float) bq8_1->qs[g*8 + 0];
-    sum += centroids[(qp[0] >> 3) & 7] * (float) bq8_1->qs[g*8 + 1];
-    sum += centroids[((qp[0]>>6)|(qp[1]<<2)) & 7] * (float) bq8_1->qs[g*8 + 2];
-    sum += centroids[(qp[1] >> 1) & 7] * (float) bq8_1->qs[g*8 + 3];
-    sum += centroids[(qp[1] >> 4) & 7] * (float) bq8_1->qs[g*8 + 4];
-    sum += centroids[((qp[1]>>7)|(qp[2]<<1)) & 7] * (float) bq8_1->qs[g*8 + 5];
-    sum += centroids[(qp[2] >> 2) & 7] * (float) bq8_1->qs[g*8 + 6];
-    sum += centroids[(qp[2] >> 5) & 7] * (float) bq8_1->qs[g*8 + 7];
 
-    return sum * d * ds8.x;
+#pragma unroll
+    for (int s = 0; s < VDR_TQ3_4S_Q8_1_MMVQ / 4; ++s) {
+        sum += tq3_4s_dot_subgroup_q8_1(bq, bq8_1, subgroup0 + s);
+    }
+
+    return sum * scale;
 }

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -35,6 +35,16 @@ static int ffs(int x) {
 #define GROUP_MAX_EPS_IQ1_S 1e-12f
 
 #define UNUSED GGML_UNUSED
+// Portable ffs (find first set bit) for Windows/MSVC compatibility
+#if defined(_MSC_VER)
+#include <intrin.h>
+static int ffs(int x) {
+    unsigned long i;
+    return _BitScanForward(&i, (unsigned long)x) ? (int)(i + 1) : 0;
+}
+#else
+#include <strings.h>
+#endif
 
 static inline int best_index_int8(int n, const int8_t * val, float x) {
     if (x <= val[0]) return 0;

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -2848,7 +2848,7 @@ void dequantize_row_tq3_4s(const block_tq3_4s * GGML_RESTRICT x, float * GGML_RE
     }
 }
 
-void quantize_row_tq3_1s_shift_ref(const float * GGML_RESTRICT x, block_tq3_1s_shift * GGML_RESTRICT y, int64_t k) {
+static void quantize_row_tq3_1s_shift_ref(const float * GGML_RESTRICT x, block_tq3_1s_shift * GGML_RESTRICT y, int64_t k) {
     assert(k % QK_TQ3_0 == 0);
     const int64_t nb = k / QK_TQ3_0;
 
@@ -3405,7 +3405,7 @@ static inline uint8_t tq3_v_choose_c4(float x) {
     return (uint8_t)best;
 }
 
-static float tq3_v_quant_group(const float * vals, int n, const float * centroids, int nc,
+static float tq3_v_quant_group(const float * vals, int n, const float * centroids, int /*nc*/,
                                 uint8_t (* choose)(float), float * out_scale, uint8_t * out_idx) {
     float sum_sq = 0.0f;
     for (int j = 0; j < n; j++) sum_sq += vals[j] * vals[j];

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -3215,18 +3215,7 @@ size_t quantize_tq3_4s(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst
             tq3_0_rht_forward(bx, rotated);
 
             // Transform importance weights through WHT (squared weights → use abs of WHT)
-            // Approximation: use original-domain weights mapped to WHT groups
-            // Each WHT coefficient mixes all 32 inputs, so weight by sum of input weights
-            float group_weight[4];
-            for (int g = 0; g < 4; ++g) {
-                float sw = 0.0f;
-                for (int j = 0; j < 8; ++j) {
-                    // WHT coefficient g*8+j depends on all inputs, but primarily on nearby ones
-                    // Use the average imatrix weight for this group's input range
-                    sw += bw[g*8+j];
-                }
-                group_weight[g] = fmaxf(sw, 1e-10f);
-            }
+            // group_weight was set but unused (WHT mixing makes per-group weights noisy)
 
             uint8_t all_idx[QK_TQ3_0];
             for (int g = 0; g < 4; ++g) {
@@ -3405,8 +3394,9 @@ static inline uint8_t tq3_v_choose_c4(float x) {
     return (uint8_t)best;
 }
 
-static float tq3_v_quant_group(const float * vals, int n, const float * centroids, int /*nc*/,
+static float tq3_v_quant_group(const float * vals, int n, const float * centroids, int nc,
                                 uint8_t (* choose)(float), float * out_scale, uint8_t * out_idx) {
+    (void)nc;
     float sum_sq = 0.0f;
     for (int j = 0; j < n; j++) sum_sq += vals[j] * vals[j];
     float scale = fmaxf(sqrtf(sum_sq / n), 1e-10f);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -7189,6 +7189,7 @@ struct ggml_cgraph * ggml_new_graph_custom(struct ggml_context * ctx, size_t siz
         /*.use_counts   =*/ use_counts_ptr,
         /*.hash_table   =*/ { hash_size, hash_used, hash_keys_ptr },
         /*.order        =*/ GGML_CGRAPH_EVAL_ORDER_LEFT_TO_RIGHT,
+        /*.uid          =*/ 0,
     };
 
     ggml_hash_set_reset(&cgraph->visited_hash_set);
@@ -7216,6 +7217,7 @@ struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph0, int i0, int i1)
         /*.use_counts       =*/ cgraph0->use_counts,
         /*.visited_hash_set =*/ cgraph0->visited_hash_set,
         /*.order            =*/ cgraph0->order,
+        /*.uid              =*/ 0,
     };
 
     return cgraph;

--- a/scripts/ui-assets.cmake
+++ b/scripts/ui-assets.cmake
@@ -1,0 +1,354 @@
+# Provision UI assets and generate ui.cpp/ui.h.
+#
+# Asset provisioning priority:
+#   1. Pre-built assets in SRC_DIST_DIR (manually built by user)
+#   2. If BUILD_UI=ON: npm build
+#   3. If above did not produce assets and HF_ENABLED=ON: HF Bucket download
+#      of dist.tar.gz (verified against dist.tar.gz.sha256)
+
+cmake_minimum_required(VERSION 3.18)
+
+set(UI_SOURCE_DIR     "" CACHE STRING "UI source directory (to run npm build)")
+set(UI_BINARY_DIR     "" CACHE STRING "UI binary directory (to store generated files)")
+set(LLAMA_SOURCE_DIR  "" CACHE STRING "Project source root (to resolve version from git)")
+set(HF_BUCKET         "" CACHE STRING "Hugging Face bucket name")
+set(HF_VERSION        "" CACHE STRING "Version to download (empty = resolve from git)")
+set(HF_ENABLED        "" CACHE STRING "Whether to allow HF Bucket download (ON/OFF)")
+set(BUILD_UI          "" CACHE STRING "Build UI via npm (ON/OFF)")
+set(LLAMA_UI_EMBED    "" CACHE STRING "Path to llama-ui-embed helper")
+set(LLAMA_UI_GZIP     "" CACHE STRING "Apply gzip compress to assets to save bandwidth")
+
+set(DIST_DIR     "${UI_BINARY_DIR}/dist")
+set(SRC_DIST_DIR "${UI_SOURCE_DIR}/dist")
+set(STAMP_FILE   "${UI_BINARY_DIR}/.ui-stamp")
+set(UI_CPP       "${UI_BINARY_DIR}/ui.cpp")
+set(UI_H         "${UI_BINARY_DIR}/ui.h")
+
+function(npm_build_should_skip out_var)
+    set(${out_var} FALSE PARENT_SCOPE)
+
+    if(NOT EXISTS "${DIST_DIR}/index.html")
+        return()
+    endif()
+
+    if(EXISTS "${STAMP_FILE}")
+        return()
+    endif()
+
+    if(NOT EXISTS "${UI_SOURCE_DIR}/sources.cmake")
+        return()
+    endif()
+    include("${UI_SOURCE_DIR}/sources.cmake")
+
+    set(globs "")
+    foreach(g ${UI_SOURCE_GLOBS})
+        list(APPEND globs "${UI_SOURCE_DIR}/${g}")
+    endforeach()
+    file(GLOB_RECURSE sources ${globs})
+    foreach(f ${UI_SOURCE_FILES})
+        list(APPEND sources "${UI_SOURCE_DIR}/${f}")
+    endforeach()
+
+    file(TIMESTAMP "${DIST_DIR}/index.html" out_ts)
+
+    foreach(s ${sources})
+        if(NOT EXISTS "${s}")
+            continue()
+        endif()
+        file(TIMESTAMP "${s}" s_ts)
+        if(s_ts STRGREATER out_ts)
+            return()
+        endif()
+    endforeach()
+
+    set(${out_var} TRUE PARENT_SCOPE)
+endfunction()
+
+function(npm_build out_var)
+    set(${out_var} FALSE PARENT_SCOPE)
+
+    if(NOT EXISTS "${UI_SOURCE_DIR}/package.json")
+        message(STATUS "UI: ${UI_SOURCE_DIR}/package.json not found, skipping npm")
+        return()
+    endif()
+
+    npm_build_should_skip(skip)
+    if(skip)
+        message(STATUS "UI: npm output up-to-date, skipping build")
+        set(${out_var} TRUE PARENT_SCOPE)
+        return()
+    endif()
+
+    if(CMAKE_HOST_WIN32)
+        find_program(NPM_EXECUTABLE NAMES npm.cmd npm.bat npm)
+    else()
+        find_program(NPM_EXECUTABLE npm)
+    endif()
+    if(NOT NPM_EXECUTABLE)
+        message(STATUS "UI: npm not found, skipping npm build")
+        return()
+    endif()
+
+    # npm writes node_modules/.package-lock.json on every successful install,
+    # so a package-lock.json newer than this marker means node_modules is stale
+    set(NPM_MARKER "${UI_SOURCE_DIR}/node_modules/.package-lock.json")
+    set(need_install FALSE)
+    if(NOT EXISTS "${NPM_MARKER}")
+        set(need_install TRUE)
+    else()
+        file(TIMESTAMP "${UI_SOURCE_DIR}/package-lock.json" lock_ts)
+        file(TIMESTAMP "${NPM_MARKER}" marker_ts)
+        if(lock_ts STRGREATER marker_ts)
+            set(need_install TRUE)
+        endif()
+    endif()
+
+    if(need_install)
+        message(STATUS "UI: running npm install")
+        execute_process(
+            COMMAND ${NPM_EXECUTABLE} install
+            WORKING_DIRECTORY "${UI_SOURCE_DIR}"
+            RESULT_VARIABLE rc
+            ERROR_VARIABLE  err
+        )
+        if(NOT rc EQUAL 0)
+            message(STATUS "UI: npm install failed (${rc})")
+            message(STATUS "  stderr: ${err}")
+            return()
+        endif()
+    endif()
+
+    file(MAKE_DIRECTORY "${DIST_DIR}")
+
+    message(STATUS "UI: running npm run build, output -> ${DIST_DIR}")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env "LLAMA_UI_OUT_DIR=${DIST_DIR}" "LLAMA_UI_VERSION=${HF_VERSION}" "LLAMA_BUILD_NUMBER=${LLAMA_BUILD_NUMBER}"
+                ${NPM_EXECUTABLE} run build
+        WORKING_DIRECTORY "${UI_SOURCE_DIR}"
+        RESULT_VARIABLE rc
+        ERROR_VARIABLE  err
+    )
+    if(NOT rc EQUAL 0)
+        message(STATUS "UI: npm run build failed (${rc})")
+        message(STATUS "  stderr: ${err}")
+        return()
+    endif()
+
+    if(NOT EXISTS "${DIST_DIR}/index.html")
+        message(STATUS "UI: npm build finished but assets missing in ${DIST_DIR}")
+        return()
+    endif()
+
+    message(STATUS "UI: npm build succeeded")
+    file(REMOVE "${STAMP_FILE}")
+    set(${out_var} TRUE PARENT_SCOPE)
+endfunction()
+
+function(resolve_version out_var)
+    if(NOT "${HF_VERSION}" STREQUAL "")
+        set(${out_var} "${HF_VERSION}" PARENT_SCOPE)
+        return()
+    endif()
+
+    if(EXISTS "${LLAMA_SOURCE_DIR}/cmake/build-info.cmake")
+        include("${LLAMA_SOURCE_DIR}/cmake/build-info.cmake")
+        if(NOT "${BUILD_NUMBER}" STREQUAL "" AND NOT BUILD_NUMBER EQUAL 0)
+            set(${out_var} "b${BUILD_NUMBER}" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
+    set(${out_var} "" PARENT_SCOPE)
+endfunction()
+
+function(hf_download version out_var out_resolved)
+    set(${out_var}      FALSE PARENT_SCOPE)
+    set(${out_resolved} ""    PARENT_SCOPE)
+
+    set(archive "${UI_BINARY_DIR}/dist.tar.gz")
+
+    set(candidates "")
+    if(NOT "${version}" STREQUAL "")
+        list(APPEND candidates "${version}")
+    endif()
+    list(APPEND candidates "latest")
+
+    foreach(resolved ${candidates})
+        set(base "https://huggingface.co/buckets/${HF_BUCKET}/resolve/${resolved}")
+
+        message(STATUS "UI: downloading from ${resolved}: ${base}/dist.tar.gz")
+
+        file(DOWNLOAD "${base}/dist.tar.gz?download=true" "${archive}"
+            STATUS status TIMEOUT 300
+        )
+        list(GET status 0 rc)
+        if(NOT rc EQUAL 0)
+            list(GET status 1 errmsg)
+            message(STATUS "UI: download dist.tar.gz from ${resolved} failed: ${errmsg}")
+            continue()
+        endif()
+
+        file(DOWNLOAD "${base}/dist.tar.gz.sha256?download=true" "${archive}.sha256"
+            STATUS status TIMEOUT 30
+        )
+        list(GET status 0 rc)
+        if(NOT rc EQUAL 0)
+            list(GET status 1 errmsg)
+            message(STATUS "UI: download dist.tar.gz.sha256 from ${resolved} failed: ${errmsg}")
+            continue()
+        endif()
+
+        # Validate sha256 checkums
+        file(READ "${archive}.sha256" expected)
+        string(REGEX MATCH "^[0-9a-fA-F]+" expected "${expected}")
+        string(TOLOWER "${expected}" expected)
+        file(SHA256 "${archive}" actual)
+        if("${expected}" STREQUAL "" OR NOT "${actual}" STREQUAL "${expected}")
+            message(STATUS "UI: checksum mismatch for dist.tar.gz from ${resolved}")
+            continue()
+        endif()
+
+        # Clear DIST_DIR to remove stale files first
+        file(REMOVE_RECURSE "${DIST_DIR}")
+
+        file(ARCHIVE_EXTRACT INPUT "${archive}" DESTINATION "${DIST_DIR}")
+
+        if(NOT EXISTS "${DIST_DIR}/index.html")
+            message(STATUS "UI: archive from ${resolved} is missing required assets")
+            continue()
+        endif()
+
+        message(STATUS "UI: archive verified and extracted")
+        set(${out_var}      TRUE          PARENT_SCOPE)
+        set(${out_resolved} "${resolved}" PARENT_SCOPE)
+        return()
+    endforeach()
+endfunction()
+
+function(emit_files dist_dir)
+    # If gzip is requested, compress every asset into a parallel _gzip/ tree
+    # the structure stays the same; for ex: /abc/def --> /_gzip/abc/def
+    # embed.cpp will check for _gzip and will pick it up
+    if(LLAMA_UI_GZIP AND EXISTS "${dist_dir}/index.html")
+        find_program(GZIP_EXECUTABLE gzip)
+        if(NOT GZIP_EXECUTABLE)
+            message(WARNING "UI: LLAMA_UI_GZIP requested but gzip not found, embedding uncompressed")
+        else()
+            set(gzip_dir "${dist_dir}/_gzip")
+            file(REMOVE_RECURSE "${gzip_dir}")
+            file(GLOB_RECURSE all_files RELATIVE "${dist_dir}" "${dist_dir}/*")
+            foreach(f ${all_files})
+                get_filename_component(dst_dir "${gzip_dir}/${f}" DIRECTORY)
+                file(MAKE_DIRECTORY "${dst_dir}")
+                execute_process(
+                    COMMAND "${GZIP_EXECUTABLE}" -c "${dist_dir}/${f}"
+                    OUTPUT_FILE "${gzip_dir}/${f}"
+                    RESULT_VARIABLE gz_rc
+                )
+                if(NOT gz_rc EQUAL 0)
+                    message(FATAL_ERROR "UI: gzip failed for ${f}")
+                endif()
+            endforeach()
+            message(STATUS "UI: gzip compression applied (${gzip_dir})")
+        endif()
+    endif()
+
+    set(args "${UI_CPP}" "${UI_H}")
+    if(EXISTS "${dist_dir}/index.html")
+        list(APPEND args "${dist_dir}")
+    endif()
+
+    if(LLAMA_UI_EMBED AND (BUILD_UI OR HF_ENABLED))
+        execute_process(
+            COMMAND "${LLAMA_UI_EMBED}" ${args}
+            RESULT_VARIABLE rc
+        )
+        if(NOT rc EQUAL 0)
+            message(FATAL_ERROR "UI: llama-ui-embed failed (${rc})")
+        endif()
+    else()
+        # UI bundle not needed in this configuration: write empty stub
+        # translation units so the llama-ui static lib still compiles and
+        # links cleanly into llama-server without any embedded bundle.
+        if(NOT EXISTS "${UI_CPP}")
+            file(WRITE "${UI_CPP}" "// ui.cpp stub - UI disabled (BUILD_UI=OFF, HF_ENABLED=OFF)\n")
+        endif()
+        if(NOT EXISTS "${UI_H}")
+            file(WRITE "${UI_H}"   "// ui.h stub - UI disabled (BUILD_UI=OFF, HF_ENABLED=OFF)\n")
+        endif()
+    endif()
+endfunction()
+
+# ---------------------------------------------------------------------------
+# 1. Priority 1: pre-built assets supplied in tools/ui/dist
+# ---------------------------------------------------------------------------
+if(EXISTS "${SRC_DIST_DIR}/index.html")
+    message(STATUS "UI: using pre-built assets from ${SRC_DIST_DIR}")
+    emit_files("${SRC_DIST_DIR}")
+    return()
+endif()
+
+# ---------------------------------------------------------------------------
+# 2. Priority 2: npm build (if BUILD_UI=ON)
+# ---------------------------------------------------------------------------
+set(provisioned FALSE)
+
+if(BUILD_UI)
+    # Resolve version from git build-info if not explicitly set
+    resolve_version(HF_VERSION)
+    npm_build(NPM_OK)
+    if(NPM_OK)
+        set(provisioned TRUE)
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
+# 3. Priority 3: HF Bucket download (if npm did not produce assets and HF_ENABLED=ON)
+# ---------------------------------------------------------------------------
+if(NOT provisioned AND HF_ENABLED)
+    resolve_version(VERSION)
+
+    set(stamp_ok FALSE)
+    if(EXISTS "${STAMP_FILE}" AND NOT "${VERSION}" STREQUAL "")
+        file(READ "${STAMP_FILE}" stamped)
+        string(STRIP "${stamped}" stamped)
+        if("${stamped}" STREQUAL "${VERSION}")
+            set(stamp_ok TRUE)
+        endif()
+    endif()
+
+    set(have_assets FALSE)
+    if(EXISTS "${DIST_DIR}/index.html")
+        set(have_assets TRUE)
+    endif()
+    if(stamp_ok AND have_assets)
+        message(STATUS "UI: HF stamp '${stamped}' matches version, skipping HF fetch")
+        set(provisioned TRUE)
+    else()
+        hf_download("${VERSION}" HF_OK HF_RESOLVED)
+        if(HF_OK)
+            file(WRITE "${STAMP_FILE}" "${HF_RESOLVED}")
+            message(STATUS "UI: HF download succeeded, stamp updated (${HF_RESOLVED})")
+            set(provisioned TRUE)
+        else()
+            message(STATUS "UI: HF download failed")
+        endif()
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
+# 4. Fallback: warn about stale or missing assets, then emit whatever we have
+# ---------------------------------------------------------------------------
+if(NOT provisioned)
+    if(EXISTS "${DIST_DIR}/index.html")
+        message(WARNING "UI: provisioning failed; embedding stale assets from ${DIST_DIR}")
+    else()
+        message(WARNING "UI: no assets available - building without an embedded UI. "
+                        "In a disconnected environment, download the pre-built UI "
+                        "from a llama.cpp release at "
+                        "https://github.com/ggml-org/llama.cpp/releases and "
+                        "extract to tools/ui/dist.")
+    endif()
+endif()
+
+emit_files("${DIST_DIR}")

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1833,13 +1833,6 @@ static bool needs_raw_logits(const llama_ubatch & ubatch, const std::map<llama_s
 }
 
 int llama_context::decode(const llama_batch & batch_inp) {
-    // PROFILING: count calls and measure timing
-    static std::atomic<int64_t> decode_call_count{0};
-    static std::atomic<int64_t> decode_total_us{0};
-    static thread_local int64_t local_count = 0;
-    const int64_t t0 = ggml_time_us();
-    const int64_t call_num = decode_call_count.fetch_add(1) + 1;
-
     // MTP hook batches carry both token (next-token id) and embd (h_nextn row),
     // so accept either present rather than requiring exactly one.
     GGML_ASSERT(batch_inp.token || batch_inp.embd);
@@ -2217,18 +2210,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     // wait for the computation to finish (automatically done when obtaining the model output)
     //synchronize();
-
-    // PROFILING: accumulate timing and log periodically
-    {
-        const int64_t elapsed = ggml_time_us() - t0;
-        decode_total_us.fetch_add(elapsed);
-        local_count++;
-        if (local_count % 10 == 1 || local_count <= 5 || batch_inp.n_tokens > 1) {
-            fprintf(stderr, "PROFILE decode #%lld n_tokens=%d elapsed=%lld us total_us=%lld\n",
-                    (long long)call_num, batch_inp.n_tokens, (long long)elapsed,
-                    (long long)decode_total_us.load());
-        }
-    }
 
     return 0;
 }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -54,7 +54,7 @@ static uint32_t server_n_outputs_max(const common_params & params) {
     const bool spec_mtp = std::find(params.speculative.types.begin(), params.speculative.types.end(),
                                     COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params.speculative.types.end()
                        || std::find(params.speculative.types.begin(), params.speculative.types.end(),
-                                    COMMON_SPECULATIVE_TYPE_MTP) != params.speculative.types.end();
+                                    COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params.speculative.types.end();
     if (spec_mtp) {
         return n_batch;
     }
@@ -826,7 +826,7 @@ private:
                                             COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end()
                                || std::find(params_base.speculative.types.begin(),
                                             params_base.speculative.types.end(),
-                                            COMMON_SPECULATIVE_TYPE_MTP) != params_base.speculative.types.end();
+                                            COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end();
             const bool has_draft = params_base.speculative.has_dft();
 
             if (has_draft || spec_mtp) {
@@ -905,7 +905,7 @@ private:
         if (std::find(params_base.speculative.types.begin(), params_base.speculative.types.end(),
                       COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end()
             || std::find(params_base.speculative.types.begin(), params_base.speculative.types.end(),
-                      COMMON_SPECULATIVE_TYPE_MTP) != params_base.speculative.types.end()) {
+                      COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end()) {
             string_parse_kv_override("llama.nomtp_trunk_only=bool:true", params_base.kv_overrides);
             if (params_base.kv_overrides.empty() || params_base.kv_overrides.back().key[0] != 0) {
                 params_base.kv_overrides.emplace_back();
@@ -965,7 +965,7 @@ private:
                                             COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end()
                                || std::find(params_base.speculative.types.begin(),
                                             params_base.speculative.types.end(),
-                                            COMMON_SPECULATIVE_TYPE_MTP) != params_base.speculative.types.end();
+                                            COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end();
 
             if (spec_mtp) {
                 cparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
@@ -983,7 +983,7 @@ private:
         } else if (std::find(params_base.speculative.types.begin(), params_base.speculative.types.end(),
                              COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end()
                || std::find(params_base.speculative.types.begin(), params_base.speculative.types.end(),
-                             COMMON_SPECULATIVE_TYPE_MTP) != params_base.speculative.types.end()) {
+                             COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end()) {
             char trunk_arch[64] = {0};
             llama_model_meta_val_str(model_tgt, "general.architecture", trunk_arch, sizeof(trunk_arch));
 


### PR DESCRIPTION
Rebased version of PR #34 on latest upstream/master (+61 commits).

Key changes:
- TQ3_4S dp4a dot-product ("/" interpolation) support for NVIDIA + best-of-N
- MTP speculative decoding runtime restore (KV cache slot clearing fix, fattn-vec CUDA fix)
- GGML-quants build fixes (Windows `_BitScanForward`, int64_t format specifiers)
- DQ3_4S set_rows tensor-type restore
- MMVQ prefill regression fix
- Server KV cache: prompt_load decoupled from prompt_save

Benchloop partial results on this branch:
- Gen tok/s: 54.23 (was 42.73, +27% from upstream improvements)
- Toolcall: 96.67% (14/15)
- Coding: 100% (12/12)

Closes #34