### PR TITLE
GX10 MTP linear sync speed path

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3665,6 +3665,54 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_P_SPLIT"));
     add_opt(common_arg(
+        {"--spec-mtp-tree-cost-aware"},
+        {"--no-spec-mtp-tree-cost-aware"},
+        "enable measured cost-aware MTP tree gating (default: disabled)",
+        [](common_params & params, bool value) {
+            params.speculative.draft.mtp_tree_cost_aware = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_COST_AWARE"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-cost-min-gain"}, "P",
+        string_format("minimum tree tok/s EMA gain over linear EMA (default: %.2f)", (double)params.speculative.draft.mtp_tree_cost_min_gain),
+        [](common_params & params, const std::string & value) {
+            params.speculative.draft.mtp_tree_cost_min_gain = std::stof(value);
+            if (params.speculative.draft.mtp_tree_cost_min_gain < 1.0f) {
+                throw std::invalid_argument("spec-mtp-tree-cost-min-gain must be >= 1");
+            }
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_COST_MIN_GAIN"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-cost-min-tps"}, "N",
+        string_format("minimum request tok/s for keeping tree enabled (default: %.2f, disabled)", (double)params.speculative.draft.mtp_tree_cost_min_tps),
+        [](common_params & params, const std::string & value) {
+            params.speculative.draft.mtp_tree_cost_min_tps = std::stof(value);
+            if (params.speculative.draft.mtp_tree_cost_min_tps < 0.0f) {
+                throw std::invalid_argument("spec-mtp-tree-cost-min-tps must be >= 0");
+            }
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_COST_MIN_TPS"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-cost-warmup"}, "N",
+        string_format("linear requests before first cost-aware tree probe (default: %d)", params.speculative.draft.mtp_tree_cost_warmup),
+        [](common_params & params, int value) {
+            if (value < 0 || value > 1024) {
+                throw std::invalid_argument("spec-mtp-tree-cost-warmup must be between 0 and 1024 inclusive");
+            }
+            params.speculative.draft.mtp_tree_cost_warmup = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_COST_WARMUP"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-cost-cooldown"}, "N",
+        string_format("linear requests after a losing cost-aware tree probe (default: %d)", params.speculative.draft.mtp_tree_cost_cooldown),
+        [](common_params & params, int value) {
+            if (value < 0 || value > 1024) {
+                throw std::invalid_argument("spec-mtp-tree-cost-cooldown must be between 0 and 1024 inclusive");
+            }
+            params.speculative.draft.mtp_tree_cost_cooldown = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_COST_COOLDOWN"));
+    add_opt(common_arg(
         {"--spec-draft-backend-sampling"},
         {"--no-spec-draft-backend-sampling"},
         string_format("offload draft sampling to the backend (default: %s)",

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3621,11 +3621,19 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     add_opt(common_arg(
         {"--spec-mtp-tree"},
         {"--no-spec-mtp-tree"},
-        "enable dynamic token-tree speculative mode for MTP (default: disabled)",
+        "enable draft-side dynamic token-tree scouting for MTP (default: disabled)",
         [](common_params & params, bool value) {
             params.speculative.draft.use_mtp_tree = value;
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-target-verify"},
+        {"--no-spec-mtp-tree-target-verify"},
+        "enable target-side MTP tree verification (diagnostic; default: disabled)",
+        [](common_params & params, bool value) {
+            params.speculative.draft.mtp_tree_target_verify = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_TARGET_VERIFY"));
     add_opt(common_arg(
         {"--spec-mtp-tree-nodes"}, "N",
         string_format("maximum number of nodes in MTP token-tree mode (default: %d)", params.speculative.draft.mtp_tree_nodes),

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2184,6 +2184,16 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_PARALLEL}));
     add_opt(common_arg(
+        {"--rs-seq"}, "N",
+        string_format("number of recurrent-state snapshots per seq for rollback (default: %d, 0 = no rollback) [EXPERIMENTAL]", params.n_rs_seq),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("error: invalid value for rs-seq\n");
+            }
+            params.n_rs_seq = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_RS_SEQ"));
+    add_opt(common_arg(
         {"-cb", "--cont-batching"},
         {"-nocb", "--no-cont-batching"},
         string_format("whether to enable continuous batching (a.k.a dynamic batching) (default: %s)", params.cont_batching ? "enabled" : "disabled"),

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3609,6 +3609,44 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_P_MIN"));
     add_opt(common_arg(
+        {"--spec-mtp-tree"},
+        {"--no-spec-mtp-tree"},
+        "enable dynamic token-tree speculative mode for MTP (default: disabled)",
+        [](common_params & params, bool value) {
+            params.speculative.draft.use_mtp_tree = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-nodes"}, "N",
+        string_format("maximum number of nodes in MTP token-tree mode (default: %d)", params.speculative.draft.mtp_tree_nodes),
+        [](common_params & params, int value) {
+            if (value < 1 || value > 1024) {
+                throw std::invalid_argument("spec-mtp-tree-nodes must be between 1 and 1024 inclusive");
+            }
+            params.speculative.draft.mtp_tree_nodes = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_NODES"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-depth"}, "D",
+        string_format("maximum token-tree depth for MTP tree mode (default: %d)", params.speculative.draft.mtp_tree_depth),
+        [](common_params & params, int value) {
+            if (value < 1 || value > 128) {
+                throw std::invalid_argument("spec-mtp-tree-depth must be between 1 and 128 inclusive");
+            }
+            params.speculative.draft.mtp_tree_depth = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_DEPTH"));
+    add_opt(common_arg(
+        {"--spec-mtp-tree-p-split"}, "P",
+        string_format("token-tree expansion minimum probability (default: %.2f)", (double)params.speculative.draft.mtp_tree_p_split),
+        [](common_params & params, const std::string & value) {
+            params.speculative.draft.mtp_tree_p_split = std::stof(value);
+            if (params.speculative.draft.mtp_tree_p_split < 0.0f || params.speculative.draft.mtp_tree_p_split > 1.0f) {
+                throw std::invalid_argument("spec-mtp-tree-p-split must be between 0 and 1");
+            }
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_TREE_P_SPLIT"));
+    add_opt(common_arg(
         {"--spec-draft-backend-sampling"},
         {"--no-spec-draft-backend-sampling"},
         string_format("offload draft sampling to the backend (default: %s)",

--- a/common/common.h
+++ b/common/common.h
@@ -307,6 +307,7 @@ struct common_params_speculative_draft {
     float p_min   = 0.0f; // minimum speculative decoding probability (greedy)
 
     bool use_mtp_tree = false; // enable experimental dynamic token-tree mode for MTP
+    bool mtp_tree_target_verify = false; // enable target-side MTP tree verification
     int32_t mtp_tree_nodes = 1; // maximum tree nodes to evaluate when tree mode is enabled
     int32_t mtp_tree_depth = 1; // maximum tree depth when tree mode is enabled
     float mtp_tree_p_split = 0.0f; // probability cutoff for tree expansion
@@ -371,7 +372,7 @@ struct common_params_speculative {
             return t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP;
         });
 
-        if (has_mtp && draft.use_mtp_tree) {
+        if (has_mtp && draft.use_mtp_tree && draft.mtp_tree_target_verify) {
             // Tree mode needs recurrent state snapshots for partial rollback
             return std::max(1, draft.mtp_tree_depth + 1);
         }

--- a/common/common.h
+++ b/common/common.h
@@ -371,6 +371,11 @@ struct common_params_speculative {
             return t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP;
         });
 
+        if (has_mtp && draft.use_mtp_tree) {
+            // Tree mode needs recurrent state snapshots for partial rollback
+            return std::max(1, draft.mtp_tree_depth + 1);
+        }
+
         if (has_mtp) {
             return 0u; // MTP path: match old preserved binary behavior (0 rs_seq)
         }
@@ -441,6 +446,7 @@ struct common_params {
     int32_t n_chunks              =    -1; // max number of chunks to process (-1 = unlimited)
     int32_t n_parallel            =     1; // number of parallel sequences to decode
     int32_t n_sequences           =     1; // number of sequences to decode
+    int32_t n_rs_seq              =     0; // number of recurrent-state snapshots per seq for rollback (0 = no rollback)
     int32_t n_outputs_max         =     0; // max outputs in a batch (0 = n_batch)
     int32_t grp_attn_n            =     1; // group-attention factor
     int32_t grp_attn_w            =   512; // group-attention width

--- a/common/common.h
+++ b/common/common.h
@@ -306,6 +306,11 @@ struct common_params_speculative_draft {
     float p_split = 0.1f; // speculative decoding split probability
     float p_min   = 0.0f; // minimum speculative decoding probability (greedy)
 
+    bool use_mtp_tree = false; // enable experimental dynamic token-tree mode for MTP
+    int32_t mtp_tree_nodes = 1; // maximum tree nodes to evaluate when tree mode is enabled
+    int32_t mtp_tree_depth = 1; // maximum tree depth when tree mode is enabled
+    float mtp_tree_p_split = 0.0f; // probability cutoff for tree expansion
+
     bool backend_sampling = true; // offload draft sampling to the backend (default: on)
 
     common_params_model mparams;

--- a/common/common.h
+++ b/common/common.h
@@ -311,6 +311,11 @@ struct common_params_speculative_draft {
     int32_t mtp_tree_nodes = 1; // maximum tree nodes to evaluate when tree mode is enabled
     int32_t mtp_tree_depth = 1; // maximum tree depth when tree mode is enabled
     float mtp_tree_p_split = 0.0f; // probability cutoff for tree expansion
+    bool mtp_tree_cost_aware = false; // enable measured cost-aware MTP tree gating
+    float mtp_tree_cost_min_gain = 1.05f; // required tree tok/s gain over linear EMA
+    float mtp_tree_cost_min_tps = 0.0f; // absolute minimum tree tok/s, disabled when <= 0
+    int32_t mtp_tree_cost_warmup = 3; // linear requests before first tree probe
+    int32_t mtp_tree_cost_cooldown = 8; // linear requests after a losing tree probe
 
     bool backend_sampling = true; // offload draft sampling to the backend (default: on)
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -546,10 +546,7 @@ struct llama_sampler * common_sampler_get(const struct common_sampler * gsmpl) {
     return gsmpl->chain;
 }
 
-llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first) {
-    llama_synchronize(ctx);
-
-    // start measuring sampling time after the llama_context synchronization in order to not measure any ongoing async operations
+static llama_token common_sampler_sample_impl(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first) {
     const auto tm = gsmpl->tm();
 
     llama_token id = LLAMA_TOKEN_NULL;
@@ -628,6 +625,17 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
     id = cur_p.data[cur_p.selected].id;
 
     return id;
+}
+
+llama_token common_sampler_sample_no_sync(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first) {
+    return common_sampler_sample_impl(gsmpl, ctx, idx, grammar_first);
+}
+
+llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first) {
+    llama_synchronize(ctx);
+
+    // start measuring sampling time after the llama_context synchronization in order to not measure any ongoing async operations
+    return common_sampler_sample_impl(gsmpl, ctx, idx, grammar_first);
 }
 
 std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sampler * gsmpl, struct llama_context * ctx, const std::vector<int> & idxs, const llama_tokens & draft, bool grammar_first) {

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -6,6 +6,7 @@
 #include "reasoning-budget.h"
 
 #include "ggml.h"
+#include "../src/llama-ext.h"
 #if __has_include(<nvtx3/nvToolsExt.h>)
 #    include <nvtx3/nvToolsExt.h>
 #elif __has_include(<nvToolsExt.h>)
@@ -136,9 +137,9 @@ struct common_sampler {
     }
 
     void set_logits(struct llama_context * ctx, int idx) {
-        const float *       sampled_probs  = llama_get_sampled_probs_ith     (ctx, idx);
-        const float *       sampled_logits = llama_get_sampled_logits_ith    (ctx, idx);
-        const llama_token * sampled_ids    = llama_get_sampled_candidates_ith(ctx, idx);
+        const float *       sampled_probs  = llama_get_sampled_probs_ith_no_sync     (ctx, idx);
+        const float *       sampled_logits = llama_get_sampled_logits_ith_no_sync    (ctx, idx);
+        const llama_token * sampled_ids    = llama_get_sampled_candidates_ith_no_sync(ctx, idx);
 
         const llama_model * model = llama_get_model(ctx);
         const llama_vocab * vocab = llama_model_get_vocab(model);
@@ -146,19 +147,19 @@ struct common_sampler {
         const int n_vocab = llama_vocab_n_tokens(vocab);
 
         if (sampled_probs) {
-            const uint32_t sampled_probs_count = llama_get_sampled_probs_count_ith(ctx, idx);
+            const uint32_t sampled_probs_count = llama_get_sampled_probs_count_ith_no_sync(ctx, idx);
             cur.resize(sampled_probs_count);
             for (uint32_t i = 0; i < sampled_probs_count; ++i) {
                 cur[i] = llama_token_data{sampled_ids[i], sampled_logits[i], sampled_probs[i]};
             }
         } else if (sampled_logits) {
-            const uint32_t sampled_logits_count = llama_get_sampled_logits_count_ith(ctx, idx);
+            const uint32_t sampled_logits_count = llama_get_sampled_logits_count_ith_no_sync(ctx, idx);
             cur.resize(sampled_logits_count);
             for (uint32_t i = 0; i < sampled_logits_count; i++) {
                 cur[i] = llama_token_data{sampled_ids[i], sampled_logits[i], 0.0f};
             }
         } else {
-            const auto * logits = llama_get_logits_ith(ctx, idx);
+            const auto * logits = llama_get_logits_ith_no_sync(ctx, idx);
             GGML_ASSERT(logits != nullptr);
             cur.resize(n_vocab);
             for (llama_token token_id = 0; token_id < n_vocab; token_id++) {
@@ -563,7 +564,7 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
     // Check if a backend sampler has already sampled a token in which case we
     // return that token id directly.
     {
-        id = llama_get_sampled_token_ith(ctx, idx);
+        id = llama_get_sampled_token_ith_no_sync(ctx, idx);
 
         if (id != LLAMA_TOKEN_NULL) {
             LOG_DBG("%s: Backend sampler selected token: '%d'. Will not run any CPU samplers\n", __func__, id);

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -6,6 +6,14 @@
 #include "reasoning-budget.h"
 
 #include "ggml.h"
+#if __has_include(<nvtx3/nvToolsExt.h>)
+#    include <nvtx3/nvToolsExt.h>
+#elif __has_include(<nvToolsExt.h>)
+#    include <nvToolsExt.h>
+#else
+static inline int nvtxRangePushA(const char *) { return 0; }
+static inline int nvtxRangePop() { return 0; }
+#endif
 
 #include <algorithm>
 #include <cctype>
@@ -470,7 +478,8 @@ void common_sampler_reset(struct common_sampler * gsmpl) {
 }
 
 struct common_sampler * common_sampler_clone(common_sampler * gsmpl) {
-    return new common_sampler {
+    nvtxRangePushA("sampler_clone");
+    struct common_sampler * result = new common_sampler {
         /* .params  = */ gsmpl->params,
         /* .grmr    = */ llama_sampler_clone(gsmpl->grmr),
         /* .rbudget = */ llama_sampler_clone(gsmpl->rbudget),
@@ -479,6 +488,8 @@ struct common_sampler * common_sampler_clone(common_sampler * gsmpl) {
         /* .cur     = */ gsmpl->cur,
         /* .cur_p   = */ gsmpl->cur_p,
     };
+    nvtxRangePop();
+    return result;
 }
 
 void common_perf_print(const struct llama_context * ctx, const struct common_sampler * gsmpl) {

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -63,6 +63,7 @@ struct llama_sampler * common_sampler_get(const struct common_sampler * gsmpl);
 // useful in cases where all the resulting candidates (not just the sampled one) must fit the grammar
 //
 llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first = false);
+llama_token common_sampler_sample_no_sync(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first = false);
 
 // generalized version of common_sampler_sample
 //

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -165,6 +165,8 @@ struct common_speculative_impl {
         return false;
     }
 
+    virtual void sync_draft_sampler(llama_seq_id /*seq_id*/, common_sampler * /*smpl*/) {}
+
     // true if this implementation requires the target context to extract post-norm embeddings
     virtual bool need_embd() const = 0;
 
@@ -369,6 +371,11 @@ struct common_speculative_impl_draft_simple : public common_speculative_impl {
                 dp.result->clear();
             }
         }
+    }
+
+    void sync_draft_sampler(llama_seq_id seq_id, common_sampler * smpl) override {
+        GGML_UNUSED(seq_id);
+        GGML_UNUSED(smpl);
     }
 
     void accept(llama_seq_id /*seq_id*/, uint16_t /*n_accepted*/, bool /*is_other*/) override {
@@ -1087,6 +1094,22 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         }
     }
 
+    void sync_draft_sampler(llama_seq_id seq_id, common_sampler * smpl) override {
+        GGML_ASSERT(seq_id >= 0 && seq_id < (llama_seq_id) n_seq);
+        if (smpl == nullptr) {
+            return;
+        }
+
+        if (!smpls[(size_t) seq_id]) {
+            return;
+        }
+
+        smpls[(size_t) seq_id].reset(common_sampler_clone(smpl));
+        if (!smpls[(size_t) seq_id]) {
+            LOG_ERR("%s: failed to clone target sampler for seq_id=%d\n", __func__, (int) seq_id);
+        }
+    }
+
     bool process(const llama_batch & batch_in) override {
         if (batch_in.n_tokens <= 0) {
             return true;
@@ -1273,7 +1296,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 if (params.use_mtp_tree && cur_p->size > 0) {
                     auto & plan = mtp_trees[seq_id];
                     if (is_new_draft) {
-                        LOG_INF("mtp_tree_build: initializing tree with root=%d n_past=%d\n", (int)dp.id_last, (int)dp.n_past);
+                        LOG_DBG("mtp_tree_build: initializing tree with root=%d n_past=%d\n", (int)dp.id_last, (int)dp.n_past);
                         plan.configure(
                             std::max(1, params.mtp_tree_nodes),
                             std::max(1, params.mtp_tree_depth),
@@ -1281,7 +1304,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                         plan.begin(dp.id_last, seq_id, dp.n_past);
                     } else {
                         if (plan.empty()) {
-                            LOG_INF("mtp_tree_build: re-initializing empty tree with root=%d n_past=%d\n", (int)dp.id_last, (int)dp.n_past);
+                            LOG_DBG("mtp_tree_build: re-initializing empty tree with root=%d n_past=%d\n", (int)dp.id_last, (int)dp.n_past);
                             plan.configure(
                                 std::max(1, params.mtp_tree_nodes),
                                 std::max(1, params.mtp_tree_depth),
@@ -1296,13 +1319,13 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                             const auto child = plan.append_child(plan.main_tail, depth, id, cur_p->data[0].p, seq_id, dp.n_past + (int32_t) i + 1);
                             if (child >= 0) {
                                 plan.main_tail = child;
-                                LOG_INF("mtp_tree_build: added main token=%d depth=%d parent=%d child=%d\n", (int)id, depth, (int)plan.main_tail, child);
+                                LOG_DBG("mtp_tree_build: added main token=%d depth=%d parent=%d child=%d\n", (int)id, depth, (int)plan.main_tail, child);
                             }
 
                             const int max_alt = std::min(4, (int)cur_p->size - 1);
                             const int32_t alt_parent = (child >= 0) ? child : plan.main_tail;
                             if (plan.try_add_alternatives(alt_parent, cur_p, max_alt, depth, seq_id, dp.n_past + (int32_t) i + 1)) {
-                                LOG_INF("mtp_tree_build: added %d alternatives at depth=%d\n", max_alt, depth);
+                                LOG_DBG("mtp_tree_build: added %d alternatives at depth=%d\n", max_alt, depth);
                             }
                     } else {
                         LOG_DBG("%s: seq_id=%d cannot extend mtp tree (depth=%d, nodes=%d)\n",
@@ -2143,6 +2166,19 @@ bool common_speculative_get_mtp_tree_plan(
     }
 
     return false;
+}
+
+void common_speculative_sync_draft_sampler(
+    common_speculative * spec,
+    llama_seq_id seq_id,
+    common_sampler * smpl_target) {
+    if (spec == nullptr) {
+        return;
+    }
+
+    for (auto & impl : spec->impls) {
+        impl->sync_draft_sampler(seq_id, smpl_target);
+    }
 }
 
 bool common_speculative_process(common_speculative * spec, const llama_batch & batch) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1001,6 +1001,13 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             LOG_INF("%s: - mtp_tree_nodes=%d, mtp_tree_depth=%d, mtp_tree_p_split=%.2f\n", __func__,
                     this->params.mtp_tree_nodes, this->params.mtp_tree_depth,
                     (double) this->params.mtp_tree_p_split);
+            if (this->params.mtp_tree_cost_aware) {
+                LOG_INF("%s: - mtp_tree_cost_aware=1, min_gain=%.2f, min_tps=%.2f, warmup=%d, cooldown=%d\n", __func__,
+                        (double) this->params.mtp_tree_cost_min_gain,
+                        (double) this->params.mtp_tree_cost_min_tps,
+                        this->params.mtp_tree_cost_warmup,
+                        this->params.mtp_tree_cost_cooldown);
+            }
         }
 
         const int32_t n_b = (int32_t) llama_n_batch(ctx_dft);
@@ -1384,7 +1391,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 auto & result = *dp.result;
                 const bool is_new_draft = result.empty();
                 const llama_pos next_pos = is_mem_shared ? dp.n_past : dp.n_past + i + 1;
-                const size_t selected_i = is_new_draft
+                const size_t selected_i = is_new_draft && dp.mtp_tree_enabled
                     ? scout_select_first(seq_id, next_pos, cur_p, smpl, h_row)
                     : 0;
 
@@ -1404,7 +1411,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 result.push_back(id);
 
-                if (params.use_mtp_tree && params.mtp_tree_target_verify && cur_p->size > 0) {
+                if (params.use_mtp_tree && params.mtp_tree_target_verify && dp.mtp_tree_enabled && cur_p->size > 0) {
                     nvtxRangePushA("mtp_tree:draft_build");
                     auto & plan = mtp_trees[seq_id];
                     if (is_new_draft) {
@@ -1446,6 +1453,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                                 (int) result.size(),
                                 (int) plan.plan.nodes.size());
                     }
+                    nvtxRangePop();
+                } else if (params.use_mtp_tree && params.mtp_tree_target_verify && !dp.mtp_tree_enabled) {
+                    mtp_trees[seq_id].clear();
                 }
 
                 if (params.n_max <= (int) result.size()) {
@@ -1463,7 +1473,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 }
                 std::memcpy(batch.embd + n_embd*(batch.n_tokens - 1), h_row, row_bytes);
             }
-            nvtxRangePop();
 
             if (batch.n_tokens == 0) {
                 break;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1307,7 +1307,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                     continue;
                 }
 
-                common_sampler_accept(smpl, id, true);
+                common_sampler_accept(smpl, id, false);
 
                 auto & dp = dparams.at(seq_id);
                 auto & result = *dp.result;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -9,6 +9,15 @@
 #include "ngram-mod.h"
 #include "sampling.h"
 
+#if __has_include(<nvtx3/nvToolsExt.h>)
+#    include <nvtx3/nvToolsExt.h>
+#elif __has_include(<nvToolsExt.h>)
+#    include <nvToolsExt.h>
+#else
+static inline int nvtxRangePushA(const char *) { return 0; }
+static inline int nvtxRangePop() { return 0; }
+#endif
+
 #include "../src/llama-ext.h" // staging API: llama_set_embeddings_nextn / llama_get_embeddings_nextn_ith (used by MTP)
 
 #include <algorithm>
@@ -321,10 +330,12 @@ struct common_speculative_impl_draft_simple : public common_speculative_impl {
                 }
 
                 // add drafted token for each sequence
-                const llama_token id = cur_p->data[0].id;
+                GGML_ASSERT(cur_p->selected >= 0);
+                const auto & selected = cur_p->data[cur_p->selected];
+                const llama_token id = selected.id;
 
                 // only collect very high-confidence draft tokens
-                if (cur_p->data[0].p < params.p_min) {
+                if (selected.p < params.p_min) {
                     drafting[seq_id] = false;
                     n_drafting--;
 
@@ -757,11 +768,13 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
                             common_token_to_piece(ctx_dft, cur_p->data[k].id).c_str());
                 }
 
-                const llama_token id = cur_p->data[0].id;
+                GGML_ASSERT(cur_p->selected >= 0);
+                const auto & selected = cur_p->data[cur_p->selected];
+                const llama_token id = selected.id;
 
                 // only collect very high-confidence draft tokens
                 // (configurable via --spec-draft-p-min, set to 0.0 to disable early-stop)
-                if (cur_p->data[0].p < params.p_min) {
+                if (selected.p < params.p_min) {
                     drafting[seq_id] = false;
                     n_drafting--;
 
@@ -883,6 +896,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             plan.max_nodes = std::max<size_t>(1, nodes_cap);
             plan.max_depth = std::max<size_t>(1, depth_cap);
             plan.p_split = split_threshold;
+            plan.nodes.reserve(plan.max_nodes);
         }
 
         bool can_add_node(int32_t parent, int32_t depth) const {
@@ -931,10 +945,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             if (!cur_p || cur_p->size <= 1 || max_alternatives <= 0) {
                 return false;
             }
-            if (!can_add_node(parent, depth)) {
-                return false;
-            }
 
+            nvtxRangePushA("mtp_tree:try_add_alt");
             int added = 0;
             for (size_t i = 1; i < cur_p->size && added < max_alternatives && plan.nodes.size() < plan.max_nodes; ++i) {
                 if (cur_p->data[i].p < plan.p_split) {
@@ -946,14 +958,18 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 }
                 ++added;
             }
+            nvtxRangePop();
             return added > 0;
         }
 
         void begin(llama_token root, llama_seq_id seq_id, int32_t batch_pos) {
+            nvtxRangePushA("mtp_tree:begin");
             clear();
+            plan.nodes.reserve(plan.max_nodes);
             const common_speculative_mtp_tree_node root_node = {root, -1, 0, 1.0f, 1.0f, seq_id, batch_pos};
             plan.nodes.push_back(root_node);
             main_tail = 0;
+            nvtxRangePop();
         }
     };
 
@@ -1095,12 +1111,15 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     }
 
     void sync_draft_sampler(llama_seq_id seq_id, common_sampler * smpl) override {
+        nvtxRangePushA("sync_draft_sampler");
         GGML_ASSERT(seq_id >= 0 && seq_id < (llama_seq_id) n_seq);
         if (smpl == nullptr) {
+            nvtxRangePop();
             return;
         }
 
         if (!smpls[(size_t) seq_id]) {
+            nvtxRangePop();
             return;
         }
 
@@ -1108,6 +1127,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         if (!smpls[(size_t) seq_id]) {
             LOG_ERR("%s: failed to clone target sampler for seq_id=%d\n", __func__, (int) seq_id);
         }
+        nvtxRangePop();
     }
 
     bool process(const llama_batch & batch_in) override {
@@ -1275,10 +1295,12 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 }
 
                 // add drafted token for each sequence
-                const llama_token id = cur_p->data[0].id;
+                GGML_ASSERT(cur_p->selected >= 0);
+                const auto & selected = cur_p->data[cur_p->selected];
+                const llama_token id = selected.id;
 
                 // only collect very high-confidence draft tokens
-                if (cur_p->data[0].p < params.p_min) {
+                if (selected.p < params.p_min) {
                     drafting[seq_id] = false;
                     n_drafting--;
 
@@ -1294,6 +1316,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 result.push_back(id);
 
                 if (params.use_mtp_tree && cur_p->size > 0) {
+                    nvtxRangePushA("mtp_tree:draft_build");
                     auto & plan = mtp_trees[seq_id];
                     if (is_new_draft) {
                         LOG_DBG("mtp_tree_build: initializing tree with root=%d n_past=%d\n", (int)dp.id_last, (int)dp.n_past);
@@ -1316,7 +1339,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                     const bool can_extend = result.size() <= plan.plan.max_depth;
                         if (can_extend) {
                             const int32_t depth = (int32_t) result.size();
-                            const auto child = plan.append_child(plan.main_tail, depth, id, cur_p->data[0].p, seq_id, dp.n_past + (int32_t) i + 1);
+                            const auto child = plan.append_child(plan.main_tail, depth, id, selected.p, seq_id, dp.n_past + (int32_t) i + 1);
                             if (child >= 0) {
                                 plan.main_tail = child;
                                 LOG_DBG("mtp_tree_build: added main token=%d depth=%d parent=%d child=%d\n", (int)id, depth, (int)plan.main_tail, child);
@@ -1351,6 +1374,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 }
                 std::memcpy(batch.embd + n_embd*(batch.n_tokens - 1), h_row, row_bytes);
             }
+            nvtxRangePop();
 
             if (batch.n_tokens == 0) {
                 break;
@@ -2155,16 +2179,20 @@ bool common_speculative_get_mtp_tree_plan(
         const common_speculative * spec,
         llama_seq_id seq_id,
         common_speculative_mtp_tree_plan & plan) {
+    nvtxRangePushA("get_mtp_tree_plan");
     if (spec == nullptr) {
+        nvtxRangePop();
         return false;
     }
 
     for (const auto & impl : spec->impls) {
         if (impl->get_mtp_tree_plan(seq_id, plan)) {
+            nvtxRangePop();
             return true;
         }
     }
 
+    nvtxRangePop();
     return false;
 }
 
@@ -2172,13 +2200,16 @@ void common_speculative_sync_draft_sampler(
     common_speculative * spec,
     llama_seq_id seq_id,
     common_sampler * smpl_target) {
+    nvtxRangePushA("spec_sync_draft_sampler");
     if (spec == nullptr) {
+        nvtxRangePop();
         return;
     }
 
     for (auto & impl : spec->impls) {
         impl->sync_draft_sampler(seq_id, smpl_target);
     }
+    nvtxRangePop();
 }
 
 bool common_speculative_process(common_speculative * spec, const llama_batch & batch) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1339,15 +1339,15 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                     const bool can_extend = result.size() <= plan.plan.max_depth;
                         if (can_extend) {
                             const int32_t depth = (int32_t) result.size();
-                            const auto child = plan.append_child(plan.main_tail, depth, id, selected.p, seq_id, dp.n_past + (int32_t) i + 1);
+                            const int32_t parent = plan.main_tail;
+                            const auto child = plan.append_child(parent, depth, id, selected.p, seq_id, dp.n_past + (int32_t) i + 1);
                             if (child >= 0) {
                                 plan.main_tail = child;
-                                LOG_DBG("mtp_tree_build: added main token=%d depth=%d parent=%d child=%d\n", (int)id, depth, (int)plan.main_tail, child);
+                                LOG_DBG("mtp_tree_build: added main token=%d depth=%d parent=%d child=%d\n", (int)id, depth, (int)parent, child);
                             }
 
                             const int max_alt = std::min(4, (int)cur_p->size - 1);
-                            const int32_t alt_parent = (child >= 0) ? child : plan.main_tail;
-                            if (plan.try_add_alternatives(alt_parent, cur_p, max_alt, depth, seq_id, dp.n_past + (int32_t) i + 1)) {
+                            if (plan.try_add_alternatives(parent, cur_p, max_alt, depth, seq_id, dp.n_past + (int32_t) i + 1)) {
                                 LOG_DBG("mtp_tree_build: added %d alternatives at depth=%d\n", max_alt, depth);
                             }
                     } else {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1273,6 +1273,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 if (params.use_mtp_tree && cur_p->size > 0) {
                     auto & plan = mtp_trees[seq_id];
                     if (is_new_draft) {
+                        LOG_INF("mtp_tree_build: initializing tree with root=%d n_past=%d\n", (int)dp.id_last, (int)dp.n_past);
                         plan.configure(
                             std::max(1, params.mtp_tree_nodes),
                             std::max(1, params.mtp_tree_depth),
@@ -1280,6 +1281,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                         plan.begin(dp.id_last, seq_id, dp.n_past);
                     } else {
                         if (plan.empty()) {
+                            LOG_INF("mtp_tree_build: re-initializing empty tree with root=%d n_past=%d\n", (int)dp.id_last, (int)dp.n_past);
                             plan.configure(
                                 std::max(1, params.mtp_tree_nodes),
                                 std::max(1, params.mtp_tree_depth),
@@ -1294,17 +1296,13 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                             const auto child = plan.append_child(plan.main_tail, depth, id, cur_p->data[0].p, seq_id, dp.n_past + (int32_t) i + 1);
                             if (child >= 0) {
                                 plan.main_tail = child;
+                                LOG_INF("mtp_tree_build: added main token=%d depth=%d parent=%d child=%d\n", (int)id, depth, (int)plan.main_tail, child);
                             }
 
                             const int max_alt = std::min(4, (int)cur_p->size - 1);
                             const int32_t alt_parent = (child >= 0) ? child : plan.main_tail;
                             if (plan.try_add_alternatives(alt_parent, cur_p, max_alt, depth, seq_id, dp.n_past + (int32_t) i + 1)) {
-                                LOG_DBG("%s: seq_id=%d tree depth=%d nodes=%d add root branches=%d\n",
-                                        __func__,
-                                        (int) seq_id,
-                                        (int) (plan.plan.nodes.empty() ? 0 : plan.plan.nodes.back().depth),
-                                        (int) max_alt,
-                                        max_alt);
+                                LOG_INF("mtp_tree_build: added %d alternatives at depth=%d\n", max_alt, depth);
                             }
                     } else {
                         LOG_DBG("%s: seq_id=%d cannot extend mtp tree (depth=%d, nodes=%d)\n",

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -159,6 +159,12 @@ struct common_speculative_impl {
 
     virtual void accept(llama_seq_id seq_id, uint16_t n_accepted, bool is_other) = 0;
 
+    virtual bool get_mtp_tree_plan(llama_seq_id seq_id, common_speculative_mtp_tree_plan & plan) const {
+        GGML_UNUSED(seq_id);
+        GGML_UNUSED(plan);
+        return false;
+    }
+
     // true if this implementation requires the target context to extract post-norm embeddings
     virtual bool need_embd() const = 0;
 
@@ -853,6 +859,99 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     // pre-advancement before process() mirrored the verify batch.
     std::vector<uint16_t> last_n_drafted;
 
+    struct mtp_tree_plan {
+        common_speculative_mtp_tree_plan plan;
+        int32_t main_tail = -1;
+
+        void clear() {
+            plan.nodes.clear();
+            main_tail = -1;
+        }
+
+        bool empty() const {
+            return plan.nodes.empty();
+        }
+
+        void configure(size_t nodes_cap, size_t depth_cap, float split_threshold) {
+            plan.max_nodes = std::max<size_t>(1, nodes_cap);
+            plan.max_depth = std::max<size_t>(1, depth_cap);
+            plan.p_split = split_threshold;
+        }
+
+        bool can_add_node(int32_t parent, int32_t depth) const {
+            if (plan.nodes.empty()) {
+                return false;
+            }
+            if (parent < 0 || parent >= (int32_t) plan.nodes.size()) {
+                return false;
+            }
+            if (plan.nodes.size() >= plan.max_nodes) {
+                return false;
+            }
+            if (depth > (int32_t) plan.max_depth) {
+                return false;
+            }
+            return true;
+        }
+
+        int32_t append_child(int32_t parent, int32_t depth, llama_token token, float prob, llama_seq_id seq_id, int32_t batch_pos) {
+            if (!can_add_node(parent, depth)) {
+                return -1;
+            }
+
+            const float parent_cum = plan.nodes[parent].cum_prob;
+            const common_speculative_mtp_tree_node node = {
+                token,
+                parent,
+                depth,
+                prob,
+                parent_cum * prob,
+                seq_id,
+                batch_pos
+            };
+            plan.nodes.push_back(node);
+            return (int32_t) plan.nodes.size() - 1;
+        }
+
+        bool try_add_alternatives(
+                int32_t parent,
+                const llama_token_data_array * cur_p,
+                int max_alternatives,
+                int32_t depth,
+                llama_seq_id seq_id,
+                int32_t batch_pos
+        ) {
+            if (!cur_p || cur_p->size <= 1 || max_alternatives <= 0) {
+                return false;
+            }
+            if (!can_add_node(parent, depth)) {
+                return false;
+            }
+
+            int added = 0;
+            for (size_t i = 1; i < cur_p->size && added < max_alternatives && plan.nodes.size() < plan.max_nodes; ++i) {
+                if (cur_p->data[i].p < plan.p_split) {
+                    break;
+                }
+                const auto child = append_child(parent, depth, cur_p->data[i].id, cur_p->data[i].p, seq_id, batch_pos);
+                if (child < 0) {
+                    break;
+                }
+                ++added;
+            }
+            return added > 0;
+        }
+
+        void begin(llama_token root, llama_seq_id seq_id, int32_t batch_pos) {
+            clear();
+            const common_speculative_mtp_tree_node root_node = {root, -1, 0, 1.0f, 1.0f, seq_id, batch_pos};
+            plan.nodes.push_back(root_node);
+            main_tail = 0;
+        }
+    };
+
+    std::vector<mtp_tree_plan> mtp_trees;
+
     common_speculative_impl_draft_mtp(const common_params_speculative & params, uint32_t n_seq)
         : common_speculative_impl(COMMON_SPECULATIVE_TYPE_DRAFT_MTP, n_seq)
         , params(params.draft)
@@ -874,6 +973,12 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 ctx_tgt ? "yes" : "no",
                 ctx_dft ? "yes" : "no",
                 common_speculative_get_devices_str(this->params.devices).c_str());
+        if (this->params.use_mtp_tree) {
+            LOG_INF("%s: MTP tree mode enabled\n", __func__);
+            LOG_INF("%s: - mtp_tree_nodes=%d, mtp_tree_depth=%d, mtp_tree_p_split=%.2f\n", __func__,
+                    this->params.mtp_tree_nodes, this->params.mtp_tree_depth,
+                    (double) this->params.mtp_tree_p_split);
+        }
 
         const int32_t n_b = (int32_t) llama_n_batch(ctx_dft);
         batch = llama_batch_init(/*n_tokens=*/ n_b, /*embd=*/ n_embd, /*n_seq_max=*/ 1);
@@ -924,6 +1029,10 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         verify_h_rows.assign(n_seq, 0);
 
         last_n_drafted.assign(n_seq, 0);
+        mtp_trees.assign(n_seq, {});
+        for (auto & plan : mtp_trees) {
+            plan.configure(std::max(1, this->params.mtp_tree_nodes), std::max(1, this->params.mtp_tree_depth), this->params.mtp_tree_p_split);
+        }
     }
 
     ~common_speculative_impl_draft_mtp() override {
@@ -953,6 +1062,13 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         verify_pos_first[seq_id] = -1;
         verify_h_rows[seq_id] = 0;
         last_n_drafted[seq_id] = 0;
+        if (params.use_mtp_tree) {
+            mtp_trees[seq_id].clear();
+            mtp_trees[seq_id].configure(
+                std::max(1, params.mtp_tree_nodes),
+                std::max(1, params.mtp_tree_depth),
+                params.mtp_tree_p_split);
+        }
 
         const int32_t N = (int32_t) prompt.size();
         if (N <= 0) {
@@ -1150,8 +1266,54 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 auto & dp = dparams.at(seq_id);
                 auto & result = *dp.result;
+                        const bool is_new_draft = result.empty();
 
                 result.push_back(id);
+
+                if (params.use_mtp_tree && cur_p->size > 0) {
+                    auto & plan = mtp_trees[seq_id];
+                    if (is_new_draft) {
+                        plan.configure(
+                            std::max(1, params.mtp_tree_nodes),
+                            std::max(1, params.mtp_tree_depth),
+                            params.mtp_tree_p_split);
+                        plan.begin(dp.id_last, seq_id, dp.n_past);
+                    } else {
+                        if (plan.empty()) {
+                            plan.configure(
+                                std::max(1, params.mtp_tree_nodes),
+                                std::max(1, params.mtp_tree_depth),
+                                params.mtp_tree_p_split);
+                            plan.begin(dp.id_last, seq_id, dp.n_past);
+                        }
+                    }
+
+                    const bool can_extend = result.size() <= plan.plan.max_depth;
+                        if (can_extend) {
+                            const int32_t depth = (int32_t) result.size();
+                            const auto child = plan.append_child(plan.main_tail, depth, id, cur_p->data[0].p, seq_id, dp.n_past + (int32_t) i + 1);
+                            if (child >= 0) {
+                                plan.main_tail = child;
+                            }
+
+                            const int max_alt = std::min(4, (int)cur_p->size - 1);
+                            const int32_t alt_parent = (child >= 0) ? child : plan.main_tail;
+                            if (plan.try_add_alternatives(alt_parent, cur_p, max_alt, depth, seq_id, dp.n_past + (int32_t) i + 1)) {
+                                LOG_DBG("%s: seq_id=%d tree depth=%d nodes=%d add root branches=%d\n",
+                                        __func__,
+                                        (int) seq_id,
+                                        (int) (plan.plan.nodes.empty() ? 0 : plan.plan.nodes.back().depth),
+                                        (int) max_alt,
+                                        max_alt);
+                            }
+                    } else {
+                        LOG_DBG("%s: seq_id=%d cannot extend mtp tree (depth=%d, nodes=%d)\n",
+                                __func__,
+                                (int) seq_id,
+                                (int) result.size(),
+                                (int) plan.plan.nodes.size());
+                    }
+                }
 
                 if (params.n_max <= (int) result.size()) {
                     drafting[seq_id] = false;
@@ -1211,6 +1373,15 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
         std::memcpy(pending_h[seq_id].data(), verify_h[seq_id].data() + (size_t) i_h * n_embd, row_bytes);
         pending_pos[seq_id] = verify_pos_first[seq_id] + i_h;
+    }
+
+    bool get_mtp_tree_plan(llama_seq_id seq_id, common_speculative_mtp_tree_plan & plan) const override {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq || !params.use_mtp_tree) {
+            return false;
+        }
+
+        plan = mtp_trees[seq_id].plan;
+        return !plan.nodes.empty();
     }
 
     bool need_embd() const override {
@@ -1957,6 +2128,23 @@ void common_speculative_begin(common_speculative * spec, llama_seq_id seq_id, co
         impl->begin(seq_id, prompt);
         impl->n_call_begin++;
     }
+}
+
+bool common_speculative_get_mtp_tree_plan(
+        const common_speculative * spec,
+        llama_seq_id seq_id,
+        common_speculative_mtp_tree_plan & plan) {
+    if (spec == nullptr) {
+        return false;
+    }
+
+    for (const auto & impl : spec->impls) {
+        if (impl->get_mtp_tree_plan(seq_id, plan)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool common_speculative_process(common_speculative * spec, const llama_batch & batch) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1295,8 +1295,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 }
 
                 // add drafted token for each sequence
-                GGML_ASSERT(cur_p->selected >= 0);
-                const auto & selected = cur_p->data[cur_p->selected];
+                const auto & selected = cur_p->data[0];
                 const llama_token id = selected.id;
 
                 // only collect very high-confidence draft tokens

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1375,7 +1375,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 auto * smpl = smpls[seq_id].get();
 
-                common_sampler_sample(smpl, ctx_dft, i_batch, true);
+                common_sampler_sample_no_sync(smpl, ctx_dft, i_batch, true);
                 h_row = llama_get_embeddings_nextn_ith_no_sync(ctx_dft, i_batch);
                 ++i_batch;
 
@@ -1478,12 +1478,14 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 break;
             }
 
-            // evaluate the drafted tokens on the draft model
+            // evaluate the drafted tokens on the draft model, then pay one sync
+            // boundary for the whole round before reading sampled outputs.
             ret = llama_decode(ctx_dft, batch);
             if (ret != 0) {
                 LOG_WRN("%s: llama_decode[%d] returned %d\n", __func__, i, ret);
                 break;
             }
+            llama_synchronize(ctx_dft);
 
             ++i;
         }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -277,7 +277,6 @@ struct common_speculative_impl_draft_simple : public common_speculative_impl {
 
     void draft(common_speculative_draft_params_vec & dparams) override {
         auto & ctx_dft = params.ctx_dft;
-
         common_batch_clear(batch);
 
         // keep track of which sequences are still drafting
@@ -1190,6 +1189,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             }
             return 0;
         }
+        llama_synchronize(ctx_dft);
 
         size_t best = 0;
         float best_score = -1.0f;
@@ -1201,9 +1201,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
             const llama_token first = cur_p->data[i].id;
             common_sampler_accept(smpl_path.get(), first, false);
-            common_sampler_sample(smpl_path.get(), ctx_dft, (int) i, true);
-            const auto * next_p = common_sampler_get_candidates(smpl_path.get(), true);
-            const float next_score = next_p && next_p->size > 0 ? next_p->data[0].p : 0.0f;
+            common_sampler_sample_no_sync(smpl_path.get(), ctx_dft, (int) i, true);
+            const auto * next_p = common_sampler_get_candidates(smpl_path.get(), false);
+            const float next_score = next_p && next_p->selected >= 0 ? next_p->data[next_p->selected].p : 0.0f;
             const float score = cur_p->data[i].p * next_score;
             if (score > best_score) {
                 best_score = score;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1375,7 +1375,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 auto * smpl = smpls[seq_id].get();
 
-                common_sampler_sample_no_sync(smpl, ctx_dft, i_batch, true);
+                common_sampler_sample(smpl, ctx_dft, i_batch, true);
                 h_row = llama_get_embeddings_nextn_ith_no_sync(ctx_dft, i_batch);
                 ++i_batch;
 
@@ -1478,14 +1478,12 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 break;
             }
 
-            // evaluate the drafted tokens on the draft model, then pay one sync
-            // boundary for the whole round before reading sampled outputs.
+            // evaluate the drafted tokens on the draft model
             ret = llama_decode(ctx_dft, batch);
             if (ret != 0) {
                 LOG_WRN("%s: llama_decode[%d] returned %d\n", __func__, i, ret);
                 break;
             }
-            llama_synchronize(ctx_dft);
 
             ++i;
         }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1130,6 +1130,92 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         nvtxRangePop();
     }
 
+    size_t scout_select_first(
+            llama_seq_id seq_id,
+            llama_pos pos,
+            const llama_token_data_array * cur_p,
+            common_sampler * smpl,
+            const float * h_row) {
+        if (!params.use_mtp_tree || params.mtp_tree_target_verify || cur_p == nullptr || smpl == nullptr || h_row == nullptr) {
+            return 0;
+        }
+        if (cur_p->size <= 1 || n_seq <= 1) {
+            return 0;
+        }
+
+        const int32_t n_eval = std::min<int32_t>({
+            (int32_t) cur_p->size,
+            std::max<int32_t>(1, params.mtp_tree_nodes),
+            (int32_t) n_seq - 1,
+            4,
+        });
+        if (n_eval <= 1) {
+            return 0;
+        }
+
+        auto * ctx_dft = params.ctx_dft;
+        const size_t row_bytes = (size_t) n_embd * sizeof(float);
+        std::vector<llama_seq_id> seqs;
+        seqs.reserve(n_eval);
+
+        common_batch_clear(batch);
+        for (llama_seq_id cand_seq = 0; cand_seq < (llama_seq_id) n_seq && (int32_t) seqs.size() < n_eval; ++cand_seq) {
+            if (cand_seq == seq_id) {
+                continue;
+            }
+
+            common_context_seq_rm(ctx_dft, cand_seq, -1, -1);
+            common_context_seq_cp(ctx_dft, seq_id, cand_seq, 0, -1);
+            common_batch_add(batch, cur_p->data[seqs.size()].id, pos, { cand_seq }, true);
+            std::memcpy(batch.embd + (size_t) n_embd * (batch.n_tokens - 1), h_row, row_bytes);
+            seqs.push_back(cand_seq);
+        }
+
+        if (seqs.empty()) {
+            return 0;
+        }
+
+        const int ret = llama_decode(ctx_dft, batch);
+        if (ret != 0) {
+            LOG_DBG("%s: scout decode failed rc=%d\n", __func__, ret);
+            for (llama_seq_id cand_seq : seqs) {
+                common_context_seq_rm(ctx_dft, cand_seq, -1, -1);
+            }
+            return 0;
+        }
+
+        size_t best = 0;
+        float best_score = -1.0f;
+        for (size_t i = 0; i < seqs.size(); ++i) {
+            common_sampler_ptr smpl_path(common_sampler_clone(smpl));
+            if (!smpl_path) {
+                continue;
+            }
+
+            const llama_token first = cur_p->data[i].id;
+            common_sampler_accept(smpl_path.get(), first, false);
+            common_sampler_sample(smpl_path.get(), ctx_dft, (int) i, true);
+            const auto * next_p = common_sampler_get_candidates(smpl_path.get(), true);
+            const float next_score = next_p && next_p->size > 0 ? next_p->data[0].p : 0.0f;
+            const float score = cur_p->data[i].p * next_score;
+            if (score > best_score) {
+                best_score = score;
+                best = i;
+            }
+        }
+
+        for (llama_seq_id cand_seq : seqs) {
+            common_context_seq_rm(ctx_dft, cand_seq, -1, -1);
+        }
+
+        if (best != 0) {
+            LOG_DBG("%s: selected candidate %zu over greedy (score=%.6f, greedy=%.6f)\n",
+                    __func__, best, (double) best_score, (double) cur_p->data[0].p);
+        }
+
+        return best;
+    }
+
     bool process(const llama_batch & batch_in) override {
         if (batch_in.n_tokens <= 0) {
             return true;
@@ -1294,8 +1380,16 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                             common_token_to_piece(ctx_dft, cur_p->data[k].id).c_str());
                 }
 
+                auto & dp = dparams.at(seq_id);
+                auto & result = *dp.result;
+                const bool is_new_draft = result.empty();
+                const llama_pos next_pos = is_mem_shared ? dp.n_past : dp.n_past + i + 1;
+                const size_t selected_i = is_new_draft
+                    ? scout_select_first(seq_id, next_pos, cur_p, smpl, h_row)
+                    : 0;
+
                 // add drafted token for each sequence
-                const auto & selected = cur_p->data[0];
+                const auto & selected = cur_p->data[selected_i];
                 const llama_token id = selected.id;
 
                 // only collect very high-confidence draft tokens
@@ -1308,13 +1402,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 common_sampler_accept(smpl, id, false);
 
-                auto & dp = dparams.at(seq_id);
-                auto & result = *dp.result;
-                        const bool is_new_draft = result.empty();
-
                 result.push_back(id);
 
-                if (params.use_mtp_tree && cur_p->size > 0) {
+                if (params.use_mtp_tree && params.mtp_tree_target_verify && cur_p->size > 0) {
                     nvtxRangePushA("mtp_tree:draft_build");
                     auto & plan = mtp_trees[seq_id];
                     if (is_new_draft) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1376,7 +1376,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 auto * smpl = smpls[seq_id].get();
 
                 common_sampler_sample(smpl, ctx_dft, i_batch, true);
-                h_row = llama_get_embeddings_nextn_ith(ctx_dft, i_batch);
+                h_row = llama_get_embeddings_nextn_ith_no_sync(ctx_dft, i_batch);
                 ++i_batch;
 
                 const auto * cur_p = common_sampler_get_candidates(smpl, true);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -3,6 +3,25 @@
 #include "llama.h"
 #include "common.h"
 
+#include <vector>
+
+struct common_speculative_mtp_tree_node {
+    llama_token token = 0;
+    int32_t parent = -1;
+    int32_t depth = 0;
+    float prob = 0.0f;
+    float cum_prob = 0.0f;
+    llama_seq_id seq_id = -1;
+    int32_t batch_pos = -1;
+};
+
+struct common_speculative_mtp_tree_plan {
+    std::vector<common_speculative_mtp_tree_node> nodes;
+    size_t max_nodes = 1;
+    size_t max_depth = 1;
+    float p_split = 0.0f;
+};
+
 struct common_speculative;
 
 // comma separated list the provided types
@@ -67,6 +86,11 @@ void common_speculative_draft(common_speculative * spec);
 
 // informs the speculative context that n_accepted tokens were accepted by the target model
 void common_speculative_accept(common_speculative * spec, llama_seq_id, uint16_t n_accepted);
+
+bool common_speculative_get_mtp_tree_plan(
+    const common_speculative * spec,
+    llama_seq_id seq_id,
+    common_speculative_mtp_tree_plan & plan);
 
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -23,6 +23,7 @@ struct common_speculative_mtp_tree_plan {
 };
 
 struct common_speculative;
+struct common_sampler;
 
 // comma separated list the provided types
 std::string common_speculative_type_name_str(const std::vector<enum common_speculative_type> & types);
@@ -86,6 +87,9 @@ void common_speculative_draft(common_speculative * spec);
 
 // informs the speculative context that n_accepted tokens were accepted by the target model
 void common_speculative_accept(common_speculative * spec, llama_seq_id, uint16_t n_accepted);
+
+// synchronize the draft sampler state for a single sequence with an existing sampler
+void common_speculative_sync_draft_sampler(common_speculative * spec, llama_seq_id seq_id, common_sampler * smpl_target);
 
 bool common_speculative_get_mtp_tree_plan(
     const common_speculative * spec,

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -66,6 +66,8 @@ struct common_speculative_draft_params {
 
     // the generated draft from the last _draft() call
     llama_tokens * result;
+
+    bool mtp_tree_enabled = true;
 };
 
 common_speculative_draft_params & common_speculative_get_draft_params(common_speculative * spec, llama_seq_id seq_id);

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -406,6 +406,16 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     // For small batch sizes the vector kernel may be preferable over the kernels optimized for large batch sizes:
     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && K->ne[1] % FATTN_KQ_STRIDE == 0;
 
+    const bool asymm_tq3_v = (K->type == GGML_TYPE_Q8_0 || K->type == GGML_TYPE_Q4_0) &&
+                              V->type == GGML_TYPE_TQ3_0;
+
+    // GB10/Blackwell currently faults in the MMA and tile flash-attention
+    // paths for asymmetric K/V cache types (q8_0 or q4_0 K with tq3_0 V).
+    // Route those cases to the vector kernel, which has native tq3_0 support.
+    if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_BLACKWELL && asymm_tq3_v) {
+        return BEST_FATTN_KERNEL_VEC;
+    }
+
     // If Turing tensor cores are available, use them:
     if (turing_mma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 72) {
         if (can_use_vector_kernel) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3994,6 +3994,38 @@ float * llama_get_embeddings_layer_inp(llama_context * ctx, uint32_t lid) {
     return ctx->get_embeddings_layer_inp(lid);
 }
 
+llama_token llama_get_sampled_token_ith_no_sync(llama_context * ctx, int32_t i) {
+    return ctx->get_sampled_token_ith(i);
+}
+
+float * llama_get_sampled_probs_ith_no_sync(llama_context * ctx, int32_t i) {
+    return ctx->get_sampled_probs_ith(i);
+}
+
+uint32_t llama_get_sampled_probs_count_ith_no_sync(llama_context * ctx, int32_t i) {
+    return static_cast<uint32_t>(ctx->get_sampled_probs_count(i));
+}
+
+float * llama_get_sampled_logits_ith_no_sync(llama_context * ctx, int32_t i) {
+    return ctx->get_sampled_logits_ith(i);
+}
+
+uint32_t llama_get_sampled_logits_count_ith_no_sync(llama_context * ctx, int32_t i) {
+    return static_cast<uint32_t>(ctx->get_sampled_logits_count(i));
+}
+
+llama_token * llama_get_sampled_candidates_ith_no_sync(llama_context * ctx, int32_t i) {
+    return const_cast<llama_token *>(ctx->get_sampled_candidates_ith(i));
+}
+
+uint32_t llama_get_sampled_candidates_count_ith_no_sync(llama_context * ctx, int32_t i) {
+    return static_cast<uint32_t>(ctx->get_sampled_candidates_count(i));
+}
+
+float * llama_get_logits_ith_no_sync(llama_context * ctx, int32_t i) {
+    return ctx->get_logits_ith(i);
+}
+
 bool llama_set_sampler(llama_context * ctx, llama_seq_id seq_id, llama_sampler * smpl) {
     return ctx->set_sampler(seq_id, smpl);
 }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3988,6 +3988,10 @@ float * llama_get_embeddings_nextn_ith(llama_context * ctx, int32_t i) {
     return ctx->get_embeddings_nextn_ith(i);
 }
 
+float * llama_get_embeddings_nextn_ith_no_sync(llama_context * ctx, int32_t i) {
+    return ctx->get_embeddings_nextn_ith(i);
+}
+
 float * llama_get_embeddings_layer_inp(llama_context * ctx, uint32_t lid) {
     ctx->synchronize();
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -987,6 +987,21 @@ llama_token llama_context::get_sampled_token_ith(int32_t idx) {
     }
 }
 
+llama_token llama_context::get_sampled_token_ith_no_sync(int32_t idx) {
+    if (!sampling.sampled.has_data()) {
+        return LLAMA_TOKEN_NULL;
+    }
+
+    try {
+        const int64_t row = output_resolve_row(idx);
+        GGML_ASSERT(row < (int64_t) sampling.sampled.size);
+        return sampling.sampled.data[row];
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: invalid backend sampled token id %d, reason: %s\n", __func__, idx, err.what());
+        return LLAMA_TOKEN_NULL;
+    }
+}
+
 float * llama_context::get_sampled_probs_ith(int32_t idx) {
     output_reorder();
 
@@ -1003,6 +1018,40 @@ float * llama_context::get_sampled_probs_ith(int32_t idx) {
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: invalid backend sampled probs id %d, reason: %s\n", __func__, idx, err.what());
         return nullptr;
+    }
+}
+
+float * llama_context::get_sampled_probs_ith_no_sync(int32_t idx) {
+    if (!sampling.probs.has_data()) {
+        return nullptr;
+    }
+
+    try {
+        const int64_t row = output_resolve_row(idx);
+        if ((size_t) row >= sampling.probs_count.size() || sampling.probs_count[row] == 0) {
+            return nullptr;
+        }
+        return sampling.probs.data + row*model.vocab.n_tokens();
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: invalid backend sampled probs id %d, reason: %s\n", __func__, idx, err.what());
+        return nullptr;
+    }
+}
+
+size_t llama_context::get_sampled_probs_count_no_sync(int32_t idx) {
+    if (!sampling.probs.has_data()) {
+        return 0;
+    }
+
+    try {
+        const int64_t row = output_resolve_row(idx);
+        if ((size_t) row >= sampling.probs_count.size()) {
+            return 0;
+        }
+        return sampling.probs_count[row];
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: invalid backend sampled probs count id %d, reason: %s\n", __func__, idx, err.what());
+        return 0;
     }
 }
 
@@ -1025,6 +1074,40 @@ float * llama_context::get_sampled_logits_ith(int32_t idx) {
     }
 }
 
+float * llama_context::get_sampled_logits_ith_no_sync(int32_t idx) {
+    if (!sampling.logits.has_data()) {
+        return nullptr;
+    }
+
+    try {
+        const int64_t row = output_resolve_row(idx);
+        if ((size_t) row >= sampling.logits_count.size() || sampling.logits_count[row] == 0) {
+            return nullptr;
+        }
+        return sampling.logits.data + row*model.vocab.n_tokens();
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: invalid backend sampled logits id %d, reason: %s\n", __func__, idx, err.what());
+        return nullptr;
+    }
+}
+
+size_t llama_context::get_sampled_logits_count_no_sync(int32_t idx) {
+    if (!sampling.logits.has_data()) {
+        return model.vocab.n_tokens();
+    }
+
+    try {
+        const int64_t row = output_resolve_row(idx);
+        if ((size_t) row >= sampling.logits_count.size()) {
+            return 0;
+        }
+        return sampling.logits_count[row];
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: invalid backend sampled logits count id %d, reason: %s\n", __func__, idx, err.what());
+        return 0;
+    }
+}
+
 const llama_token * llama_context::get_sampled_candidates_ith(int32_t idx) {
     output_reorder();
 
@@ -1041,6 +1124,38 @@ const llama_token * llama_context::get_sampled_candidates_ith(int32_t idx) {
     }
 
     return sampling.token_ids_full_vocab.data();
+}
+
+const llama_token * llama_context::get_sampled_candidates_ith_no_sync(int32_t idx) {
+    try {
+        const int64_t row = output_resolve_row(idx);
+        if (sampling.candidates.has_data() &&
+            (size_t) row < sampling.candidates_count.size() &&
+            sampling.candidates_count[row] > 0) {
+            return sampling.candidates.data + row*model.vocab.n_tokens();
+        }
+    } catch (const std::exception & err) {
+        GGML_UNUSED(err);
+    }
+
+    return sampling.token_ids_full_vocab.data();
+}
+
+size_t llama_context::get_sampled_candidates_count_no_sync(int32_t idx) {
+    if (!sampling.candidates.has_data()) {
+        return 0;
+    }
+
+    try {
+        const int64_t row = output_resolve_row(idx);
+        if ((size_t) row >= sampling.candidates_count.size()) {
+            return 0;
+        }
+        return sampling.candidates_count[row];
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: invalid backend sampled candidates count id %d, reason: %s\n", __func__, idx, err.what());
+        return 0;
+    }
 }
 
 size_t llama_context::get_sampled_candidates_count(int32_t idx) {
@@ -3993,31 +4108,31 @@ float * llama_get_embeddings_layer_inp(llama_context * ctx, uint32_t lid) {
 }
 
 llama_token llama_get_sampled_token_ith_no_sync(llama_context * ctx, int32_t i) {
-    return ctx->get_sampled_token_ith(i);
+    return ctx->get_sampled_token_ith_no_sync(i);
 }
 
 float * llama_get_sampled_probs_ith_no_sync(llama_context * ctx, int32_t i) {
-    return ctx->get_sampled_probs_ith(i);
+    return ctx->get_sampled_probs_ith_no_sync(i);
 }
 
 uint32_t llama_get_sampled_probs_count_ith_no_sync(llama_context * ctx, int32_t i) {
-    return static_cast<uint32_t>(ctx->get_sampled_probs_count(i));
+    return static_cast<uint32_t>(ctx->get_sampled_probs_count_no_sync(i));
 }
 
 float * llama_get_sampled_logits_ith_no_sync(llama_context * ctx, int32_t i) {
-    return ctx->get_sampled_logits_ith(i);
+    return ctx->get_sampled_logits_ith_no_sync(i);
 }
 
 uint32_t llama_get_sampled_logits_count_ith_no_sync(llama_context * ctx, int32_t i) {
-    return static_cast<uint32_t>(ctx->get_sampled_logits_count(i));
+    return static_cast<uint32_t>(ctx->get_sampled_logits_count_no_sync(i));
 }
 
 llama_token * llama_get_sampled_candidates_ith_no_sync(llama_context * ctx, int32_t i) {
-    return const_cast<llama_token *>(ctx->get_sampled_candidates_ith(i));
+    return const_cast<llama_token *>(ctx->get_sampled_candidates_ith_no_sync(i));
 }
 
 uint32_t llama_get_sampled_candidates_count_ith_no_sync(llama_context * ctx, int32_t i) {
-    return static_cast<uint32_t>(ctx->get_sampled_candidates_count(i));
+    return static_cast<uint32_t>(ctx->get_sampled_candidates_count_no_sync(i));
 }
 
 float * llama_get_logits_ith_no_sync(llama_context * ctx, int32_t i) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1190,12 +1190,12 @@ void llama_context::set_mtp(llama_context * ctx_mtp_in) {
         mtp.hook_tokens.clear();
     }
 
-    mtp.ctx_mtp     = ctx_mtp_in;
-    mtp.pending_pos = -1;
+    mtp.ctx_mtp = ctx_mtp_in;
 
     if (mtp.ctx_mtp) {
         const int32_t n_ub   = (int32_t) cparams.n_ubatch;
         const int32_t n_embd = (int32_t) model.hparams.n_embd;
+        const uint32_t n_seq = mtp.ctx_mtp->n_seq_max();
         mtp.hook_batch       = llama_batch_init(n_ub, n_embd, 1);
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
         if (mtp.hook_batch.embd != nullptr) {
@@ -1213,7 +1213,8 @@ void llama_context::set_mtp(llama_context * ctx_mtp_in) {
 #endif
         mtp.hook_tokens.assign(n_ub, LLAMA_TOKEN_NULL);
         mtp.hook_batch.token = mtp.hook_tokens.data();
-        mtp.pending_h.assign(n_embd, 0.0f);
+        mtp.pending_h.assign((size_t) n_seq * n_embd, 0.0f);
+        mtp.pending_pos.assign(n_seq, -1);
         LLAMA_LOG_INFO("%s: MTP draft head registered (ctx_mtp=%p, n_ubatch=%d, n_embd=%d)\n",
                        __func__, (const void *) mtp.ctx_mtp, n_ub, n_embd);
     } else {
@@ -1221,6 +1222,8 @@ void llama_context::set_mtp(llama_context * ctx_mtp_in) {
         mtp.hook_tokens.shrink_to_fit();
         mtp.pending_h.clear();
         mtp.pending_h.shrink_to_fit();
+        mtp.pending_pos.clear();
+        mtp.pending_pos.shrink_to_fit();
         LLAMA_LOG_INFO("%s: MTP draft head unregistered\n", __func__);
     }
 }
@@ -1229,9 +1232,11 @@ void llama_context::handle_mtp_for_ubatch(
         int32_t              n_tokens,
         const llama_token  * tokens,
         const llama_pos    * positions,
+        const int32_t      * n_seq_id,
+        llama_seq_id * const * seq_ids,
         struct ggml_tensor * t,
         bool                 decode_mtp) {
-    if (mtp.ctx_mtp == nullptr || n_tokens == 0 || t == nullptr) {
+    if (mtp.ctx_mtp == nullptr || n_tokens == 0 || t == nullptr || n_seq_id == nullptr || seq_ids == nullptr) {
         return;
     }
     if (t->ne[1] != (int64_t) n_tokens) {
@@ -1240,83 +1245,95 @@ void llama_context::handle_mtp_for_ubatch(
 
     const int64_t n_embd = model.hparams.n_embd;
     GGML_ASSERT(t->ne[0] == n_embd);
-
-    const int       n_rows    = (int) n_tokens;
-    const llama_pos pos_start = positions[0];
-
-    const llama_pos pos_max_mtp = llama_memory_seq_pos_max(llama_get_memory(mtp.ctx_mtp), 0);
-    if (pos_start <= pos_max_mtp) {
-        llama_memory_seq_rm(llama_get_memory(mtp.ctx_mtp), 0, pos_start, -1);
-        if (mtp.pending_pos >= pos_start) {
-            mtp.pending_pos = -1;
-        }
-    }
+    const uint32_t n_seq_max = mtp.ctx_mtp->n_seq_max();
+    const size_t row_bytes = (size_t) n_embd * sizeof(float);
 
     synchronize();
 
-    const bool pending_continues = mtp.pending_pos >= 0 && mtp.pending_pos + 1 == pos_start;
-    if (mtp.pending_pos >= 0 && !pending_continues) {
-        mtp.pending_pos = -1;
+    for (int32_t k = 0; k < n_tokens; ++k) {
+        GGML_ASSERT(n_seq_id[k] == 1);
+        const llama_seq_id seq_id = seq_ids[k][0];
+        GGML_ASSERT(seq_id >= 0);
+        GGML_ASSERT((uint32_t) seq_id < n_seq_max);
+
+        const llama_pos pos = positions[k];
+        const llama_pos pos_max_mtp = llama_memory_seq_pos_max(llama_get_memory(mtp.ctx_mtp), seq_id);
+        if (pos <= pos_max_mtp) {
+            llama_memory_seq_rm(llama_get_memory(mtp.ctx_mtp), seq_id, pos, -1);
+            if (mtp.pending_pos[seq_id] >= pos) {
+                mtp.pending_pos[seq_id] = -1;
+            }
+        }
     }
 
-    const size_t row_bytes = (size_t) n_embd * sizeof(float);
-    const int    n_out     = (pending_continues ? 1 : 0) + (n_rows - 1);
+    if (decode_mtp) {
+        ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
+        GGML_ASSERT(backend_t != nullptr);
 
-    if (decode_mtp && n_out > 0) {
         int out_idx = 0;
-        if (pending_continues) {
-            std::memcpy(mtp.hook_batch.embd + (size_t) out_idx * n_embd, mtp.pending_h.data(), row_bytes);
-            mtp.hook_batch.token[out_idx]     = tokens[0];
-            mtp.hook_batch.pos[out_idx]       = pos_start;
-            mtp.hook_batch.n_seq_id[out_idx]  = 1;
-            mtp.hook_batch.seq_id[out_idx][0] = 0;
-            mtp.hook_batch.logits[out_idx]    = 0;
-            ++out_idx;
-        }
-        if (n_rows > 1) {
-            ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
-            GGML_ASSERT(backend_t != nullptr);
+        for (int32_t k = 0; k < n_tokens; ++k) {
+            const llama_seq_id seq_id = seq_ids[k][0];
+            const float * pending_h = mtp.pending_h.data() + (size_t) seq_id * n_embd;
+            const bool pending_continues = mtp.pending_pos[seq_id] >= 0 && mtp.pending_pos[seq_id] + 1 == positions[k];
+            if (mtp.pending_pos[seq_id] >= 0 && !pending_continues) {
+                mtp.pending_pos[seq_id] = -1;
+            }
 
-            ggml_backend_tensor_get_2d_async(
-                backend_t,
-                t,
-                mtp.hook_batch.embd + (size_t) out_idx * n_embd,
-                0,
-                row_bytes,
-                (size_t) n_rows - 1,
-                row_bytes,
-                row_bytes);
-        }
-        for (int k = 0; k + 1 < n_rows; ++k) {
-            mtp.hook_batch.token[out_idx]     = tokens[k + 1];
-            mtp.hook_batch.pos[out_idx]       = positions[k + 1];
-            mtp.hook_batch.n_seq_id[out_idx]  = 1;
-            mtp.hook_batch.seq_id[out_idx][0] = 0;
-            mtp.hook_batch.logits[out_idx]    = 0;
-            ++out_idx;
-        }
-        GGML_ASSERT(out_idx == n_out);
-        mtp.hook_batch.n_tokens = n_out;
+            if (pending_continues) {
+                std::memcpy(mtp.hook_batch.embd + (size_t) out_idx * n_embd, pending_h, row_bytes);
+                mtp.hook_batch.token[out_idx]     = tokens[k];
+                mtp.hook_batch.pos[out_idx]       = positions[k];
+                mtp.hook_batch.n_seq_id[out_idx]  = 1;
+                mtp.hook_batch.seq_id[out_idx][0] = seq_id;
+                mtp.hook_batch.logits[out_idx]    = 0;
+                ++out_idx;
+            }
 
-        synchronize();
+            if (k + 1 < n_tokens && seq_ids[k + 1][0] == seq_id) {
+                ggml_backend_tensor_get_2d_async(
+                    backend_t,
+                    t,
+                    mtp.hook_batch.embd + (size_t) out_idx * n_embd,
+                    0,
+                    row_bytes,
+                    1,
+                    (size_t) k * row_bytes,
+                    row_bytes);
 
-        const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
-        if (rc_dec != 0) {
-            LLAMA_LOG_ERROR("%s: llama_decode(ctx_mtp) failed rc=%d (pos=%d, n=%d)\n",
-                            __func__, (int) rc_dec, (int) pos_start, n_out);
+                mtp.hook_batch.token[out_idx]     = tokens[k + 1];
+                mtp.hook_batch.pos[out_idx]       = positions[k + 1];
+                mtp.hook_batch.n_seq_id[out_idx]  = 1;
+                mtp.hook_batch.seq_id[out_idx][0] = seq_id;
+                mtp.hook_batch.logits[out_idx]    = 0;
+                ++out_idx;
+            }
+        }
+
+        mtp.hook_batch.n_tokens = out_idx;
+
+        if (out_idx > 0) {
+            synchronize();
+
+            const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
+            if (rc_dec != 0) {
+                LLAMA_LOG_ERROR("%s: llama_decode(ctx_mtp) failed rc=%d (pos=%d, n=%d)\n",
+                                __func__, (int) rc_dec, (int) positions[0], out_idx);
+            }
         }
     }
 
     ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
     GGML_ASSERT(backend_t != nullptr);
-
-    ggml_backend_tensor_get_async(
-        backend_t,
-        t,
-        mtp.pending_h.data(),
-        (size_t) (n_rows - 1) * row_bytes,
-        row_bytes);
-    mtp.pending_pos = pos_start + n_rows - 1;
+    for (int32_t k = 0; k < n_tokens; ++k) {
+        const llama_seq_id seq_id = seq_ids[k][0];
+        ggml_backend_tensor_get_async(
+            backend_t,
+            t,
+            mtp.pending_h.data() + (size_t) seq_id * n_embd,
+            (size_t) k * row_bytes,
+            row_bytes);
+        mtp.pending_pos[seq_id] = positions[k];
+    }
 }
 
 void llama_context::set_causal_attn(bool value) {
@@ -2142,7 +2159,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
         }
 
         if (mtp.ctx_mtp != nullptr && t_h_nextn != nullptr && ubatch.token != nullptr && ubatch.pos != nullptr) {
-            handle_mtp_for_ubatch((int32_t) ubatch.n_tokens, ubatch.token, ubatch.pos, t_h_nextn, true);
+            handle_mtp_for_ubatch((int32_t) ubatch.n_tokens, ubatch.token, ubatch.pos, ubatch.n_seq_id, ubatch.seq_id, t_h_nextn, true);
         }
 
         // Copy backend sampling output if this ubatch produced any sampling tensors.

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1266,6 +1266,8 @@ void llama_context::handle_mtp_for_ubatch(
         }
     }
 
+    std::vector<int32_t> last_row_by_seq(n_seq_max, -1);
+
     if (decode_mtp) {
         ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
         GGML_ASSERT(backend_t != nullptr);
@@ -1289,7 +1291,7 @@ void llama_context::handle_mtp_for_ubatch(
                 ++out_idx;
             }
 
-            if (k + 1 < n_tokens && seq_ids[k + 1][0] == seq_id) {
+            if (last_row_by_seq[seq_id] >= 0) {
                 ggml_backend_tensor_get_2d_async(
                     backend_t,
                     t,
@@ -1297,16 +1299,18 @@ void llama_context::handle_mtp_for_ubatch(
                     0,
                     row_bytes,
                     1,
-                    (size_t) k * row_bytes,
+                    (size_t) last_row_by_seq[seq_id] * row_bytes,
                     row_bytes);
 
-                mtp.hook_batch.token[out_idx]     = tokens[k + 1];
-                mtp.hook_batch.pos[out_idx]       = positions[k + 1];
+                mtp.hook_batch.token[out_idx]     = tokens[k];
+                mtp.hook_batch.pos[out_idx]       = positions[k];
                 mtp.hook_batch.n_seq_id[out_idx]  = 1;
                 mtp.hook_batch.seq_id[out_idx][0] = seq_id;
                 mtp.hook_batch.logits[out_idx]    = 0;
                 ++out_idx;
             }
+
+            last_row_by_seq[seq_id] = k;
         }
 
         mtp.hook_batch.n_tokens = out_idx;
@@ -1324,15 +1328,17 @@ void llama_context::handle_mtp_for_ubatch(
 
     ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
     GGML_ASSERT(backend_t != nullptr);
-    for (int32_t k = 0; k < n_tokens; ++k) {
-        const llama_seq_id seq_id = seq_ids[k][0];
+    for (uint32_t seq_id = 0; seq_id < n_seq_max; ++seq_id) {
+        if (last_row_by_seq[seq_id] < 0) {
+            continue;
+        }
         ggml_backend_tensor_get_async(
             backend_t,
             t,
             mtp.pending_h.data() + (size_t) seq_id * n_embd,
-            (size_t) k * row_bytes,
+            (size_t) last_row_by_seq[seq_id] * row_bytes,
             row_bytes);
-        mtp.pending_pos[seq_id] = positions[k];
+        mtp.pending_pos[seq_id] = positions[last_row_by_seq[seq_id]];
     }
 }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1250,11 +1250,20 @@ void llama_context::handle_mtp_for_ubatch(
 
     synchronize();
 
+    llama_seq_id single_seq_id = -1;
+    bool single_seq = true;
+
     for (int32_t k = 0; k < n_tokens; ++k) {
         GGML_ASSERT(n_seq_id[k] == 1);
         const llama_seq_id seq_id = seq_ids[k][0];
         GGML_ASSERT(seq_id >= 0);
         GGML_ASSERT((uint32_t) seq_id < n_seq_max);
+
+        if (single_seq_id < 0) {
+            single_seq_id = seq_id;
+        } else if (single_seq_id != seq_id) {
+            single_seq = false;
+        }
 
         const llama_pos pos = positions[k];
         const llama_pos pos_max_mtp = llama_memory_seq_pos_max(llama_get_memory(mtp.ctx_mtp), seq_id);
@@ -1267,6 +1276,75 @@ void llama_context::handle_mtp_for_ubatch(
     }
 
     std::vector<int32_t> last_row_by_seq(n_seq_max, -1);
+
+    if (decode_mtp && single_seq) {
+        ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
+        GGML_ASSERT(backend_t != nullptr);
+
+        const llama_seq_id seq_id = single_seq_id;
+        const llama_pos pos_start = positions[0];
+        const bool pending_continues = mtp.pending_pos[seq_id] >= 0 && mtp.pending_pos[seq_id] + 1 == pos_start;
+        if (mtp.pending_pos[seq_id] >= 0 && !pending_continues) {
+            mtp.pending_pos[seq_id] = -1;
+        }
+
+        const int n_out = (pending_continues ? 1 : 0) + (n_tokens - 1);
+        if (n_out > 0) {
+            int out_idx = 0;
+            if (pending_continues) {
+                std::memcpy(mtp.hook_batch.embd + (size_t) out_idx * n_embd, mtp.pending_h.data() + (size_t) seq_id * n_embd, row_bytes);
+                mtp.hook_batch.token[out_idx]     = tokens[0];
+                mtp.hook_batch.pos[out_idx]       = pos_start;
+                mtp.hook_batch.n_seq_id[out_idx]  = 1;
+                mtp.hook_batch.seq_id[out_idx][0] = seq_id;
+                mtp.hook_batch.logits[out_idx]    = 0;
+                ++out_idx;
+            }
+
+            if (n_tokens > 1) {
+                ggml_backend_tensor_get_2d_async(
+                    backend_t,
+                    t,
+                    mtp.hook_batch.embd + (size_t) out_idx * n_embd,
+                    0,
+                    row_bytes,
+                    (size_t) n_tokens - 1,
+                    row_bytes,
+                    row_bytes);
+            }
+
+            for (int32_t k = 0; k + 1 < n_tokens; ++k) {
+                mtp.hook_batch.token[out_idx]     = tokens[k + 1];
+                mtp.hook_batch.pos[out_idx]       = positions[k + 1];
+                mtp.hook_batch.n_seq_id[out_idx]  = 1;
+                mtp.hook_batch.seq_id[out_idx][0] = seq_id;
+                mtp.hook_batch.logits[out_idx]    = 0;
+                ++out_idx;
+            }
+
+            GGML_ASSERT(out_idx == n_out);
+            mtp.hook_batch.n_tokens = n_out;
+
+            synchronize();
+
+            const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
+            if (rc_dec != 0) {
+                LLAMA_LOG_ERROR("%s: llama_decode(ctx_mtp) failed rc=%d (pos=%d, n=%d)\n",
+                                __func__, (int) rc_dec, (int) pos_start, n_out);
+            }
+        }
+
+        if (n_tokens > 0) {
+            ggml_backend_tensor_get_async(
+                backend_t,
+                t,
+                mtp.pending_h.data() + (size_t) seq_id * n_embd,
+                (size_t) (n_tokens - 1) * row_bytes,
+                row_bytes);
+            mtp.pending_pos[seq_id] = positions[n_tokens - 1];
+        }
+        return;
+    }
 
     if (decode_mtp) {
         ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1247,8 +1247,10 @@ void llama_context::handle_mtp_for_ubatch(
     GGML_ASSERT(t->ne[0] == n_embd);
     const uint32_t n_seq_max = mtp.ctx_mtp->n_seq_max();
     const size_t row_bytes = (size_t) n_embd * sizeof(float);
+    ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
+    GGML_ASSERT(backend_t != nullptr);
 
-    synchronize();
+    ggml_backend_synchronize(backend_t);
 
     llama_seq_id single_seq_id = -1;
     bool single_seq = true;
@@ -1278,9 +1280,6 @@ void llama_context::handle_mtp_for_ubatch(
     std::vector<int32_t> last_row_by_seq(n_seq_max, -1);
 
     if (decode_mtp && single_seq) {
-        ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
-        GGML_ASSERT(backend_t != nullptr);
-
         const llama_seq_id seq_id = single_seq_id;
         const llama_pos pos_start = positions[0];
         const bool pending_continues = mtp.pending_pos[seq_id] >= 0 && mtp.pending_pos[seq_id] + 1 == pos_start;
@@ -1325,7 +1324,7 @@ void llama_context::handle_mtp_for_ubatch(
             GGML_ASSERT(out_idx == n_out);
             mtp.hook_batch.n_tokens = n_out;
 
-            synchronize();
+            ggml_backend_synchronize(backend_t);
 
             const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
             if (rc_dec != 0) {
@@ -1347,9 +1346,6 @@ void llama_context::handle_mtp_for_ubatch(
     }
 
     if (decode_mtp) {
-        ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
-        GGML_ASSERT(backend_t != nullptr);
-
         int out_idx = 0;
         for (int32_t k = 0; k < n_tokens; ++k) {
             const llama_seq_id seq_id = seq_ids[k][0];
@@ -1394,7 +1390,7 @@ void llama_context::handle_mtp_for_ubatch(
         mtp.hook_batch.n_tokens = out_idx;
 
         if (out_idx > 0) {
-            synchronize();
+            ggml_backend_synchronize(backend_t);
 
             const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
             if (rc_dec != 0) {
@@ -1404,8 +1400,6 @@ void llama_context::handle_mtp_for_ubatch(
         }
     }
 
-    ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
-    GGML_ASSERT(backend_t != nullptr);
     for (uint32_t seq_id = 0; seq_id < n_seq_max; ++seq_id) {
         if (last_row_by_seq[seq_id] < 0) {
             continue;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -97,15 +97,22 @@ struct llama_context {
 
     llama_token * get_sampled_tokens() const;
     llama_token   get_sampled_token_ith(int32_t idx);
+    llama_token   get_sampled_token_ith_no_sync(int32_t idx);
 
     float * get_sampled_logits_ith(int32_t idx);
     size_t  get_sampled_logits_count(int32_t idx);
+    float * get_sampled_logits_ith_no_sync(int32_t idx);
+    size_t  get_sampled_logits_count_no_sync(int32_t idx);
 
     float * get_sampled_probs_ith(int32_t idx);
     size_t  get_sampled_probs_count(int32_t idx);
+    float * get_sampled_probs_ith_no_sync(int32_t idx);
+    size_t  get_sampled_probs_count_no_sync(int32_t idx);
 
     const llama_token * get_sampled_candidates_ith(int32_t idx);
     size_t get_sampled_candidates_count(int32_t idx);
+    const llama_token * get_sampled_candidates_ith_no_sync(int32_t idx);
+    size_t get_sampled_candidates_count_no_sync(int32_t idx);
 
     void attach_threadpool(
             ggml_threadpool_t threadpool,

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -270,6 +270,8 @@ private:
             int32_t              n_tokens,
             const llama_token  * tokens,
             const llama_pos    * positions,
+            const int32_t      * n_seq_id,
+            llama_seq_id * const * seq_id,
             struct ggml_tensor * t_h_pre_norm,
             bool                 decode_mtp);
 

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -101,6 +101,7 @@ LLAMA_API float * llama_get_embeddings_nextn(struct llama_context * ctx);
 
 // LLAMA_API float * llama_get_embeddings_ith(struct llama_context * ctx, int32_t i);
 LLAMA_API float * llama_get_embeddings_nextn_ith(struct llama_context * ctx, int32_t i);
+LLAMA_API float * llama_get_embeddings_nextn_ith_no_sync(struct llama_context * ctx, int32_t i);
 LLAMA_API struct ggml_tensor * llama_context_get_t_h_pre_norm(struct llama_context * ctx);
 LLAMA_API struct ggml_tensor * llama_context_get_t_mtp_out(struct llama_context * ctx);
 LLAMA_API void llama_set_mtp(struct llama_context * ctx_target, struct llama_context * ctx_mtp);

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -114,6 +114,15 @@ LLAMA_API float * llama_get_embeddings_layer_inp(struct llama_context * ctx, uin
 
 LLAMA_API llama_context * llama_get_ctx_other(struct llama_context * ctx);
 
+LLAMA_API llama_token llama_get_sampled_token_ith_no_sync(struct llama_context * ctx, int32_t i);
+LLAMA_API float * llama_get_sampled_probs_ith_no_sync(struct llama_context * ctx, int32_t i);
+LLAMA_API uint32_t llama_get_sampled_probs_count_ith_no_sync(struct llama_context * ctx, int32_t i);
+LLAMA_API float * llama_get_sampled_logits_ith_no_sync(struct llama_context * ctx, int32_t i);
+LLAMA_API uint32_t llama_get_sampled_logits_count_ith_no_sync(struct llama_context * ctx, int32_t i);
+LLAMA_API llama_token * llama_get_sampled_candidates_ith_no_sync(struct llama_context * ctx, int32_t i);
+LLAMA_API uint32_t llama_get_sampled_candidates_count_ith_no_sync(struct llama_context * ctx, int32_t i);
+LLAMA_API float * llama_get_logits_ith_no_sync(struct llama_context * ctx, int32_t i);
+
 //
 // model/context data extraction
 //

--- a/src/llama-mtp.h
+++ b/src/llama-mtp.h
@@ -11,7 +11,7 @@ struct llama_mtp {
     ggml_backend_buffer_t hook_batch_embd_buffer = nullptr;
     std::vector<llama_token> hook_tokens;
 
-    // Cross-ubatch carryover for the final hidden-state row.
-    std::vector<float> pending_h;   // [n_embd]
-    llama_pos          pending_pos = -1;
+    // Cross-ubatch carryover for the final hidden-state row, indexed by seq_id.
+    std::vector<float> pending_h;   // [n_seq_max * n_embd]
+    std::vector<llama_pos> pending_pos;
 };

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -342,16 +342,21 @@ static bool mtp_tree_verify_paths(
         }
     }
 
-    // Clear temporary sequences and restore the source sequence position window.
+    // Copy best temp sequence KV back to the main sequence before cleanup,
+    // so the accepted tokens survive in the main KV cache.
+    if (best_result.ok) {
+        for (const auto & info : active) {
+            if (info.path_index == best_path_index) {
+                common_context_seq_cp(ctx_tgt, info.seq_id, seq_id, 0, -1);
+                break;
+            }
+        }
+    }
+
+    // Clear temporary sequences.
     for (const auto & info : active) {
         common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
     }
-    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
-        LOG_DBG("mtp_tree_verify_paths: failed to restore source rollback window (pos_max=%d)\n", (int) ckpt.pos_max);
-        llama_batch_free(batch);
-        return false;
-    }
-
     llama_batch_free(batch);
     nvtxRangePop();
     return true;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -66,20 +66,6 @@ static uint32_t server_n_outputs_max(const common_params & params) {
     return std::max<uint32_t>(1, std::min<uint64_t>(n_batch, n_outputs));
 }
 
-static int32_t server_target_n_seq_max(const common_params & params) {
-    const bool spec_mtp = std::find(params.speculative.types.begin(), params.speculative.types.end(),
-                                    COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params.speculative.types.end()
-                       || std::find(params.speculative.types.begin(), params.speculative.types.end(),
-                                    COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params.speculative.types.end();
-    if (!spec_mtp || !params.speculative.draft.use_mtp_tree || !params.kv_unified) {
-        return params.n_parallel;
-    }
-
-    const int32_t tree_nodes = std::max(1, params.speculative.draft.mtp_tree_nodes);
-    const int32_t extra_verify_seq = std::min<int32_t>(2, std::max(0, tree_nodes - params.n_parallel));
-    return params.n_parallel + extra_verify_seq;
-}
-
 struct mtp_tree_candidate_path {
     llama_tokens tokens;
     float score = 0.0f;
@@ -1084,7 +1070,6 @@ private:
     // use server_context methods instead
 
     common_params params_base;
-    int32_t n_slots_user = 0;
 
     // note: keep these alive - they determine the lifetime of the model, context, etc.
     common_init_result_ptr llama_init;
@@ -1170,11 +1155,8 @@ private:
         SRV_INF("loading model '%s'\n", params.model.path.c_str());
 
         params_base = params;
-        n_slots_user = params_base.n_parallel;
         params_base.n_outputs_max = server_n_outputs_max(params_base);
-        const int32_t n_seq_max_tgt = server_target_n_seq_max(params_base);
         common_params params_tgt = params_base;
-        params_tgt.n_parallel = n_seq_max_tgt;
 
         std::string & mmproj_path = params_base.mmproj.path;
         bool has_mmproj = !mmproj_path.empty();
@@ -1243,7 +1225,7 @@ private:
                     measure_model_bytes = false;
                 }
 
-                params_dft.n_outputs_max = n_slots_user;
+                params_dft.n_outputs_max = params_base.n_parallel;
 
                 auto mparams_dft = common_model_params_to_llama(params_dft);
                 auto cparams_dft = common_context_params_to_llama(params_dft);
@@ -1308,11 +1290,6 @@ private:
                 params_base.kv_overrides.emplace_back();
                 params_base.kv_overrides.back().key[0] = 0;
             }
-        }
-
-        if (n_seq_max_tgt != n_slots_user) {
-            SRV_INF("reserving %d target sequences for MTP tree verification (user slots = %d)\n",
-                    n_seq_max_tgt, n_slots_user);
         }
 
         llama_init = common_init_from_params(params_tgt);
@@ -1427,7 +1404,7 @@ private:
             cparams_mtp.type_k        = params_base.cache_type_k;
             cparams_mtp.type_v        = params_base.cache_type_v;
             cparams_mtp.n_rs_seq      = 0;
-            cparams_mtp.n_outputs_max = n_slots_user;
+            cparams_mtp.n_outputs_max = params_base.n_parallel;
             cparams_mtp.ctx_other = ctx_tgt;
 
             ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams_mtp));
@@ -1488,7 +1465,7 @@ private:
         slot_prompt_similarity = params_base.slot_prompt_similarity;
 
         // setup slots
-        SRV_INF("initializing slots, n_slots = %d\n", n_slots_user);
+        SRV_INF("initializing slots, n_slots = %d\n", params_base.n_parallel);
 
         const int n_ctx_train = llama_model_n_ctx_train(model_tgt);
 
@@ -1510,14 +1487,14 @@ private:
         }
 
         // initialize slots
-        for (int i = 0; i < n_slots_user; i++) {
+        for (int i = 0; i < params_base.n_parallel; i++) {
             slots.emplace_back();
         }
 
         // try speculative decoding
         if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             try {
-                spec.reset(common_speculative_init(params_base.speculative, n_slots_user));
+                spec.reset(common_speculative_init(params_base.speculative, params_base.n_parallel));
             } catch (const std::exception & e) {
                 SRV_ERR("failed to initialize speculative decoding context: %s\n", e.what());
             }
@@ -1533,7 +1510,7 @@ private:
             ctx_dft.reset();
         }
 
-        for (int i = 0; i < n_slots_user; i++) {
+        for (int i = 0; i < params_base.n_parallel; i++) {
             server_slot & slot = slots[i];
 
             slot.id      = i;
@@ -1576,7 +1553,7 @@ private:
         // note that n_batch can be > n_ctx (e.g. for non-causal attention models such as BERT where the KV cache is not used)
         {
             const int32_t n_batch = llama_n_batch(ctx_tgt);
-            batch = llama_batch_init(std::max(n_batch, n_slots_user), 0, 1);
+            batch = llama_batch_init(std::max(n_batch, params_base.n_parallel), 0, 1);
         }
 
         if (params_base.cache_ram_mib != 0) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -77,6 +77,8 @@ static bool mtp_tree_collect_candidates(
         std::vector<mtp_tree_candidate_path> & paths) {
     paths.clear();
 
+    LOG_INF("mtp_tree_collect_candidates: plan.nodes.size()=%zu max_depth=%zu\n", plan.nodes.size(), max_depth);
+
     if (plan.nodes.size() <= 1) {
         return false;
     }
@@ -106,6 +108,9 @@ static bool mtp_tree_collect_candidates(
         }
 
         std::reverse(tokens.begin(), tokens.end());
+
+        LOG_INF("mtp_tree_collect_candidates: path[%zu] tokens=%zu score=%.4f first_token=%d\n", 
+                paths.size(), tokens.size(), (double)node.cum_prob, (int)tokens[0]);
 
         paths.push_back({std::move(tokens), node.cum_prob});
     }
@@ -168,11 +173,13 @@ static bool mtp_tree_verify_path(
         common_sampler * smpl,
         mtp_tree_verify_result & result) {
     if (!ctx_tgt || !smpl || path.tokens.empty()) {
+        LOG_INF("mtp_tree_verify_path: invalid input (ctx=%p smpl=%p tokens=%zu)\n", ctx_tgt, smpl, path.tokens.size());
         return false;
     }
 
     ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
     if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
+        LOG_INF("mtp_tree_verify_path: seq_rm failed (pos_max=%d)\n", (int)ckpt.pos_max);
         return false;
     }
 
@@ -180,6 +187,7 @@ static bool mtp_tree_verify_path(
     auto batch = llama_batch_init(n_tokens, 0, 1);
     if (batch.n_tokens < 0) {
         llama_batch_free(batch);
+        LOG_INF("mtp_tree_verify_path: batch_init failed (n_tokens=%d)\n", n_tokens);
         return false;
     }
 
@@ -192,6 +200,7 @@ static bool mtp_tree_verify_path(
     llama_batch_free(batch);
 
     if (rc != 0) {
+        LOG_INF("mtp_tree_verify_path: decode failed (rc=%d)\n", rc);
         return false;
     }
 
@@ -201,6 +210,8 @@ static bool mtp_tree_verify_path(
         const llama_token id = common_sampler_sample(smpl, ctx_tgt, (int) i + 1, false);
         common_sampler_accept(smpl, id, true);
         result.accepted.push_back(id);
+
+        LOG_INF("mtp_tree_verify_path: pos=%zu sampled=%d expected=%d match=%d\n", i, (int)id, (int)path.tokens[i], id == path.tokens[i] ? 1 : 0);
 
         if (id != path.tokens[i]) {
             result.ok = true;
@@ -3696,6 +3707,7 @@ private:
                     if (params_base.speculative.draft.use_mtp_tree && use_ckpt_tgt && !slot.spec_ckpt.empty()) {
                         common_speculative_mtp_tree_plan mtp_tree;
                         if (common_speculative_get_mtp_tree_plan(spec.get(), slot.id, mtp_tree)) {
+                            LOG_INF("slot %d: got tree plan with %zu nodes\n", slot.id, mtp_tree.nodes.size());
                             if (trace > 0) {
                                 SLT_DBG(slot,
                                         "mtp-tree draft: nodes=%zu max_nodes=%zu max_depth=%zu p_split=%.4g\n",
@@ -3707,11 +3719,13 @@ private:
 
                             std::vector<mtp_tree_candidate_path> tree_paths;
                             if (mtp_tree_collect_candidates(mtp_tree, n_draft, tree_paths)) {
+                                LOG_INF("slot %d: collected %zu candidate paths\n", slot.id, tree_paths.size());
                                 size_t best_accept = 0;
                                 float best_score = -1.0f;
                                 mtp_tree_candidate_path best_path;
 
                                 const llama_token root = slot.sampled;
+                                LOG_INF("slot %d: using root=%d for verification\n", slot.id, (int)root);
                                 const int32_t tree_start_pos = slot.spec_ckpt.pos_max >= 0
                                     ? (int32_t) slot.spec_ckpt.pos_max + 1
                                     : (int32_t) slot.spec_ckpt.n_tokens;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -342,21 +342,16 @@ static bool mtp_tree_verify_paths(
         }
     }
 
-    // Copy best temp sequence KV back to the main sequence before cleanup,
-    // so the accepted tokens survive in the main KV cache.
-    if (best_result.ok) {
-        for (const auto & info : active) {
-            if (info.path_index == best_path_index) {
-                common_context_seq_cp(ctx_tgt, info.seq_id, seq_id, 0, -1);
-                break;
-            }
-        }
-    }
-
-    // Clear temporary sequences.
+    // Clear temporary sequences and restore the source sequence position window.
     for (const auto & info : active) {
         common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
     }
+    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
+        LOG_DBG("mtp_tree_verify_paths: failed to restore source rollback window (pos_max=%d)\n", (int) ckpt.pos_max);
+        llama_batch_free(batch);
+        return false;
+    }
+
     llama_batch_free(batch);
     nvtxRangePop();
     return true;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -171,6 +171,30 @@ struct mtp_tree_verify_paths_result {
     bool ok = false;
 };
 
+struct mtp_tree_inline_candidate {
+    size_t path_index = 0;
+    llama_seq_id seq_id = -1;
+    size_t batch_offset = 0;
+};
+
+struct mtp_tree_inline_state {
+    std::vector<mtp_tree_candidate_path> paths;
+    std::vector<mtp_tree_inline_candidate> active;
+    llama_token root = LLAMA_TOKEN_NULL;
+    llama_pos start_pos = 0;
+
+    void clear() {
+        paths.clear();
+        active.clear();
+        root = LLAMA_TOKEN_NULL;
+        start_pos = 0;
+    }
+
+    bool empty() const {
+        return active.empty();
+    }
+};
+
 static size_t mtp_tree_candidate_slots_available(llama_context * ctx_tgt) {
     const int32_t n_seq_max = llama_n_seq_max(ctx_tgt);
     if (n_seq_max <= 1) {
@@ -178,6 +202,93 @@ static size_t mtp_tree_candidate_slots_available(llama_context * ctx_tgt) {
     }
 
     return (size_t) std::max(0, n_seq_max - 1);
+}
+
+static void mtp_tree_inline_clear_context(
+        llama_context * ctx_tgt,
+        mtp_tree_inline_state & state) {
+    if (ctx_tgt == nullptr) {
+        state.clear();
+        return;
+    }
+
+    for (const auto & info : state.active) {
+        if (info.seq_id >= 0) {
+            common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
+        }
+    }
+    state.clear();
+}
+
+static bool mtp_tree_inline_accept(
+        llama_context * ctx_tgt,
+        const mtp_tree_inline_state & state,
+        common_sampler * smpl,
+        common_sampler_ptr & smpl_best,
+        llama_seq_id & best_seq_id,
+        size_t & best_path_index,
+        mtp_tree_verify_paths_result & best_result) {
+    if (ctx_tgt == nullptr || smpl == nullptr || state.empty()) {
+        return false;
+    }
+
+    best_seq_id = -1;
+    best_path_index = 0;
+    best_result = {};
+
+    for (const auto & info : state.active) {
+        if (info.path_index >= state.paths.size()) {
+            continue;
+        }
+
+        const auto & path = state.paths[info.path_index];
+        if (path.tokens.empty()) {
+            continue;
+        }
+
+        common_sampler_ptr smpl_path(common_sampler_clone(smpl));
+        if (!smpl_path) {
+            continue;
+        }
+
+        mtp_tree_verify_paths_result cur_result;
+        const int base_pos = (int) info.batch_offset;
+        bool full_match = true;
+
+        for (size_t j = 0; j < path.tokens.size(); ++j) {
+            const int sample_pos = base_pos + (int) j;
+            const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
+            common_sampler_accept(smpl_path.get(), id, true);
+            cur_result.accepted.push_back(id);
+
+            if (id != path.tokens[j]) {
+                full_match = false;
+                break;
+            }
+        }
+
+        if (!full_match) {
+            continue;
+        }
+
+        const int sample_pos = base_pos + (int) path.tokens.size();
+        const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
+        common_sampler_accept(smpl_path.get(), id, true);
+        cur_result.accepted.push_back(id);
+        cur_result.ok = true;
+        cur_result.n_accept = path.tokens.size();
+
+        if (!best_result.ok ||
+                cur_result.n_accept > best_result.n_accept ||
+                (cur_result.n_accept == best_result.n_accept && path.score > state.paths[best_path_index].score)) {
+            best_result = std::move(cur_result);
+            best_seq_id = info.seq_id;
+            best_path_index = info.path_index;
+            smpl_best = std::move(smpl_path);
+        }
+    }
+
+    return best_result.ok && best_seq_id >= 0 && smpl_best != nullptr;
 }
 
 static bool mtp_tree_verify_paths(
@@ -544,6 +655,7 @@ struct server_slot {
     llama_tokens spec_prompt;
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
+    mtp_tree_inline_state spec_tree_inline;
     bool kv_needs_restore = false; // reset by ckpt.update_tgt() before each draft round; guards load_tgt in mtp_tree_verify_paths
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
@@ -680,6 +792,7 @@ struct server_slot {
             spec_draft.clear();
             spec_i_batch.clear();
             spec_ckpt.clear();
+            mtp_tree_inline_clear_context(ctx_tgt, spec_tree_inline);
         }
         generated_tokens.clear();
         generated_token_probs.clear();
@@ -803,6 +916,98 @@ struct server_slot {
         SLT_DBG(*this, "max possible draft: %d\n", n_draft_max);
 
         return n_draft_max;
+    }
+
+    bool prepare_mtp_tree_inline(
+            common_speculative * spec_impl,
+            const common_params_speculative_draft & draft_params,
+            int32_t batch_n_tokens,
+            int32_t n_batch) {
+        mtp_tree_inline_clear_context(ctx_tgt, spec_tree_inline);
+
+        if (spec_impl == nullptr || spec_draft.empty()) {
+            return false;
+        }
+        if (!draft_params.use_mtp_tree || !draft_params.mtp_tree_target_verify) {
+            return false;
+        }
+
+        const size_t max_candidates = mtp_tree_candidate_slots_available(ctx_tgt);
+        if (max_candidates == 0) {
+            return false;
+        }
+
+        common_speculative_mtp_tree_plan mtp_tree;
+        if (!common_speculative_get_mtp_tree_plan(spec_impl, id, mtp_tree)) {
+            return false;
+        }
+
+        if (!mtp_tree_collect_candidates(mtp_tree, spec_draft.size(), spec_tree_inline.paths)) {
+            spec_tree_inline.clear();
+            return false;
+        }
+
+        const int32_t n_main_rows = (int32_t) spec_draft.size() + 1;
+        int32_t n_capacity = n_batch - batch_n_tokens - n_main_rows;
+        if (n_capacity <= 0) {
+            spec_tree_inline.clear();
+            return false;
+        }
+
+        spec_tree_inline.root = sampled;
+        spec_tree_inline.start_pos = prompt.tokens.pos_next();
+
+        size_t seq_id_probe = 0;
+        for (size_t i = 0; i < spec_tree_inline.paths.size() && spec_tree_inline.active.size() < max_candidates; ++i) {
+            const auto & path = spec_tree_inline.paths[i];
+            if (path.tokens.empty()) {
+                continue;
+            }
+
+            const int32_t n_path_rows = (int32_t) path.tokens.size() + 1;
+            if (n_path_rows > n_capacity) {
+                continue;
+            }
+
+            while ((llama_seq_id) seq_id_probe == id) {
+                ++seq_id_probe;
+            }
+            if (seq_id_probe >= (size_t) llama_n_seq_max(ctx_tgt)) {
+                break;
+            }
+
+            const llama_seq_id seq = (llama_seq_id) seq_id_probe;
+            ++seq_id_probe;
+
+            common_context_seq_rm(ctx_tgt, seq, -1, -1);
+            common_context_seq_cp(ctx_tgt, id, seq, 0, -1);
+
+            spec_tree_inline.active.push_back({ i, seq, 0 });
+            n_capacity -= n_path_rows;
+        }
+
+        if (spec_tree_inline.active.empty()) {
+            spec_tree_inline.clear();
+            return false;
+        }
+
+        return true;
+    }
+
+    void append_mtp_tree_inline_batch(llama_batch & batch) {
+        if (spec_tree_inline.empty()) {
+            return;
+        }
+
+        for (auto & info : spec_tree_inline.active) {
+            const auto & path = spec_tree_inline.paths[info.path_index];
+            info.batch_offset = (size_t) batch.n_tokens;
+
+            common_batch_add(batch, spec_tree_inline.root, spec_tree_inline.start_pos, { info.seq_id }, true);
+            for (size_t j = 0; j < path.tokens.size(); ++j) {
+                common_batch_add(batch, path.tokens[j], spec_tree_inline.start_pos + (llama_pos) j + 1, { info.seq_id }, true);
+            }
+        }
     }
 
     void update_batch(llama_batch & batch) {
@@ -3130,16 +3335,22 @@ private:
             }
         }
 
+        // process in chunks of params.n_batch
+        int32_t n_batch  = llama_n_batch(ctx_tgt);
+        int32_t n_ubatch = llama_n_ubatch(ctx_tgt);
+
         // update the batch with the sampled/drafted tokens
         for (auto * slot_ptr : generating) {
             auto & slot = *slot_ptr;
 
+            slot.prepare_mtp_tree_inline(
+                    spec.get(),
+                    params_base.speculative.draft,
+                    batch.n_tokens,
+                    n_batch);
             slot.update_batch(batch);
+            slot.append_mtp_tree_inline_batch(batch);
         }
-
-        // process in chunks of params.n_batch
-        int32_t n_batch  = llama_n_batch(ctx_tgt);
-        int32_t n_ubatch = llama_n_ubatch(ctx_tgt);
 
         float  alora_scale       = -1.0f;
         size_t alora_disabled_id = 0;
@@ -3975,64 +4186,36 @@ private:
                     bool used_tree_verify = false;
                     llama_tokens accepted_tree;
 
-                    const bool can_use_tree = params_base.speculative.draft.use_mtp_tree
-                        && params_base.speculative.draft.mtp_tree_target_verify
-                        && use_ckpt_tgt
-                        && !slot.spec_ckpt.empty()
-                        && mtp_tree_candidate_slots_available(slot.ctx_tgt) > 1;
+                    if (!slot.spec_tree_inline.empty()) {
+                        nvtxRangePushA("server:mtp_tree_inline_accept");
 
-                    SLT_INF(slot, "can_use_tree: use_mtp=%d target_verify=%d ckpt_tgt=%d ckpt_empty=%d cand_slots=%zu n_seq=%d rm_type=%d n_draft=%d n_rs=%d\n", (int)params_base.speculative.draft.use_mtp_tree, (int)params_base.speculative.draft.mtp_tree_target_verify, (int)use_ckpt_tgt, (int)slot.spec_ckpt.empty(), mtp_tree_candidate_slots_available(slot.ctx_tgt), (int)llama_n_seq_max(slot.ctx_tgt), (int)ctx_tgt_seq_rm_type, (int)n_draft, (int)llama_n_rs_seq(slot.ctx_tgt));
-                    if (can_use_tree) {
-                        nvtxRangePushA("server:can_use_tree");
-                        common_speculative_mtp_tree_plan mtp_tree;
-                        if (common_speculative_get_mtp_tree_plan(spec.get(), slot.id, mtp_tree)) {
+                        llama_seq_id best_seq_id = -1;
+                        size_t best_path_index = 0;
+                        mtp_tree_verify_paths_result best_path_result;
+                        common_sampler_ptr best_path_smpl;
 
-                            LOG_DBG("slot %d: got tree plan with %zu nodes\n", slot.id, mtp_tree.nodes.size());
-                            if (trace > 0) {
-                                SLT_DBG(slot,
-                                        "mtp-tree draft: nodes=%zu max_nodes=%zu max_depth=%zu p_split=%.4g\n",
-                                        mtp_tree.nodes.size(),
-                                        mtp_tree.max_nodes,
-                                        mtp_tree.max_depth,
-                                        (double) mtp_tree.p_split);
-                            }
+                        if (mtp_tree_inline_accept(
+                                    slot.ctx_tgt,
+                                    slot.spec_tree_inline,
+                                    smpl_save.get(),
+                                    best_path_smpl,
+                                    best_seq_id,
+                                    best_path_index,
+                                    best_path_result)) {
+                            if (mtp_tree_seq_rm_with_fallback(slot.ctx_tgt, slot.id, slot.spec_tree_inline.start_pos, -1)) {
+                                common_context_seq_cp(slot.ctx_tgt, best_seq_id, slot.id, 0, -1);
+                                accepted_tree = std::move(best_path_result.accepted);
+                                slot.smpl = std::move(best_path_smpl);
+                                slot.kv_needs_restore = false;
+                                used_tree_verify = true;
 
-                            std::vector<mtp_tree_candidate_path> tree_paths;
-                            if (mtp_tree_collect_candidates(mtp_tree, n_draft, tree_paths)) {
-                                LOG_DBG("slot %d: collected %zu candidate paths\n", slot.id, tree_paths.size());
-                                const llama_token root = slot.sampled;
-                                const int32_t tree_start_pos = slot.spec_ckpt.pos_max >= 0
-                                    ? (int32_t) slot.spec_ckpt.pos_max + 1
-                                    : (int32_t) slot.spec_ckpt.n_tokens;
-                                LOG_DBG("slot %d: using root=%d for verification\n", slot.id, (int)root);
-
-                                size_t best_path_index = 0;
-                                mtp_tree_verify_paths_result best_path_result;
-                                common_sampler_ptr best_path_smpl;
-                                std::vector<mtp_tree_verify_paths_result> verify_results;
-
-                                const bool tree_verified = mtp_tree_verify_paths(
-                                        slot.ctx_tgt,
-                                        slot.spec_ckpt,
-                                        spec_ckpt_flags,
-                                        slot.id,
-                                        tree_start_pos,
-                                        root,
-                                        tree_paths,
-                                        smpl_save.get(),
-                                        verify_results,
-                                        best_path_smpl,
-                                        best_path_index,
-                                        best_path_result,
-                                        slot.kv_needs_restore);
-
-                                if (tree_verified && best_path_result.ok && best_path_smpl) {
-                                    accepted_tree = std::move(best_path_result.accepted);
-                                    slot.smpl = std::move(best_path_smpl);
-                                    used_tree_verify = true;
+                                if (trace > 0) {
+                                    SLT_INF(slot, "accepted %2zu/%2zu draft tokens (tree inline)\n", accepted_tree.size() - 1, n_draft);
                                 }
                             }
                         }
+
+                        mtp_tree_inline_clear_context(slot.ctx_tgt, slot.spec_tree_inline);
                         nvtxRangePop();
                     }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -210,12 +210,68 @@ static bool mtp_tree_verify_paths(
     best_path_index = 0;
 
     LOG_DBG("mtp_tree_verify_paths: restore and batch verify %zu/%zu candidates\n", n_candidates, paths.size());
-    common_sampler_ptr replay_smpl;
+    if (kv_needs_restore) {
+        ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
+        kv_needs_restore = false;
+    }
+    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
+        LOG_DBG("mtp_tree_verify_paths: source seq trim failed (pos_max=%d)\n", (int) ckpt.pos_max);
+        nvtxRangePop();
+        return false;
+    }
 
-    for (size_t i = 0; i < paths.size() && i < n_candidates; ++i) {
+    size_t total_tokens = 0;
+    size_t n_paths_pre = 0;
+    for (size_t i = 0; i < paths.size() && n_paths_pre < n_candidates; ++i) {
+        if (paths[i].tokens.empty()) {
+            continue;
+        }
+        total_tokens += 1 + paths[i].tokens.size();
+        ++n_paths_pre;
+    }
+
+    llama_batch batch = llama_batch_init((int32_t) std::max(total_tokens, (size_t) 1), 0, llama_n_seq_max(ctx_tgt));
+    if (batch.n_tokens < 0) {
+        LOG_DBG("mtp_tree_verify_paths: batch_init failed\n");
+        nvtxRangePop();
+        return false;
+    }
+
+    struct batched_path {
+        size_t path_index = 0;
+        llama_seq_id seq_id = -1;
+        size_t batch_offset = 0;
+    };
+
+    std::vector<batched_path> active;
+    std::vector<common_sampler_ptr> samplers;
+    active.reserve(n_candidates);
+    samplers.reserve(n_candidates);
+
+    size_t seq_id_probe = 0;
+    for (size_t i = 0; i < paths.size() && active.size() < n_candidates; ++i) {
         const auto & path = paths[i];
         if (path.tokens.empty()) {
             continue;
+        }
+
+        while ((llama_seq_id) seq_id_probe == seq_id) {
+            ++seq_id_probe;
+        }
+        if (seq_id_probe >= (size_t) llama_n_seq_max(ctx_tgt)) {
+            break;
+        }
+
+        const llama_seq_id seq = (llama_seq_id) seq_id_probe;
+        ++seq_id_probe;
+
+        common_context_seq_rm(ctx_tgt, seq, -1, -1);
+        common_context_seq_cp(ctx_tgt, seq_id, seq, 0, -1);
+
+        const size_t n_offset = (size_t) batch.n_tokens;
+        common_batch_add(batch, root, start_pos, { seq }, true);
+        for (size_t j = 0; j < path.tokens.size(); ++j) {
+            common_batch_add(batch, path.tokens[j], start_pos + (int32_t) j + 1, { seq }, true);
         }
 
         common_sampler_ptr path_smpl(common_sampler_clone(smpl));
@@ -225,49 +281,86 @@ static bool mtp_tree_verify_paths(
             continue;
         }
 
-        mtp_tree_verify_result path_result;
-        if (!mtp_tree_verify_path(ctx_tgt, ckpt, ckpt_flags, seq_id, start_pos, root, path, path_smpl.get(), path_result)) {
-            LOG_DBG("mtp_tree_verify_paths: path verify failed for path=%zu\n", i);
+        active.push_back({ i, seq, n_offset });
+        samplers.push_back(std::move(path_smpl));
+    }
+
+    if (active.empty()) {
+        llama_batch_free(batch);
+        LOG_DBG("mtp_tree_verify_paths: no active candidates\n");
+        nvtxRangePop();
+        return false;
+    }
+
+    const int rc = llama_decode(ctx_tgt, batch);
+    llama_batch_free(batch);
+    if (rc != 0) {
+        LOG_DBG("mtp_tree_verify_paths: decode failed (rc=%d)\n", rc);
+        nvtxRangePop();
+        return false;
+    }
+
+    for (size_t i = 0; i < active.size(); ++i) {
+        const auto & info = active[i];
+        const auto & path = paths[info.path_index];
+        auto & result = results[info.path_index];
+        auto & smpl_path = samplers[i];
+
+        const int base_pos = (int) info.batch_offset;
+        for (size_t j = 0; j < path.tokens.size(); ++j) {
+            const int sample_pos = base_pos + (int) j;
+            const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
+            common_sampler_accept(smpl_path.get(), id, true);
+            result.accepted.push_back(id);
+
+            if (id != path.tokens[j]) {
+                break;
+            }
+        }
+
+        if (!result.accepted.empty() && result.accepted.size() == path.tokens.size()) {
+            const int sample_pos = base_pos + (int) path.tokens.size();
+            const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
+            common_sampler_accept(smpl_path.get(), id, true);
+            result.accepted.push_back(id);
+        }
+
+        if (!result.accepted.empty()) {
+            result.ok = true;
+            result.n_accept = result.accepted.size() - 1;
+        }
+
+        if (!result.ok) {
             continue;
         }
 
-        auto & result = results[i];
-        result.ok = path_result.ok;
-        result.accepted = std::move(path_result.accepted);
-        result.n_accept = result.accepted.empty() ? 0 : result.accepted.size() - 1;
-
-        if (result.ok &&
-                (result.n_accept > best_result.n_accept ||
-                 (result.n_accept == best_result.n_accept && path.score > paths[best_path_index].score))) {
+        if (result.n_accept > best_result.n_accept ||
+                (result.n_accept == best_result.n_accept && path.score > paths[best_path_index].score)) {
             best_result = result;
-            best_path_index = i;
-            smpl_best = std::move(path_smpl);
+            best_path_index = info.path_index;
+            smpl_best = std::move(smpl_path);
         }
     }
 
     if (!best_result.ok) {
+        for (const auto & info : active) {
+            common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
+        }
         nvtxRangePop();
         return false;
     }
 
-    // Replay the winning path so the main sequence ends in the accepted state.
-    replay_smpl.reset(common_sampler_clone(smpl));
-    if (!replay_smpl) {
-        nvtxRangePop();
-        return false;
+    for (const auto & info : active) {
+        if (info.path_index == best_path_index) {
+            common_context_seq_cp(ctx_tgt, info.seq_id, seq_id, 0, -1);
+            break;
+        }
     }
 
-    mtp_tree_verify_result replay_result;
-    if (!mtp_tree_verify_path(ctx_tgt, ckpt, ckpt_flags, seq_id, start_pos, root, paths[best_path_index], replay_smpl.get(), replay_result)) {
-        nvtxRangePop();
-        return false;
+    for (const auto & info : active) {
+        common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
     }
 
-    best_result.ok = replay_result.ok;
-    best_result.accepted = std::move(replay_result.accepted);
-    best_result.n_accept = best_result.accepted.empty() ? 0 : best_result.accepted.size() - 1;
-
-    smpl_best = std::move(replay_smpl);
     results[best_path_index] = best_result;
     kv_needs_restore = false;
     nvtxRangePop();

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3710,6 +3710,7 @@ private:
                                 size_t best_accept = 0;
                                 float best_score = -1.0f;
                                 mtp_tree_candidate_path best_path;
+                                llama_tokens best_accepted;
 
                                 const llama_token root = slot.sampled;
                                 const int32_t tree_start_pos = slot.spec_ckpt.pos_max >= 0
@@ -3737,7 +3738,7 @@ private:
                                         best_accept = n_accept;
                                         best_score = path.score;
                                         best_path = path;
-                                        accepted_tree = std::move(result.accepted);
+                                        best_accepted = std::move(result.accepted);
                                         used_tree_verify = true;
                                     }
 
@@ -3747,25 +3748,7 @@ private:
                                 }
 
                                 if (used_tree_verify) {
-                                    mtp_tree_verify_result result;
-                                    common_sampler_ptr smpl_tree(common_sampler_clone(smpl_save.get()));
-
-                                    if (!mtp_tree_verify_path(
-                                            slot.ctx_tgt,
-                                            slot.spec_ckpt,
-                                            spec_ckpt_flags,
-                                            slot.id,
-                                            tree_start_pos,
-                                            root,
-                                            best_path,
-                                            smpl_tree.get(),
-                                            result) || result.accepted.empty()) {
-                                        used_tree_verify = false;
-                                        accepted_tree.clear();
-                                    } else {
-                                        accepted_tree = std::move(result.accepted);
-                                        slot.smpl = std::move(smpl_tree);
-                                    }
+                                    accepted_tree = std::move(best_accepted);
                                 }
                             }
                         }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3710,7 +3710,6 @@ private:
                                 size_t best_accept = 0;
                                 float best_score = -1.0f;
                                 mtp_tree_candidate_path best_path;
-                                llama_tokens best_accepted;
 
                                 const llama_token root = slot.sampled;
                                 const int32_t tree_start_pos = slot.spec_ckpt.pos_max >= 0
@@ -3738,7 +3737,7 @@ private:
                                         best_accept = n_accept;
                                         best_score = path.score;
                                         best_path = path;
-                                        best_accepted = std::move(result.accepted);
+                                        accepted_tree = std::move(result.accepted);
                                         used_tree_verify = true;
                                     }
 
@@ -3748,7 +3747,25 @@ private:
                                 }
 
                                 if (used_tree_verify) {
-                                    accepted_tree = std::move(best_accepted);
+                                    mtp_tree_verify_result result;
+                                    common_sampler_ptr smpl_tree(common_sampler_clone(smpl_save.get()));
+
+                                    if (!mtp_tree_verify_path(
+                                            slot.ctx_tgt,
+                                            slot.spec_ckpt,
+                                            spec_ckpt_flags,
+                                            slot.id,
+                                            tree_start_pos,
+                                            root,
+                                            best_path,
+                                            smpl_tree.get(),
+                                            result) || result.accepted.empty()) {
+                                        used_tree_verify = false;
+                                        accepted_tree.clear();
+                                    } else {
+                                        accepted_tree = std::move(result.accepted);
+                                        slot.smpl = std::move(smpl_tree);
+                                    }
                                 }
                             }
                         }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -66,6 +66,20 @@ static uint32_t server_n_outputs_max(const common_params & params) {
     return std::max<uint32_t>(1, std::min<uint64_t>(n_batch, n_outputs));
 }
 
+static int32_t server_target_n_seq_max(const common_params & params) {
+    const bool spec_mtp = std::find(params.speculative.types.begin(), params.speculative.types.end(),
+                                    COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params.speculative.types.end()
+                       || std::find(params.speculative.types.begin(), params.speculative.types.end(),
+                                    COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params.speculative.types.end();
+    if (!spec_mtp || !params.speculative.draft.use_mtp_tree || !params.kv_unified) {
+        return params.n_parallel;
+    }
+
+    const int32_t tree_nodes = std::max(1, params.speculative.draft.mtp_tree_nodes);
+    const int32_t extra_verify_seq = std::min<int32_t>(2, std::max(0, tree_nodes - params.n_parallel));
+    return params.n_parallel + extra_verify_seq;
+}
+
 struct mtp_tree_candidate_path {
     llama_tokens tokens;
     float score = 0.0f;
@@ -1070,6 +1084,7 @@ private:
     // use server_context methods instead
 
     common_params params_base;
+    int32_t n_slots_user = 0;
 
     // note: keep these alive - they determine the lifetime of the model, context, etc.
     common_init_result_ptr llama_init;
@@ -1155,7 +1170,11 @@ private:
         SRV_INF("loading model '%s'\n", params.model.path.c_str());
 
         params_base = params;
+        n_slots_user = params_base.n_parallel;
         params_base.n_outputs_max = server_n_outputs_max(params_base);
+        const int32_t n_seq_max_tgt = server_target_n_seq_max(params_base);
+        common_params params_tgt = params_base;
+        params_tgt.n_parallel = n_seq_max_tgt;
 
         std::string & mmproj_path = params_base.mmproj.path;
         bool has_mmproj = !mmproj_path.empty();
@@ -1224,7 +1243,7 @@ private:
                     measure_model_bytes = false;
                 }
 
-                params_dft.n_outputs_max = params_base.n_parallel;
+                params_dft.n_outputs_max = n_slots_user;
 
                 auto mparams_dft = common_model_params_to_llama(params_dft);
                 auto cparams_dft = common_context_params_to_llama(params_dft);
@@ -1291,7 +1310,12 @@ private:
             }
         }
 
-        llama_init = common_init_from_params(params_base);
+        if (n_seq_max_tgt != n_slots_user) {
+            SRV_INF("reserving %d target sequences for MTP tree verification (user slots = %d)\n",
+                    n_seq_max_tgt, n_slots_user);
+        }
+
+        llama_init = common_init_from_params(params_tgt);
 
         model_tgt = llama_init->model();
         ctx_tgt   = llama_init->context();
@@ -1403,7 +1427,7 @@ private:
             cparams_mtp.type_k        = params_base.cache_type_k;
             cparams_mtp.type_v        = params_base.cache_type_v;
             cparams_mtp.n_rs_seq      = 0;
-            cparams_mtp.n_outputs_max = params_base.n_parallel;
+            cparams_mtp.n_outputs_max = n_slots_user;
             cparams_mtp.ctx_other = ctx_tgt;
 
             ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams_mtp));
@@ -1464,7 +1488,7 @@ private:
         slot_prompt_similarity = params_base.slot_prompt_similarity;
 
         // setup slots
-        SRV_INF("initializing slots, n_slots = %d\n", params_base.n_parallel);
+        SRV_INF("initializing slots, n_slots = %d\n", n_slots_user);
 
         const int n_ctx_train = llama_model_n_ctx_train(model_tgt);
 
@@ -1486,14 +1510,14 @@ private:
         }
 
         // initialize slots
-        for (int i = 0; i < params_base.n_parallel; i++) {
+        for (int i = 0; i < n_slots_user; i++) {
             slots.emplace_back();
         }
 
         // try speculative decoding
         if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             try {
-                spec.reset(common_speculative_init(params_base.speculative, params_base.n_parallel));
+                spec.reset(common_speculative_init(params_base.speculative, n_slots_user));
             } catch (const std::exception & e) {
                 SRV_ERR("failed to initialize speculative decoding context: %s\n", e.what());
             }
@@ -1509,7 +1533,7 @@ private:
             ctx_dft.reset();
         }
 
-        for (int i = 0; i < params_base.n_parallel; i++) {
+        for (int i = 0; i < n_slots_user; i++) {
             server_slot & slot = slots[i];
 
             slot.id      = i;
@@ -1552,7 +1576,7 @@ private:
         // note that n_batch can be > n_ctx (e.g. for non-causal attention models such as BERT where the KV cache is not used)
         {
             const int32_t n_batch = llama_n_batch(ctx_tgt);
-            batch = llama_batch_init(std::max(n_batch, params_base.n_parallel), 0, 1);
+            batch = llama_batch_init(std::max(n_batch, n_slots_user), 0, 1);
         }
 
         if (params_base.cache_ram_mib != 0) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1204,7 +1204,6 @@ private:
 
         params_base = params;
         params_base.n_outputs_max = server_n_outputs_max(params_base);
-        common_params params_tgt = params_base;
 
         std::string & mmproj_path = params_base.mmproj.path;
         bool has_mmproj = !mmproj_path.empty();
@@ -1340,7 +1339,7 @@ private:
             }
         }
 
-        llama_init = common_init_from_params(params_tgt);
+        llama_init = common_init_from_params(params_base);
 
         model_tgt = llama_init->model();
         ctx_tgt   = llama_init->context();

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3976,11 +3976,12 @@ private:
                     llama_tokens accepted_tree;
 
                     const bool can_use_tree = params_base.speculative.draft.use_mtp_tree
+                        && params_base.speculative.draft.mtp_tree_target_verify
                         && use_ckpt_tgt
                         && !slot.spec_ckpt.empty()
-                        && mtp_tree_candidate_slots_available(slot.ctx_tgt) > 0;
+                        && mtp_tree_candidate_slots_available(slot.ctx_tgt) > 1;
 
-                    SLT_INF(slot, "can_use_tree: use_mtp=%d ckpt_tgt=%d ckpt_empty=%d cand_slots=%zu n_seq=%d rm_type=%d n_draft=%d n_rs=%d\n", (int)params_base.speculative.draft.use_mtp_tree, (int)use_ckpt_tgt, (int)slot.spec_ckpt.empty(), mtp_tree_candidate_slots_available(slot.ctx_tgt), (int)llama_n_seq_max(slot.ctx_tgt), (int)ctx_tgt_seq_rm_type, (int)n_draft, (int)llama_n_rs_seq(slot.ctx_tgt));
+                    SLT_INF(slot, "can_use_tree: use_mtp=%d target_verify=%d ckpt_tgt=%d ckpt_empty=%d cand_slots=%zu n_seq=%d rm_type=%d n_draft=%d n_rs=%d\n", (int)params_base.speculative.draft.use_mtp_tree, (int)params_base.speculative.draft.mtp_tree_target_verify, (int)use_ckpt_tgt, (int)slot.spec_ckpt.empty(), mtp_tree_candidate_slots_available(slot.ctx_tgt), (int)llama_n_seq_max(slot.ctx_tgt), (int)ctx_tgt_seq_rm_type, (int)n_draft, (int)llama_n_rs_seq(slot.ctx_tgt));
                     if (can_use_tree) {
                         nvtxRangePushA("server:can_use_tree");
                         common_speculative_mtp_tree_plan mtp_tree;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -210,6 +210,7 @@ static bool mtp_tree_verify_paths(
     best_path_index = 0;
 
     LOG_DBG("mtp_tree_verify_paths: restore and batch verify %zu/%zu candidates\n", n_candidates, paths.size());
+    const int64_t t_verify_begin = ggml_time_us();
     if (kv_needs_restore) {
         ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
         kv_needs_restore = false;
@@ -248,6 +249,7 @@ static bool mtp_tree_verify_paths(
     active.reserve(n_candidates);
     samplers.reserve(n_candidates);
 
+    const int64_t t_prepare_begin = ggml_time_us();
     size_t seq_id_probe = 0;
     for (size_t i = 0; i < paths.size() && active.size() < n_candidates; ++i) {
         const auto & path = paths[i];
@@ -284,6 +286,7 @@ static bool mtp_tree_verify_paths(
         active.push_back({ i, seq, n_offset });
         samplers.push_back(std::move(path_smpl));
     }
+    const int64_t t_prepare_end = ggml_time_us();
 
     if (active.empty()) {
         llama_batch_free(batch);
@@ -292,7 +295,9 @@ static bool mtp_tree_verify_paths(
         return false;
     }
 
+    const int64_t t_decode_begin = ggml_time_us();
     const int rc = llama_decode(ctx_tgt, batch);
+    const int64_t t_decode_end = ggml_time_us();
     llama_batch_free(batch);
     if (rc != 0) {
         LOG_DBG("mtp_tree_verify_paths: decode failed (rc=%d)\n", rc);
@@ -300,6 +305,7 @@ static bool mtp_tree_verify_paths(
         return false;
     }
 
+    const int64_t t_sample_begin = ggml_time_us();
     for (size_t i = 0; i < active.size(); ++i) {
         const auto & info = active[i];
         const auto & path = paths[info.path_index];
@@ -341,6 +347,7 @@ static bool mtp_tree_verify_paths(
             smpl_best = std::move(smpl_path);
         }
     }
+    const int64_t t_sample_end = ggml_time_us();
 
     if (!best_result.ok) {
         for (const auto & info : active) {
@@ -350,6 +357,7 @@ static bool mtp_tree_verify_paths(
         return false;
     }
 
+    const int64_t t_commit_begin = ggml_time_us();
     for (const auto & info : active) {
         if (info.path_index == best_path_index) {
             common_context_seq_cp(ctx_tgt, info.seq_id, seq_id, 0, -1);
@@ -360,9 +368,18 @@ static bool mtp_tree_verify_paths(
     for (const auto & info : active) {
         common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
     }
+    const int64_t t_commit_end = ggml_time_us();
 
     results[best_path_index] = best_result;
     kv_needs_restore = false;
+    LOG_INF("mtp_tree_verify_paths: n_candidates=%zu accepted=%zu prepare=%.3f decode=%.3f sample=%.3f commit=%.3f total=%.3f ms\n",
+            active.size(),
+            best_result.n_accept,
+            (t_prepare_end - t_prepare_begin) / 1000.0,
+            (t_decode_end - t_decode_begin) / 1000.0,
+            (t_sample_end - t_sample_begin) / 1000.0,
+            (t_commit_end - t_commit_begin) / 1000.0,
+            (t_commit_end - t_verify_begin) / 1000.0);
     nvtxRangePop();
     return true;
 }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -66,6 +66,155 @@ static uint32_t server_n_outputs_max(const common_params & params) {
     return std::max<uint32_t>(1, std::min<uint64_t>(n_batch, n_outputs));
 }
 
+struct mtp_tree_candidate_path {
+    llama_tokens tokens;
+    float score = 0.0f;
+};
+
+static bool mtp_tree_collect_candidates(
+        const common_speculative_mtp_tree_plan & plan,
+        size_t max_depth,
+        std::vector<mtp_tree_candidate_path> & paths) {
+    paths.clear();
+
+    if (plan.nodes.size() <= 1) {
+        return false;
+    }
+
+    for (size_t i = 1; i < plan.nodes.size(); ++i) {
+        const auto & node = plan.nodes[i];
+        if (node.depth <= 0 || node.depth > (int32_t) max_depth) {
+            continue;
+        }
+        if (node.parent < 0 || (size_t) node.parent >= plan.nodes.size()) {
+            continue;
+        }
+
+        llama_tokens tokens;
+        int32_t j = (int32_t) i;
+        while (j > 0 && (size_t) j < plan.nodes.size()) {
+            const auto & cur = plan.nodes[(size_t) j];
+            if (cur.depth <= 0) {
+                break;
+            }
+            tokens.push_back(cur.token);
+            j = cur.parent;
+        }
+
+        if (tokens.empty()) {
+            continue;
+        }
+
+        std::reverse(tokens.begin(), tokens.end());
+
+        paths.push_back({std::move(tokens), node.cum_prob});
+    }
+
+    if (paths.empty()) {
+        return false;
+    }
+
+    std::sort(paths.begin(), paths.end(), [](const mtp_tree_candidate_path & a, const mtp_tree_candidate_path & b) {
+        if (a.score != b.score) {
+            return a.score > b.score;
+        }
+        if (a.tokens.size() != b.tokens.size()) {
+            return a.tokens.size() > b.tokens.size();
+        }
+        return a.tokens < b.tokens;
+    });
+
+    return true;
+}
+
+struct mtp_tree_verify_result {
+    bool ok = false;
+    llama_tokens accepted;
+};
+
+static bool mtp_tree_seq_rm_with_fallback(
+        llama_context * ctx_tgt,
+        llama_seq_id seq_id,
+        llama_pos p0,
+        llama_pos p1) {
+    auto * mem = llama_get_memory(ctx_tgt);
+    if (mem == nullptr) {
+        return true;
+    }
+
+    if (llama_memory_seq_rm(mem, seq_id, p0, p1)) {
+        return true;
+    }
+
+    // The recurrent cache can reject large bounded rollbacks when asked to trim
+    // beyond the configured RS window. Fall back to trimming only the last token,
+    // which is enough to clear a stale pending row in this verification path.
+    const llama_pos pos_max = llama_memory_seq_pos_max(mem, seq_id);
+    if (p1 < 0 && pos_max >= 0 && p0 <= pos_max) {
+        return llama_memory_seq_rm(mem, seq_id, pos_max, -1);
+    }
+
+    return false;
+}
+
+static bool mtp_tree_verify_path(
+        llama_context * ctx_tgt,
+        const common_prompt_checkpoint & ckpt,
+        llama_state_seq_flags ckpt_flags,
+        llama_seq_id seq_id,
+        int32_t start_pos,
+        llama_token root,
+        const mtp_tree_candidate_path & path,
+        common_sampler * smpl,
+        mtp_tree_verify_result & result) {
+    if (!ctx_tgt || !smpl || path.tokens.empty()) {
+        return false;
+    }
+
+    ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
+    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
+        return false;
+    }
+
+    const int32_t n_tokens = (int32_t) path.tokens.size() + 1;
+    auto batch = llama_batch_init(n_tokens, 0, 1);
+    if (batch.n_tokens < 0) {
+        llama_batch_free(batch);
+        return false;
+    }
+
+    common_batch_add(batch, root, start_pos, { seq_id }, true);
+    for (int32_t i = 0; i < (int32_t) path.tokens.size(); ++i) {
+        common_batch_add(batch, path.tokens[(size_t) i], start_pos + i + 1, { seq_id }, true);
+    }
+
+    const int rc = llama_decode(ctx_tgt, batch);
+    llama_batch_free(batch);
+
+    if (rc != 0) {
+        return false;
+    }
+
+    result.accepted.clear();
+
+    for (size_t i = 0; i < path.tokens.size(); ++i) {
+        const llama_token id = common_sampler_sample(smpl, ctx_tgt, (int) i + 1, false);
+        common_sampler_accept(smpl, id, true);
+        result.accepted.push_back(id);
+
+        if (id != path.tokens[i]) {
+            result.ok = true;
+            return true;
+        }
+    }
+
+    const llama_token id = common_sampler_sample(smpl, ctx_tgt, (int) path.tokens.size(), false);
+    common_sampler_accept(smpl, id, true);
+    result.accepted.push_back(id);
+    result.ok = true;
+    return true;
+}
+
 static common_context_seq_rm_type server_seq_rm_type_for_startup(llama_context * ctx, bool warmup_enabled) {
     if (ctx == nullptr) {
         return COMMON_CONTEXT_SEQ_RM_TYPE_NO;
@@ -2665,7 +2814,9 @@ private:
                     ckpt.load_dft(ctx_dft.get(), slot.id, spec_ckpt_flags);
                 }
 
-                common_context_seq_rm(ctx_dft.get(), slot.id, ckpt.pos_max + 1, -1);
+                if (!mtp_tree_seq_rm_with_fallback(ctx_dft.get(), slot.id, ckpt.pos_max + 1, -1)) {
+                    SLT_WRN(slot, "failed to trim speculative draft rollback state (%d -> -1)\n", ckpt.pos_max + 1);
+                }
             }
 
             if (!draft.empty()) {
@@ -3532,25 +3683,116 @@ private:
                 GGML_ASSERT(n_draft > 0);
 
                 // verify and try to accept the draft
+                common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
                 {
                     // save the sampler sampler state in case we need to restore it
-                    common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
+                    const bool use_ckpt_tgt =
+                        ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+                       (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && n_draft > llama_n_rs_seq(ctx_tgt));
+
+                    bool used_tree_verify = false;
+                    llama_tokens accepted_tree;
+
+                    if (params_base.speculative.draft.use_mtp_tree && use_ckpt_tgt && !slot.spec_ckpt.empty()) {
+                        common_speculative_mtp_tree_plan mtp_tree;
+                        if (common_speculative_get_mtp_tree_plan(spec.get(), slot.id, mtp_tree)) {
+                            if (trace > 0) {
+                                SLT_DBG(slot,
+                                        "mtp-tree draft: nodes=%zu max_nodes=%zu max_depth=%zu p_split=%.4g\n",
+                                        mtp_tree.nodes.size(),
+                                        mtp_tree.max_nodes,
+                                        mtp_tree.max_depth,
+                                        (double) mtp_tree.p_split);
+                            }
+
+                            std::vector<mtp_tree_candidate_path> tree_paths;
+                            if (mtp_tree_collect_candidates(mtp_tree, n_draft, tree_paths)) {
+                                size_t best_accept = 0;
+                                float best_score = -1.0f;
+                                mtp_tree_candidate_path best_path;
+
+                                const llama_token root = slot.sampled;
+                                const int32_t tree_start_pos = slot.spec_ckpt.pos_max >= 0
+                                    ? (int32_t) slot.spec_ckpt.pos_max + 1
+                                    : (int32_t) slot.spec_ckpt.n_tokens;
+                                for (const auto & path : tree_paths) {
+                                    mtp_tree_verify_result result;
+                                    common_sampler_ptr smpl_tree(common_sampler_clone(smpl_save.get()));
+
+                                    if (!mtp_tree_verify_path(
+                                            slot.ctx_tgt,
+                                            slot.spec_ckpt,
+                                            spec_ckpt_flags,
+                                            slot.id,
+                                            tree_start_pos,
+                                            root,
+                                            path,
+                                            smpl_tree.get(),
+                                            result) || result.accepted.empty()) {
+                                        continue;
+                                    }
+
+                                    const size_t n_accept = result.accepted.size() - 1;
+                                    if (n_accept > best_accept || (n_accept == best_accept && path.score > best_score)) {
+                                        best_accept = n_accept;
+                                        best_score = path.score;
+                                        best_path = path;
+                                        accepted_tree = std::move(result.accepted);
+                                        used_tree_verify = true;
+                                    }
+
+                                    if (best_accept >= n_draft) {
+                                        break;
+                                    }
+                                }
+
+                                if (used_tree_verify) {
+                                    mtp_tree_verify_result result;
+                                    common_sampler_ptr smpl_tree(common_sampler_clone(smpl_save.get()));
+
+                                    if (!mtp_tree_verify_path(
+                                            slot.ctx_tgt,
+                                            slot.spec_ckpt,
+                                            spec_ckpt_flags,
+                                            slot.id,
+                                            tree_start_pos,
+                                            root,
+                                            best_path,
+                                            smpl_tree.get(),
+                                            result) || result.accepted.empty()) {
+                                        used_tree_verify = false;
+                                        accepted_tree.clear();
+                                    } else {
+                                        accepted_tree = std::move(result.accepted);
+                                        slot.smpl = std::move(smpl_tree);
+                                    }
+                                }
+                            }
+                        }
+                    }
 
                     GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
-                    auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
+                    llama_tokens accepted;
+                    if (used_tree_verify) {
+                        accepted = std::move(accepted_tree);
+                        if (trace > 0) {
+                            SLT_INF(slot, "accepted %2zu/%2zu draft tokens (tree)\n", accepted.size() - 1, n_draft);
+                        }
+                    } else {
+                        accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
+                        if (trace > 0) {
+                            SLT_INF(slot, "accepted %2zu/%2zu draft tokens\n", accepted.size() - 1, n_draft);
+                        }
+                    }
                     slot.spec_i_batch.clear();
 
                     GGML_ASSERT(accepted.size() >= 1);
 
                     const uint32_t n_rollback = slot.spec_draft.size() + 1 - accepted.size();
 
-                    const bool use_ckpt_tgt =
-                        ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-                       (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && n_rollback > llama_n_rs_seq(ctx_tgt));
-
                     // check for partial draft acceptance
                     if (n_rollback > 0) {
-                        if (use_ckpt_tgt) {
+                        if (use_ckpt_tgt && !used_tree_verify) {
                             if (trace > 0) {
                                 SLT_INF(slot, "accepted %2zu/%2zu draft tokens (restore checkpoint)\n", accepted.size() - 1, slot.spec_draft.size());
                             }
@@ -3565,13 +3807,20 @@ private:
                             {
                                 ckpt.load_tgt(slot.ctx_tgt, slot.id, spec_ckpt_flags);
 
-                                common_context_seq_rm(slot.ctx_tgt, slot.id, ckpt.pos_max + 1, -1);
+                                if (!mtp_tree_seq_rm_with_fallback(slot.ctx_tgt, slot.id, ckpt.pos_max + 1, -1)) {
+                                    slot.smpl = std::move(smpl_save);
+                                    accepted.clear();
+                                    slot.spec_draft.clear();
+                                    continue;
+                                }
                             }
 
                             if (slot.ctx_dft) {
                                 ckpt.load_dft(slot.ctx_dft, slot.id, spec_ckpt_flags);
 
-                                common_context_seq_rm(slot.ctx_dft, slot.id, ckpt.pos_max + 1, -1);
+                                if (!mtp_tree_seq_rm_with_fallback(slot.ctx_dft, slot.id, ckpt.pos_max + 1, -1)) {
+                                    SLT_WRN(slot, "failed to trim draft rollback state for dft (%d -> -1)\n", ckpt.pos_max + 1);
+                                }
                             }
 
                             slot.prompt.tokens.keep_first(ckpt.n_tokens);
@@ -3606,9 +3855,18 @@ private:
                 slot.sampled = ids.back(); // last accepted token
                 SLT_DBG(slot, "add accepted tokens: sampled=%d, ids.size=%zu, n_draft=%zu\n", slot.sampled, ids.size(), n_draft);
 
-                common_context_seq_rm(slot.ctx_tgt, slot.id, slot.prompt.tokens.pos_next(), -1);
+                if (!mtp_tree_seq_rm_with_fallback(slot.ctx_tgt, slot.id, slot.prompt.tokens.pos_next(), -1)) {
+                    slot.prompt.tokens.keep_first(slot.prompt.n_tokens() - ids.size());
+                    slot.n_draft_accepted -= ids.size() - 1;
+                    slot.sampled = slot.prompt.tokens.get_tokens().back();
+                    slot.smpl = std::move(smpl_save);
+                    slot.spec_draft = {};
+                    continue;
+                }
                 if (slot.ctx_dft) {
-                    common_context_seq_rm(slot.ctx_dft, slot.id, slot.prompt.tokens.pos_next(), -1);
+                    if (!mtp_tree_seq_rm_with_fallback(slot.ctx_dft, slot.id, slot.prompt.tokens.pos_next(), -1)) {
+                        SLT_WRN(slot, "failed to trim draft rollback state for dft (%d -> -1)\n", (int) slot.prompt.tokens.pos_next());
+                    }
                 }
 
                 for (size_t i = 0; i < ids.size(); ++i) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -195,6 +195,136 @@ struct mtp_tree_inline_state {
     }
 };
 
+struct mtp_tree_cost_state {
+    double linear_tps_ema = 0.0;
+    double tree_tps_ema   = 0.0;
+
+    int32_t requests_seen = 0;
+    int32_t cooldown_left = 0;
+    int32_t requests_since_tree = 0;
+
+    bool request_decided = false;
+    bool request_use_tree = false;
+    bool request_used_tree = false;
+
+    int32_t request_tree_rounds = 0;
+    int32_t request_tree_accepted = 0;
+    int32_t request_tree_generated = 0;
+
+    float min_gain = 1.05f;
+    float min_tps = 0.0f;
+    int32_t warmup = 3;
+    int32_t cooldown = 8;
+
+    static double ema_update(double old_value, double value) {
+        constexpr double alpha = 0.25;
+        return old_value <= 0.0 ? value : old_value * (1.0 - alpha) + value * alpha;
+    }
+
+    void reset_request() {
+        request_decided = false;
+        request_use_tree = false;
+        request_used_tree = false;
+        request_tree_rounds = 0;
+        request_tree_accepted = 0;
+        request_tree_generated = 0;
+    }
+
+    bool should_use_tree(const common_params_speculative_draft & params) {
+        min_gain = params.mtp_tree_cost_min_gain;
+        min_tps = params.mtp_tree_cost_min_tps;
+        warmup = params.mtp_tree_cost_warmup;
+        cooldown = params.mtp_tree_cost_cooldown;
+
+        if (!params.mtp_tree_cost_aware) {
+            request_decided = true;
+            request_use_tree = true;
+            return true;
+        }
+
+        if (request_decided) {
+            return request_use_tree;
+        }
+
+        request_decided = true;
+        request_use_tree = false;
+
+        if (cooldown_left > 0) {
+            return false;
+        }
+
+        if (requests_seen < warmup) {
+            return false;
+        }
+
+        if (linear_tps_ema <= 0.0 || tree_tps_ema <= 0.0) {
+            request_use_tree = true;
+            return true;
+        }
+
+        const double required_gain = std::max(1.0f, min_gain);
+        if (tree_tps_ema >= linear_tps_ema * required_gain) {
+            request_use_tree = true;
+            return true;
+        }
+
+        if (requests_since_tree >= cooldown) {
+            request_use_tree = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    void record_tree_round(int32_t n_accepted, int32_t n_generated) {
+        request_used_tree = true;
+        request_tree_rounds++;
+        request_tree_accepted += std::max(0, n_accepted);
+        request_tree_generated += std::max(0, n_generated);
+    }
+
+    void record_tree_attempt() {
+        request_used_tree = true;
+    }
+
+    bool finish_request(
+            int32_t n_decoded,
+            double t_token_generation_ms) {
+        if (n_decoded <= 0 || t_token_generation_ms <= 0.0) {
+            reset_request();
+            return false;
+        }
+
+        const double tps = 1e3 * n_decoded / t_token_generation_ms;
+        bool disabled_tree = false;
+
+        if (request_used_tree) {
+            tree_tps_ema = ema_update(tree_tps_ema, tps);
+            requests_since_tree = 0;
+
+            const bool below_absolute = min_tps > 0.0f && tps < min_tps;
+            const bool below_linear =
+                linear_tps_ema > 0.0 &&
+                tree_tps_ema < linear_tps_ema * std::max(1.0f, min_gain);
+
+            if (below_absolute || below_linear) {
+                cooldown_left = cooldown;
+                disabled_tree = true;
+            }
+        } else {
+            linear_tps_ema = ema_update(linear_tps_ema, tps);
+            requests_since_tree++;
+            if (cooldown_left > 0) {
+                cooldown_left--;
+            }
+        }
+
+        requests_seen++;
+        reset_request();
+        return disabled_tree;
+    }
+};
+
 static size_t mtp_tree_candidate_slots_available(llama_context * ctx_tgt) {
     const int32_t n_seq_max = llama_n_seq_max(ctx_tgt);
     if (n_seq_max <= 1) {
@@ -656,6 +786,8 @@ struct server_slot {
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
     mtp_tree_inline_state spec_tree_inline;
+    mtp_tree_cost_state spec_tree_cost;
+    mtp_tree_cost_state * spec_tree_cost_shared = nullptr;
     bool kv_needs_restore = false; // reset by ckpt.update_tgt() before each draft round; guards load_tgt in mtp_tree_verify_paths
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
@@ -888,6 +1020,10 @@ struct server_slot {
         return !!spec;
     }
 
+    mtp_tree_cost_state & tree_cost() {
+        return spec_tree_cost_shared ? *spec_tree_cost_shared : spec_tree_cost;
+    }
+
     void add_token(const completion_token_output & token) {
         if (!is_processing()) {
             SLT_WRN(*this, "%s", "slot is not processing\n");
@@ -929,6 +1065,9 @@ struct server_slot {
             return false;
         }
         if (!draft_params.use_mtp_tree || !draft_params.mtp_tree_target_verify) {
+            return false;
+        }
+        if (!tree_cost().should_use_tree(draft_params)) {
             return false;
         }
 
@@ -1050,8 +1189,42 @@ struct server_slot {
 
             t_last_used        =  ggml_time_us();
             t_token_generation = (ggml_time_us() - t_start_generation) / 1e3;
+            bool clear_after_cost_probe = false;
+            if (can_speculate()) {
+                auto & cost = tree_cost();
+                const bool had_tree = cost.request_used_tree;
+                const int32_t n_tree_rounds = cost.request_tree_rounds;
+                const int32_t n_tree_accepted = cost.request_tree_accepted;
+                const int32_t n_tree_generated = cost.request_tree_generated;
+                const bool disabled_tree = cost.finish_request(n_decoded, t_token_generation);
+                if (disabled_tree) {
+                    const double tps = n_decoded > 0 && t_token_generation > 0.0 ? 1e3 * n_decoded / t_token_generation : 0.0;
+                    SLT_INF(*this,
+                            "cost-aware MTP tree disabled: tps=%.2f, linear_ema=%.2f, tree_ema=%.2f, tree_rounds=%d, tree_accept=%d/%d, cooldown=%d\n",
+                            tps,
+                            cost.linear_tps_ema,
+                            cost.tree_tps_ema,
+                            n_tree_rounds,
+                            n_tree_accepted,
+                            n_tree_generated,
+                            cost.cooldown_left);
+                    clear_after_cost_probe = true;
+                } else if (had_tree) {
+                    SLT_DBG(*this,
+                            "cost-aware MTP tree kept: linear_ema=%.2f, tree_ema=%.2f, tree_rounds=%d, tree_accept=%d/%d\n",
+                            cost.linear_tps_ema,
+                            cost.tree_tps_ema,
+                            n_tree_rounds,
+                            n_tree_accepted,
+                            n_tree_generated);
+                }
+            }
 
             state = SLOT_STATE_IDLE;
+
+            if (clear_after_cost_probe) {
+                prompt_clear(false);
+            }
 
             // do not keep context of the child slots - the parent's context is enough
             if (task->is_child()) {
@@ -1360,6 +1533,7 @@ private:
     common_context_seq_rm_type ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
 
     common_speculative_ptr spec;
+    mtp_tree_cost_state spec_tree_cost;
 
     bool add_bos_token = true;
 
@@ -1792,6 +1966,7 @@ private:
             slot.ctx_tgt = ctx_tgt;
             slot.ctx_dft = ctx_dft.get();
             slot.spec    = spec.get();
+            slot.spec_tree_cost_shared = &spec_tree_cost;
             slot.n_ctx   = n_ctx_slot;
 
             slot.mctx                   = mctx;
@@ -3260,6 +3435,13 @@ private:
 
                         slot.spec_prompt = slot.prompt.tokens.get_text_tokens();
 
+                        const bool mtp_tree_enabled =
+                            params_base.speculative.draft.use_mtp_tree &&
+                            slot.tree_cost().should_use_tree(params_base.speculative.draft);
+                        if (mtp_tree_enabled) {
+                            slot.tree_cost().record_tree_attempt();
+                        }
+
                         common_speculative_get_draft_params(spec.get(), slot.id) = {
                             /* .drafting = */ true,
                             /* .n_max    = */ n_draft_max,
@@ -3267,9 +3449,10 @@ private:
                             /* .id_last  = */ slot.sampled,
                             /* .prompt   = */ &slot.spec_prompt,
                             /* .result   = */ &slot.spec_draft,
+                            /* .mtp_tree_enabled = */ mtp_tree_enabled,
                         };
 
-                        if (spec != nullptr && params_base.speculative.draft.use_mtp_tree) {
+                        if (spec != nullptr && mtp_tree_enabled) {
                             common_speculative_sync_draft_sampler(spec.get(), slot.id, slot.smpl.get());
                         }
 
@@ -4188,6 +4371,7 @@ private:
 
                     if (!slot.spec_tree_inline.empty()) {
                         nvtxRangePushA("server:mtp_tree_inline_accept");
+                        size_t n_tree_accepted = 0;
 
                         llama_seq_id best_seq_id = -1;
                         size_t best_path_index = 0;
@@ -4208,6 +4392,7 @@ private:
                                 slot.smpl = std::move(best_path_smpl);
                                 slot.kv_needs_restore = false;
                                 used_tree_verify = true;
+                                n_tree_accepted = accepted_tree.size() > 0 ? accepted_tree.size() - 1 : 0;
 
                                 if (trace > 0) {
                                     SLT_INF(slot, "accepted %2zu/%2zu draft tokens (tree inline)\n", accepted_tree.size() - 1, n_draft);
@@ -4215,6 +4400,7 @@ private:
                             }
                         }
 
+                        slot.tree_cost().record_tree_round((int32_t) n_tree_accepted, (int32_t) n_draft);
                         mtp_tree_inline_clear_context(slot.ctx_tgt, slot.spec_tree_inline);
                         nvtxRangePop();
                     }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -154,6 +154,17 @@ static bool mtp_tree_seq_rm_with_fallback(
         llama_pos p0,
         llama_pos p1);
 
+static bool mtp_tree_verify_path(
+        llama_context * ctx_tgt,
+        const common_prompt_checkpoint & ckpt,
+        llama_state_seq_flags ckpt_flags,
+        llama_seq_id seq_id,
+        int32_t start_pos,
+        llama_token root,
+        const mtp_tree_candidate_path & path,
+        common_sampler * smpl,
+        mtp_tree_verify_result & result);
+
 struct mtp_tree_verify_paths_result {
     size_t n_accept = 0;
     llama_tokens accepted;
@@ -199,165 +210,66 @@ static bool mtp_tree_verify_paths(
     best_path_index = 0;
 
     LOG_DBG("mtp_tree_verify_paths: restore and batch verify %zu/%zu candidates\n", n_candidates, paths.size());
+    common_sampler_ptr replay_smpl;
 
-    if (kv_needs_restore) {
-        ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
-        kv_needs_restore = false;
-    }
-    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
-        LOG_DBG("mtp_tree_verify_paths: source seq trim failed (pos_max=%d)\n", (int)ckpt.pos_max);
-        return false;
-    }
-
-    // pre-compute total tokens for the batch to avoid assertion failure (batch does not auto-resize)
-    // keep in sync with build loop below
-    size_t total_tokens = 0;
-    size_t n_paths_pre = 0;
-    for (size_t i = 0; i < paths.size() && n_paths_pre < n_candidates; ++i) {
-        if (paths[i].tokens.empty()) {
-            continue;
-        }
-        total_tokens += 1 + paths[i].tokens.size();
-        ++n_paths_pre;
-    }
-
-    llama_batch batch = llama_batch_init((int32_t) std::max(total_tokens, (size_t) 1), 0, llama_n_seq_max(ctx_tgt));
-    if (batch.n_tokens < 0) {
-        llama_batch_free(batch);
-        LOG_DBG("mtp_tree_verify_paths: batch_init failed\n");
-        return false;
-    }
-
-    struct batched_path {
-        size_t path_index = 0;
-        llama_seq_id seq_id = -1;
-        size_t batch_offset = 0;
-    };
-    std::vector<batched_path> active;
-    std::vector<common_sampler_ptr> samplers;
-    active.reserve(n_candidates);
-    samplers.reserve(n_candidates);
-
-    // Build dedicated temp sequences for each candidate and run one decode on a
-    // single combined batch containing all candidate tokens.
-    size_t seq_id_probe = 0;
-    for (size_t i = 0; i < paths.size() && active.size() < n_candidates; ++i) {
+    for (size_t i = 0; i < paths.size() && i < n_candidates; ++i) {
         const auto & path = paths[i];
         if (path.tokens.empty()) {
             continue;
         }
 
-        while ((llama_seq_id) seq_id_probe == seq_id) {
-            ++seq_id_probe;
-        }
-        if (seq_id_probe >= (size_t) llama_n_seq_max(ctx_tgt)) {
-            break;
-        }
-
-        const llama_seq_id seq = (llama_seq_id) seq_id_probe;
-        ++seq_id_probe;
-
-        common_context_seq_rm(ctx_tgt, seq, -1, -1);
-        // seq_cp requires copying from position 0 (is_full assert in KV cache);
-        common_context_seq_cp(ctx_tgt, seq_id, seq, 0, -1);
-        // prefix trim disabled: investigate ckpt.pos_min effect on GX10 logits
-
-        const size_t n_offset = (size_t) batch.n_tokens;
-
-        common_batch_add(batch, root, start_pos, {seq}, true);
-        for (size_t j = 0; j < path.tokens.size(); ++j) {
-            common_batch_add(batch, path.tokens[j], start_pos + (int32_t)j + 1, {seq}, true);
-        }
-
-        batched_path info;
-        info.path_index = i;
-        info.seq_id = seq;
-        info.batch_offset = n_offset;
-        active.push_back(info);
-        samplers.push_back(common_sampler_ptr(common_sampler_clone(smpl)));
-        if (!samplers.back()) {
+        common_sampler_ptr path_smpl(common_sampler_clone(smpl));
+        if (!path_smpl) {
             LOG_DBG("mtp_tree_verify_paths: sampler clone failed for path=%zu\n", i);
             results[i].ok = false;
-            active.pop_back();
-            samplers.pop_back();
-            continue;
-        }
-    }
-
-    if (active.empty()) {
-        llama_batch_free(batch);
-        LOG_DBG("mtp_tree_verify_paths: no active candidates\n");
-        return false;
-    }
-
-    const int rc = llama_decode(ctx_tgt, batch);
-    if (rc != 0) {
-        LOG_DBG("mtp_tree_verify_paths: decode failed (rc=%d)\n", rc);
-        llama_batch_free(batch);
-        return false;
-    }
-
-    for (size_t i = 0; i < active.size(); ++i) {
-        const auto & info = active[i];
-        const auto & path = paths[info.path_index];
-        auto & result = results[info.path_index];
-        auto & smpl_path = samplers[i];
-
-        const int base_pos = (int) info.batch_offset;
-        fprintf(stderr, "mtp-tree-verify: path[%zu] seq=%d expecting %zu tokens: ", info.path_index, (int)info.seq_id, path.tokens.size());
-        for (size_t k = 0; k < path.tokens.size(); ++k) { fprintf(stderr, "%d ", path.tokens[k]); }
-        fprintf(stderr, "\n");
-        for (size_t j = 0; j < path.tokens.size(); ++j) {
-            const int sample_pos = base_pos + (int) j;
-            const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
-            common_sampler_accept(smpl_path.get(), id, true);
-            result.accepted.push_back(id);
-
-            if (id != path.tokens[j]) {
-                fprintf(stderr, "mtp-tree-verify: MISMATCH path[%zu] pos=%zu expected=%d got=%d\n", info.path_index, j+1, path.tokens[j], id);
-                break;
-            }
-        }
-
-        if (!result.accepted.empty() && result.accepted.size() == path.tokens.size()) {
-            const int sample_pos = base_pos + (int) path.tokens.size();
-            const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
-            common_sampler_accept(smpl_path.get(), id, true);
-            result.accepted.push_back(id);
-        }
-
-        if (!result.accepted.empty()) {
-            result.ok = true;
-            result.n_accept = result.accepted.size() - 1;
-        }
-
-        if (!result.ok) {
             continue;
         }
 
-        if (result.n_accept > best_result.n_accept || (result.n_accept == best_result.n_accept && path.score > paths[best_path_index].score)) {
+        mtp_tree_verify_result path_result;
+        if (!mtp_tree_verify_path(ctx_tgt, ckpt, ckpt_flags, seq_id, start_pos, root, path, path_smpl.get(), path_result)) {
+            LOG_DBG("mtp_tree_verify_paths: path verify failed for path=%zu\n", i);
+            continue;
+        }
+
+        auto & result = results[i];
+        result.ok = path_result.ok;
+        result.accepted = std::move(path_result.accepted);
+        result.n_accept = result.accepted.empty() ? 0 : result.accepted.size() - 1;
+
+        if (result.ok &&
+                (result.n_accept > best_result.n_accept ||
+                 (result.n_accept == best_result.n_accept && path.score > paths[best_path_index].score))) {
             best_result = result;
-            best_path_index = info.path_index;
-            smpl_best = std::move(smpl_path);
+            best_path_index = i;
+            smpl_best = std::move(path_smpl);
         }
     }
 
-    // Copy best temp sequence KV back to the main sequence before cleanup,
-    // so the accepted tokens survive in the main KV cache.
-    if (best_result.ok) {
-        for (const auto & info : active) {
-            if (info.path_index == best_path_index) {
-                common_context_seq_cp(ctx_tgt, info.seq_id, seq_id, 0, -1);
-                break;
-            }
-        }
+    if (!best_result.ok) {
+        nvtxRangePop();
+        return false;
     }
 
-    // Clear temporary sequences.
-    for (const auto & info : active) {
-        common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
+    // Replay the winning path so the main sequence ends in the accepted state.
+    replay_smpl.reset(common_sampler_clone(smpl));
+    if (!replay_smpl) {
+        nvtxRangePop();
+        return false;
     }
-    llama_batch_free(batch);
+
+    mtp_tree_verify_result replay_result;
+    if (!mtp_tree_verify_path(ctx_tgt, ckpt, ckpt_flags, seq_id, start_pos, root, paths[best_path_index], replay_smpl.get(), replay_result)) {
+        nvtxRangePop();
+        return false;
+    }
+
+    best_result.ok = replay_result.ok;
+    best_result.accepted = std::move(replay_result.accepted);
+    best_result.n_accept = best_result.accepted.empty() ? 0 : best_result.accepted.size() - 1;
+
+    smpl_best = std::move(replay_smpl);
+    results[best_path_index] = best_result;
+    kv_needs_restore = false;
     nvtxRangePop();
     return true;
 }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -77,7 +77,7 @@ static bool mtp_tree_collect_candidates(
         std::vector<mtp_tree_candidate_path> & paths) {
     paths.clear();
 
-    LOG_INF("mtp_tree_collect_candidates: plan.nodes.size()=%zu max_depth=%zu\n", plan.nodes.size(), max_depth);
+    LOG_DBG("mtp_tree_collect_candidates: plan.nodes.size()=%zu max_depth=%zu\n", plan.nodes.size(), max_depth);
 
     if (plan.nodes.size() <= 1) {
         return false;
@@ -109,7 +109,7 @@ static bool mtp_tree_collect_candidates(
 
         std::reverse(tokens.begin(), tokens.end());
 
-        LOG_INF("mtp_tree_collect_candidates: path[%zu] tokens=%zu score=%.4f first_token=%d\n", 
+        LOG_DBG("mtp_tree_collect_candidates: path[%zu] tokens=%zu score=%.4f first_token=%d\n",
                 paths.size(), tokens.size(), (double)node.cum_prob, (int)tokens[0]);
 
         paths.push_back({std::move(tokens), node.cum_prob});
@@ -136,6 +136,190 @@ struct mtp_tree_verify_result {
     bool ok = false;
     llama_tokens accepted;
 };
+
+static bool mtp_tree_seq_rm_with_fallback(
+        llama_context * ctx_tgt,
+        llama_seq_id seq_id,
+        llama_pos p0,
+        llama_pos p1);
+
+struct mtp_tree_verify_paths_result {
+    size_t n_accept = 0;
+    llama_tokens accepted;
+    bool ok = false;
+};
+
+static size_t mtp_tree_candidate_slots_available(llama_context * ctx_tgt) {
+    const int32_t n_seq_max = llama_n_seq_max(ctx_tgt);
+    if (n_seq_max <= 1) {
+        return 0;
+    }
+
+    return (size_t) std::max(0, n_seq_max - 1);
+}
+
+static bool mtp_tree_verify_paths(
+        llama_context * ctx_tgt,
+        const common_prompt_checkpoint & ckpt,
+        llama_state_seq_flags ckpt_flags,
+        llama_seq_id seq_id,
+        int32_t start_pos,
+        llama_token root,
+        const std::vector<mtp_tree_candidate_path> & paths,
+        common_sampler * smpl,
+        std::vector<mtp_tree_verify_paths_result> & results,
+        common_sampler_ptr & smpl_best,
+        size_t & best_path_index,
+        mtp_tree_verify_paths_result & best_result) {
+    if (!ctx_tgt || !smpl || paths.empty()) {
+        return false;
+    }
+
+    const size_t max_candidates = mtp_tree_candidate_slots_available(ctx_tgt);
+    if (max_candidates == 0) {
+        return false;
+    }
+
+    const size_t n_candidates = std::min(paths.size(), max_candidates);
+    results.assign(paths.size(), {});
+    best_path_index = 0;
+
+    LOG_DBG("mtp_tree_verify_paths: restore and batch verify %zu/%zu candidates\n", n_candidates, paths.size());
+
+    ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
+    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
+        LOG_DBG("mtp_tree_verify_paths: source seq trim failed (pos_max=%d)\n", (int)ckpt.pos_max);
+        return false;
+    }
+
+    llama_batch batch = llama_batch_init(1, 0, llama_n_seq_max(ctx_tgt));
+    if (batch.n_tokens < 0) {
+        llama_batch_free(batch);
+        LOG_DBG("mtp_tree_verify_paths: batch_init failed\n");
+        return false;
+    }
+
+    struct batched_path {
+        size_t path_index = 0;
+        llama_seq_id seq_id = -1;
+        size_t batch_offset = 0;
+    };
+    std::vector<batched_path> active;
+    std::vector<common_sampler_ptr> samplers;
+    active.reserve(n_candidates);
+    samplers.reserve(n_candidates);
+
+    // Build dedicated temp sequences for each candidate and run one decode on a
+    // single combined batch containing all candidate tokens.
+    size_t seq_id_probe = 0;
+    for (size_t i = 0; i < paths.size() && active.size() < n_candidates; ++i) {
+        const auto & path = paths[i];
+        if (path.tokens.empty()) {
+            continue;
+        }
+
+        while ((llama_seq_id) seq_id_probe == seq_id) {
+            ++seq_id_probe;
+        }
+        if (seq_id_probe >= (size_t) llama_n_seq_max(ctx_tgt)) {
+            break;
+        }
+
+        const llama_seq_id seq = (llama_seq_id) seq_id_probe;
+        ++seq_id_probe;
+
+        common_context_seq_rm(ctx_tgt, seq, -1, -1);
+        common_context_seq_cp(ctx_tgt, seq_id, seq, ckpt.pos_min, -1);
+
+        const size_t n_offset = (size_t) batch.n_tokens;
+
+        common_batch_add(batch, root, start_pos, {seq}, true);
+        for (size_t j = 0; j < path.tokens.size(); ++j) {
+            common_batch_add(batch, path.tokens[j], start_pos + (int32_t)j + 1, {seq}, true);
+        }
+
+        batched_path info;
+        info.path_index = i;
+        info.seq_id = seq;
+        info.batch_offset = n_offset;
+        active.push_back(info);
+        samplers.push_back(common_sampler_ptr(common_sampler_clone(smpl)));
+        if (!samplers.back()) {
+            LOG_DBG("mtp_tree_verify_paths: sampler clone failed for path=%zu\n", i);
+            results[i].ok = false;
+            active.pop_back();
+            samplers.pop_back();
+            continue;
+        }
+    }
+
+    if (active.empty()) {
+        llama_batch_free(batch);
+        LOG_DBG("mtp_tree_verify_paths: no active candidates\n");
+        return false;
+    }
+
+    const int rc = llama_decode(ctx_tgt, batch);
+    if (rc != 0) {
+        LOG_DBG("mtp_tree_verify_paths: decode failed (rc=%d)\n", rc);
+        llama_batch_free(batch);
+        return false;
+    }
+
+    for (size_t i = 0; i < active.size(); ++i) {
+        const auto & info = active[i];
+        const auto & path = paths[info.path_index];
+        auto & result = results[info.path_index];
+        auto & smpl_path = samplers[i];
+
+        const int base_pos = (int) info.batch_offset;
+        for (size_t j = 0; j < path.tokens.size(); ++j) {
+            const int sample_pos = base_pos + 1 + (int) j;
+            const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
+            common_sampler_accept(smpl_path.get(), id, true);
+            result.accepted.push_back(id);
+
+            if (id != path.tokens[j]) {
+                break;
+            }
+        }
+
+        if (!result.accepted.empty() && result.accepted.size() == path.tokens.size()) {
+            const int sample_pos = base_pos + (int) path.tokens.size();
+            const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
+            common_sampler_accept(smpl_path.get(), id, true);
+            result.accepted.push_back(id);
+        }
+
+        if (!result.accepted.empty()) {
+            result.ok = true;
+            result.n_accept = result.accepted.size() - 1;
+        }
+
+        if (!result.ok) {
+            continue;
+        }
+
+        if (result.n_accept > best_result.n_accept || (result.n_accept == best_result.n_accept && path.score > paths[best_path_index].score)) {
+            best_result = result;
+            best_path_index = info.path_index;
+            smpl_best = std::move(smpl_path);
+        }
+    }
+
+    // Clear temporary sequences and restore the source sequence position window.
+    for (const auto & info : active) {
+        common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
+    }
+    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
+        LOG_DBG("mtp_tree_verify_paths: failed to restore source rollback window (pos_max=%d)\n", (int) ckpt.pos_max);
+        llama_batch_free(batch);
+        return false;
+    }
+
+    llama_batch_free(batch);
+    return true;
+}
 
 static bool mtp_tree_seq_rm_with_fallback(
         llama_context * ctx_tgt,
@@ -173,21 +357,27 @@ static bool mtp_tree_verify_path(
         common_sampler * smpl,
         mtp_tree_verify_result & result) {
     if (!ctx_tgt || !smpl || path.tokens.empty()) {
-        LOG_INF("mtp_tree_verify_path: invalid input (ctx=%p smpl=%p tokens=%zu)\n", ctx_tgt, smpl, path.tokens.size());
+        LOG_DBG("mtp_tree_verify_path: invalid input (ctx=%p smpl=%p tokens=%zu)\n", (void *) ctx_tgt, (void *) smpl, path.tokens.size());
         return false;
     }
 
+    LOG_DBG("mtp_tree_verify_path: BEFORE restore - ckpt.pos_max=%d start_pos=%d root=%d path_tokens=%zu\n",
+            (int)ckpt.pos_max, start_pos, (int)root, path.tokens.size());
+
     ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
     if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
-        LOG_INF("mtp_tree_verify_path: seq_rm failed (pos_max=%d)\n", (int)ckpt.pos_max);
+        LOG_DBG("mtp_tree_verify_path: seq_rm failed (pos_max=%d)\n", (int)ckpt.pos_max);
         return false;
     }
+
+    LOG_DBG("mtp_tree_verify_path: AFTER restore - kv_pos_max=%d\n",
+            (int)llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), seq_id));
 
     const int32_t n_tokens = (int32_t) path.tokens.size() + 1;
     auto batch = llama_batch_init(n_tokens, 0, 1);
     if (batch.n_tokens < 0) {
         llama_batch_free(batch);
-        LOG_INF("mtp_tree_verify_path: batch_init failed (n_tokens=%d)\n", n_tokens);
+        LOG_DBG("mtp_tree_verify_path: batch_init failed (n_tokens=%d)\n", n_tokens);
         return false;
     }
 
@@ -196,13 +386,19 @@ static bool mtp_tree_verify_path(
         common_batch_add(batch, path.tokens[(size_t) i], start_pos + i + 1, { seq_id }, true);
     }
 
+    LOG_DBG("mtp_tree_verify_path: batch built - n_tokens=%d first_token=%d first_pos=%d\n",
+            batch.n_tokens, (int)batch.token[0], (int)batch.pos[0]);
+
     const int rc = llama_decode(ctx_tgt, batch);
     llama_batch_free(batch);
 
     if (rc != 0) {
-        LOG_INF("mtp_tree_verify_path: decode failed (rc=%d)\n", rc);
+        LOG_DBG("mtp_tree_verify_path: decode failed (rc=%d)\n", rc);
         return false;
     }
+
+    LOG_DBG("mtp_tree_verify_path: AFTER decode - kv_pos_max=%d\n",
+            (int)llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), seq_id));
 
     result.accepted.clear();
 
@@ -211,7 +407,7 @@ static bool mtp_tree_verify_path(
         common_sampler_accept(smpl, id, true);
         result.accepted.push_back(id);
 
-        LOG_INF("mtp_tree_verify_path: pos=%zu sampled=%d expected=%d match=%d\n", i, (int)id, (int)path.tokens[i], id == path.tokens[i] ? 1 : 0);
+        LOG_DBG("mtp_tree_verify_path: pos=%zu sampled=%d expected=%d match=%d\n", i, (int)id, (int)path.tokens[i], id == path.tokens[i] ? 1 : 0);
 
         if (id != path.tokens[i]) {
             result.ok = true;
@@ -1208,7 +1404,7 @@ private:
             cparams_mtp.type_v        = params_base.cache_type_v;
             cparams_mtp.n_rs_seq      = 0;
             cparams_mtp.n_outputs_max = params_base.n_parallel;
-            cparams_mtp.ctx_other     = ctx_tgt;
+            cparams_mtp.ctx_other = ctx_tgt;
 
             ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams_mtp));
             if (ctx_dft == nullptr) {
@@ -2797,6 +2993,10 @@ private:
                             /* .result   = */ &slot.spec_draft,
                         };
 
+                        if (spec != nullptr && params_base.speculative.draft.use_mtp_tree) {
+                            common_speculative_sync_draft_sampler(spec.get(), slot.id, slot.smpl.get());
+                        }
+
                         drafting.push_back(&slot);
                     }
                 }
@@ -3693,7 +3893,7 @@ private:
 
                 GGML_ASSERT(n_draft > 0);
 
-                // verify and try to accept the draft
+            // verify and try to accept the draft
                 common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
                 {
                     // save the sampler sampler state in case we need to restore it
@@ -3704,10 +3904,15 @@ private:
                     bool used_tree_verify = false;
                     llama_tokens accepted_tree;
 
-                    if (params_base.speculative.draft.use_mtp_tree && use_ckpt_tgt && !slot.spec_ckpt.empty()) {
+                    const bool can_use_tree = params_base.speculative.draft.use_mtp_tree
+                        && use_ckpt_tgt
+                        && !slot.spec_ckpt.empty()
+                        && n_draft <= 16;
+
+                    if (can_use_tree) {
                         common_speculative_mtp_tree_plan mtp_tree;
                         if (common_speculative_get_mtp_tree_plan(spec.get(), slot.id, mtp_tree)) {
-                            LOG_INF("slot %d: got tree plan with %zu nodes\n", slot.id, mtp_tree.nodes.size());
+                            LOG_DBG("slot %d: got tree plan with %zu nodes\n", slot.id, mtp_tree.nodes.size());
                             if (trace > 0) {
                                 SLT_DBG(slot,
                                         "mtp-tree draft: nodes=%zu max_nodes=%zu max_depth=%zu p_split=%.4g\n",
@@ -3719,67 +3924,35 @@ private:
 
                             std::vector<mtp_tree_candidate_path> tree_paths;
                             if (mtp_tree_collect_candidates(mtp_tree, n_draft, tree_paths)) {
-                                LOG_INF("slot %d: collected %zu candidate paths\n", slot.id, tree_paths.size());
-                                size_t best_accept = 0;
-                                float best_score = -1.0f;
-                                mtp_tree_candidate_path best_path;
-
+                                LOG_DBG("slot %d: collected %zu candidate paths\n", slot.id, tree_paths.size());
                                 const llama_token root = slot.sampled;
-                                LOG_INF("slot %d: using root=%d for verification\n", slot.id, (int)root);
                                 const int32_t tree_start_pos = slot.spec_ckpt.pos_max >= 0
                                     ? (int32_t) slot.spec_ckpt.pos_max + 1
                                     : (int32_t) slot.spec_ckpt.n_tokens;
-                                for (const auto & path : tree_paths) {
-                                    mtp_tree_verify_result result;
-                                    common_sampler_ptr smpl_tree(common_sampler_clone(smpl_save.get()));
+                                LOG_DBG("slot %d: using root=%d for verification\n", slot.id, (int)root);
 
-                                    if (!mtp_tree_verify_path(
-                                            slot.ctx_tgt,
-                                            slot.spec_ckpt,
-                                            spec_ckpt_flags,
-                                            slot.id,
-                                            tree_start_pos,
-                                            root,
-                                            path,
-                                            smpl_tree.get(),
-                                            result) || result.accepted.empty()) {
-                                        continue;
-                                    }
+                                size_t best_path_index = 0;
+                                mtp_tree_verify_paths_result best_path_result;
+                                common_sampler_ptr best_path_smpl;
+                                std::vector<mtp_tree_verify_paths_result> verify_results;
+                                const bool tree_verified = mtp_tree_verify_paths(
+                                        slot.ctx_tgt,
+                                        slot.spec_ckpt,
+                                        spec_ckpt_flags,
+                                        slot.id,
+                                        tree_start_pos,
+                                        root,
+                                        tree_paths,
+                                        smpl_save.get(),
+                                        verify_results,
+                                        best_path_smpl,
+                                        best_path_index,
+                                        best_path_result);
 
-                                    const size_t n_accept = result.accepted.size() - 1;
-                                    if (n_accept > best_accept || (n_accept == best_accept && path.score > best_score)) {
-                                        best_accept = n_accept;
-                                        best_score = path.score;
-                                        best_path = path;
-                                        accepted_tree = std::move(result.accepted);
-                                        used_tree_verify = true;
-                                    }
-
-                                    if (best_accept >= n_draft) {
-                                        break;
-                                    }
-                                }
-
-                                if (used_tree_verify) {
-                                    mtp_tree_verify_result result;
-                                    common_sampler_ptr smpl_tree(common_sampler_clone(smpl_save.get()));
-
-                                    if (!mtp_tree_verify_path(
-                                            slot.ctx_tgt,
-                                            slot.spec_ckpt,
-                                            spec_ckpt_flags,
-                                            slot.id,
-                                            tree_start_pos,
-                                            root,
-                                            best_path,
-                                            smpl_tree.get(),
-                                            result) || result.accepted.empty()) {
-                                        used_tree_verify = false;
-                                        accepted_tree.clear();
-                                    } else {
-                                        accepted_tree = std::move(result.accepted);
-                                        slot.smpl = std::move(smpl_tree);
-                                    }
+                                if (tree_verified && best_path_result.ok && best_path_smpl) {
+                                    accepted_tree = std::move(best_path_result.accepted);
+                                    slot.smpl = std::move(best_path_smpl);
+                                    used_tree_verify = true;
                                 }
                             }
                         }
@@ -3787,6 +3960,14 @@ private:
 
                     GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
                     llama_tokens accepted;
+                    if (used_tree_verify && accepted_tree.size() <= 1) {
+                        if (trace > 0) {
+                            SLT_INF(slot, "tree verify accepted zero tokens, falling back to linear acceptance %s\n", "");
+                        }
+                        used_tree_verify = false;
+                        slot.smpl = std::move(smpl_save);
+                    }
+
                     if (used_tree_verify) {
                         accepted = std::move(accepted_tree);
                         if (trace > 0) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -9,6 +9,14 @@
 #include "common.h"
 #include "fit.h"
 #include "llama.h"
+#if __has_include(<nvtx3/nvToolsExt.h>)
+#    include <nvtx3/nvToolsExt.h>
+#elif __has_include(<nvToolsExt.h>)
+#    include <nvToolsExt.h>
+#else
+static inline int nvtxRangePushA(const char *) { return 0; }
+static inline int nvtxRangePop() { return 0; }
+#endif
 #include "log.h"
 #include "sampling.h"
 #include "speculative.h"
@@ -79,7 +87,9 @@ static bool mtp_tree_collect_candidates(
 
     LOG_DBG("mtp_tree_collect_candidates: plan.nodes.size()=%zu max_depth=%zu\n", plan.nodes.size(), max_depth);
 
+    nvtxRangePushA("mtp_tree:collect_candidates");
     if (plan.nodes.size() <= 1) {
+        nvtxRangePop();
         return false;
     }
 
@@ -109,7 +119,7 @@ static bool mtp_tree_collect_candidates(
 
         std::reverse(tokens.begin(), tokens.end());
 
-        LOG_DBG("mtp_tree_collect_candidates: path[%zu] tokens=%zu score=%.4f first_token=%d\n",
+    LOG_DBG("mtp_tree_collect_candidates: path[%zu] tokens=%zu score=%.4f first_token=%d\n",
                 paths.size(), tokens.size(), (double)node.cum_prob, (int)tokens[0]);
 
         paths.push_back({std::move(tokens), node.cum_prob});
@@ -129,6 +139,7 @@ static bool mtp_tree_collect_candidates(
         return a.tokens < b.tokens;
     });
 
+    nvtxRangePop();
     return true;
 }
 
@@ -170,10 +181,13 @@ static bool mtp_tree_verify_paths(
         std::vector<mtp_tree_verify_paths_result> & results,
         common_sampler_ptr & smpl_best,
         size_t & best_path_index,
-        mtp_tree_verify_paths_result & best_result) {
+        mtp_tree_verify_paths_result & best_result,
+        bool & kv_needs_restore) {
     if (!ctx_tgt || !smpl || paths.empty()) {
         return false;
     }
+
+    nvtxRangePushA("mtp_tree:verify_paths");
 
     const size_t max_candidates = mtp_tree_candidate_slots_available(ctx_tgt);
     if (max_candidates == 0) {
@@ -186,13 +200,28 @@ static bool mtp_tree_verify_paths(
 
     LOG_DBG("mtp_tree_verify_paths: restore and batch verify %zu/%zu candidates\n", n_candidates, paths.size());
 
-    ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
+    if (kv_needs_restore) {
+        ckpt.load_tgt(ctx_tgt, seq_id, ckpt_flags);
+        kv_needs_restore = false;
+    }
     if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
         LOG_DBG("mtp_tree_verify_paths: source seq trim failed (pos_max=%d)\n", (int)ckpt.pos_max);
         return false;
     }
 
-    llama_batch batch = llama_batch_init(1, 0, llama_n_seq_max(ctx_tgt));
+    // pre-compute total tokens for the batch to avoid assertion failure (batch does not auto-resize)
+    // keep in sync with build loop below
+    size_t total_tokens = 0;
+    size_t n_paths_pre = 0;
+    for (size_t i = 0; i < paths.size() && n_paths_pre < n_candidates; ++i) {
+        if (paths[i].tokens.empty()) {
+            continue;
+        }
+        total_tokens += 1 + paths[i].tokens.size();
+        ++n_paths_pre;
+    }
+
+    llama_batch batch = llama_batch_init((int32_t) std::max(total_tokens, (size_t) 1), 0, llama_n_seq_max(ctx_tgt));
     if (batch.n_tokens < 0) {
         llama_batch_free(batch);
         LOG_DBG("mtp_tree_verify_paths: batch_init failed\n");
@@ -229,7 +258,9 @@ static bool mtp_tree_verify_paths(
         ++seq_id_probe;
 
         common_context_seq_rm(ctx_tgt, seq, -1, -1);
-        common_context_seq_cp(ctx_tgt, seq_id, seq, ckpt.pos_min, -1);
+        // seq_cp requires copying from position 0 (is_full assert in KV cache);
+        common_context_seq_cp(ctx_tgt, seq_id, seq, 0, -1);
+        // prefix trim disabled: investigate ckpt.pos_min effect on GX10 logits
 
         const size_t n_offset = (size_t) batch.n_tokens;
 
@@ -273,13 +304,17 @@ static bool mtp_tree_verify_paths(
         auto & smpl_path = samplers[i];
 
         const int base_pos = (int) info.batch_offset;
+        fprintf(stderr, "mtp-tree-verify: path[%zu] seq=%d expecting %zu tokens: ", info.path_index, (int)info.seq_id, path.tokens.size());
+        for (size_t k = 0; k < path.tokens.size(); ++k) { fprintf(stderr, "%d ", path.tokens[k]); }
+        fprintf(stderr, "\n");
         for (size_t j = 0; j < path.tokens.size(); ++j) {
-            const int sample_pos = base_pos + 1 + (int) j;
+            const int sample_pos = base_pos + (int) j;
             const llama_token id = common_sampler_sample(smpl_path.get(), ctx_tgt, sample_pos, false);
             common_sampler_accept(smpl_path.get(), id, true);
             result.accepted.push_back(id);
 
             if (id != path.tokens[j]) {
+                fprintf(stderr, "mtp-tree-verify: MISMATCH path[%zu] pos=%zu expected=%d got=%d\n", info.path_index, j+1, path.tokens[j], id);
                 break;
             }
         }
@@ -307,17 +342,23 @@ static bool mtp_tree_verify_paths(
         }
     }
 
-    // Clear temporary sequences and restore the source sequence position window.
+    // Copy best temp sequence KV back to the main sequence before cleanup,
+    // so the accepted tokens survive in the main KV cache.
+    if (best_result.ok) {
+        for (const auto & info : active) {
+            if (info.path_index == best_path_index) {
+                common_context_seq_cp(ctx_tgt, info.seq_id, seq_id, 0, -1);
+                break;
+            }
+        }
+    }
+
+    // Clear temporary sequences.
     for (const auto & info : active) {
         common_context_seq_rm(ctx_tgt, info.seq_id, -1, -1);
     }
-    if (!mtp_tree_seq_rm_with_fallback(ctx_tgt, seq_id, ckpt.pos_max + 1, -1)) {
-        LOG_DBG("mtp_tree_verify_paths: failed to restore source rollback window (pos_max=%d)\n", (int) ckpt.pos_max);
-        llama_batch_free(batch);
-        return false;
-    }
-
     llama_batch_free(batch);
+    nvtxRangePop();
     return true;
 }
 
@@ -335,12 +376,18 @@ static bool mtp_tree_seq_rm_with_fallback(
         return true;
     }
 
-    // The recurrent cache can reject large bounded rollbacks when asked to trim
-    // beyond the configured RS window. Fall back to trimming only the last token,
-    // which is enough to clear a stale pending row in this verification path.
-    const llama_pos pos_max = llama_memory_seq_pos_max(mem, seq_id);
-    if (p1 < 0 && pos_max >= 0 && p0 <= pos_max) {
-        return llama_memory_seq_rm(mem, seq_id, pos_max, -1);
+    // The recurrent cache can reject large bounded rollbacks.
+    // Fall back to removing tokens one at a time from the end until
+    // all entries from p0 onwards are cleared.
+    if (p1 < 0) {
+        llama_pos pos_max = llama_memory_seq_pos_max(mem, seq_id);
+        while (pos_max >= 0 && pos_max >= p0) {
+            if (!llama_memory_seq_rm(mem, seq_id, pos_max, -1)) {
+                break;
+            }
+            pos_max = llama_memory_seq_pos_max(mem, seq_id);
+        }
+        return llama_memory_seq_pos_max(mem, seq_id) < p0;
     }
 
     return false;
@@ -403,7 +450,7 @@ static bool mtp_tree_verify_path(
     result.accepted.clear();
 
     for (size_t i = 0; i < path.tokens.size(); ++i) {
-        const llama_token id = common_sampler_sample(smpl, ctx_tgt, (int) i + 1, false);
+        const llama_token id = common_sampler_sample(smpl, ctx_tgt, (int) i, false);
         common_sampler_accept(smpl, id, true);
         result.accepted.push_back(id);
 
@@ -475,6 +522,7 @@ struct server_slot {
     llama_tokens spec_prompt;
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
+    bool kv_needs_restore = false; // reset by ckpt.update_tgt() before each draft round; guards load_tgt in mtp_tree_verify_paths
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
     //       see https://github.com/ggml-org/llama.cpp/pull/18283#issuecomment-3710175837
@@ -1478,6 +1526,7 @@ private:
         slots.clear();
 
         ctx_tgt_seq_rm_type = server_seq_rm_type_for_startup(ctx_tgt, params_base.warmup);
+
         if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             SRV_WRN("%s", "speculative decoding not supported by this context\n");
         }
@@ -3034,15 +3083,16 @@ private:
             if (!draft.empty()) {
                 const bool use_ckpt_tgt =
                     ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-                   (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && draft.size() > llama_n_rs_seq(ctx_tgt));
+                   (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && draft.size() >= llama_n_rs_seq(ctx_tgt));
 
                 const bool use_ckpt_dft =
-                   (ctx_dft_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && draft.size() > llama_n_rs_seq(ctx_dft.get()));
+                   (ctx_dft_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && draft.size() >= llama_n_rs_seq(ctx_dft.get()));
 
                 if (use_ckpt_tgt) {
                     //const int64_t t_start = ggml_time_us();
 
                     ckpt.update_tgt(ctx_tgt, slot.id, spec_ckpt_flags);
+                    slot.kv_needs_restore = false;
 
                     //const int64_t t_total = ggml_time_us() - t_start;
                     //printf("checkpoint total: %f ms\n", t_total / 1000.0);
@@ -3897,10 +3947,9 @@ private:
             // verify and try to accept the draft
                 common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
                 {
-                    // save the sampler sampler state in case we need to restore it
                     const bool use_ckpt_tgt =
                         ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-                       (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && n_draft > llama_n_rs_seq(ctx_tgt));
+                       (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS && n_draft >= llama_n_rs_seq(ctx_tgt));
 
                     bool used_tree_verify = false;
                     llama_tokens accepted_tree;
@@ -3908,11 +3957,14 @@ private:
                     const bool can_use_tree = params_base.speculative.draft.use_mtp_tree
                         && use_ckpt_tgt
                         && !slot.spec_ckpt.empty()
-                        && n_draft <= 16;
+                        && mtp_tree_candidate_slots_available(slot.ctx_tgt) > 0;
 
+                    SLT_INF(slot, "can_use_tree: use_mtp=%d ckpt_tgt=%d ckpt_empty=%d cand_slots=%zu n_seq=%d rm_type=%d n_draft=%d n_rs=%d\n", (int)params_base.speculative.draft.use_mtp_tree, (int)use_ckpt_tgt, (int)slot.spec_ckpt.empty(), mtp_tree_candidate_slots_available(slot.ctx_tgt), (int)llama_n_seq_max(slot.ctx_tgt), (int)ctx_tgt_seq_rm_type, (int)n_draft, (int)llama_n_rs_seq(slot.ctx_tgt));
                     if (can_use_tree) {
+                        nvtxRangePushA("server:can_use_tree");
                         common_speculative_mtp_tree_plan mtp_tree;
                         if (common_speculative_get_mtp_tree_plan(spec.get(), slot.id, mtp_tree)) {
+
                             LOG_DBG("slot %d: got tree plan with %zu nodes\n", slot.id, mtp_tree.nodes.size());
                             if (trace > 0) {
                                 SLT_DBG(slot,
@@ -3936,6 +3988,7 @@ private:
                                 mtp_tree_verify_paths_result best_path_result;
                                 common_sampler_ptr best_path_smpl;
                                 std::vector<mtp_tree_verify_paths_result> verify_results;
+
                                 const bool tree_verified = mtp_tree_verify_paths(
                                         slot.ctx_tgt,
                                         slot.spec_ckpt,
@@ -3948,7 +4001,8 @@ private:
                                         verify_results,
                                         best_path_smpl,
                                         best_path_index,
-                                        best_path_result);
+                                        best_path_result,
+                                        slot.kv_needs_restore);
 
                                 if (tree_verified && best_path_result.ok && best_path_smpl) {
                                     accepted_tree = std::move(best_path_result.accepted);
@@ -3957,6 +4011,7 @@ private:
                                 }
                             }
                         }
+                        nvtxRangePop();
                     }
 
                     GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
@@ -3971,11 +4026,14 @@ private:
 
                     if (used_tree_verify) {
                         accepted = std::move(accepted_tree);
+
                         if (trace > 0) {
                             SLT_INF(slot, "accepted %2zu/%2zu draft tokens (tree)\n", accepted.size() - 1, n_draft);
                         }
+
                     } else {
                         accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
+                        slot.kv_needs_restore = true;
                         if (trace > 0) {
                             SLT_INF(slot, "accepted %2zu/%2zu draft tokens\n", accepted.size() - 1, n_draft);
                         }
@@ -4002,6 +4060,7 @@ private:
 
                             {
                                 ckpt.load_tgt(slot.ctx_tgt, slot.id, spec_ckpt_flags);
+                                slot.kv_needs_restore = false;
 
                                 if (!mtp_tree_seq_rm_with_fallback(slot.ctx_tgt, slot.id, ckpt.pos_max + 1, -1)) {
                                     slot.smpl = std::move(smpl_save);


### PR DESCRIPTION
## Summary
- carry the GX10 MTP runtime speed path from the validated b62ad77bd checkpoint
- includes Blackwell TQ3 FA routing, MTP hook sequence-awareness, tree verifier work, and reduced MTP sampler synchronization

## Validation
- validated on .44 using the clean UI-enabled build at b62ad77bd
- llama.cpp UI: http://192.168.1.44:8080/ returned 200
- health endpoint returned 200

Assisted-by: Codex