### PR TITLE
ggml-cuda: restrict tq3_0 V vector FA bypass to decode only

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -412,13 +412,15 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     const bool asymm_tq3_v = (K->type == GGML_TYPE_Q8_0 || K->type == GGML_TYPE_Q4_0) &&
                               V->type == GGML_TYPE_TQ3_0;
 
-    // Asymmetric tq3_0 V has a native vector path. Keep it off the f16
-    // temp-buffer FA paths used by tile/MMA kernels.
-    if (asymm_tq3_v) {
+    // Asymmetric tq3_0 V has a native vector path. For decode (small Q batch),
+    // keep it on vector FA — the MMA/tile paths crashed on Blackwell in that mode.
+    // For PP (Q->ne[1] > 4), fall through to MMA: the crash was decode-specific
+    // and MMA FA gives ~40% better PP throughput at long contexts.
+    if (asymm_tq3_v && Q->ne[1] <= 4) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
     }
 
-    if (K->type == GGML_TYPE_TURBO4_0 && V->type == GGML_TYPE_TQ3_0) {
+    if (K->type == GGML_TYPE_TURBO4_0 && V->type == GGML_TYPE_TQ3_0 && Q->ne[1] <= 4) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
     }
 


### PR DESCRIPTION
## Problem

Commit 257125639 unconditionally routes all Blackwell `q8_0/tq3_0` and `tq4_0/tq3_0` KV attention through the vector FA kernel to avoid an MMA/tile FA crash observed on GB10. However, the crash was decode-specific (small Q batch, typically Q->ne[1] == 1). By applying the bypass to prefill as well, we force O(N²) attention cost during PP:

- Vector FA PP at 10K context: **443 tok/s**
- MMA FA PP at 10K context: **625 tok/s** (+41%)
- Vector FA PP degrades with context length; MMA FA is flat (FFN-bound)

## Fix

Gate the vector FA bypass on `Q->ne[1] <= 4` (decode only). PP falls through to MMA FA, which is safe for large-Q batches on Blackwell.

```cpp
// Before
if (asymm_tq3_v) { ... force vector FA ... }

// After
if (asymm_tq3_v && Q->ne[1] <= 4) { ... force vector FA (decode only) ... }
```

## Validation (GB10, Qwen3.6-27B-MTP-TQ3_4S, -ctk q8_0 -ctv tq3_0)

| Context  | Before  | After   | Δ     |
|----------|---------|---------|-------|
| 184 tok  | 594 t/s | 591 t/s | ~0    |
| 738 tok  | 643 t/s | 693 t/s | +8%   |
| 2957 tok | 570 t/s | 638 t/s | +12%  |
| 10000 tok| 443 t/s | 624 t/s | **+41%** |

MTP decode smoke test (original crash scenario): stable, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiUD4XkcbjmrP48BTxqqrW