### PR TITLE
port: turbo2/3/4 KV cache from TheTom crush/turbo4 + asymmetric crash fix

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -435,7 +435,8 @@ extern "C" {
         GGML_TYPE_TQ3_0      = 200,
         GGML_TYPE_TURBO3_0   = 201,
         GGML_TYPE_TURBO4_0   = 202,
-        GGML_TYPE_COUNT      = 203,
+        GGML_TYPE_TURBO2_0   = 203,
+        GGML_TYPE_COUNT      = 204,
     };
 
     // op hint

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -286,24 +286,58 @@ typedef struct {
 } block_tq3_0;
 static_assert(sizeof(block_tq3_0) == sizeof(ggml_half) + QK_TQ3_0 * 3 / 8, "wrong tq3_0 block size/padding");
 
-// TurboQuant 3-bit KV cache: 2-bit PolarQuant + 1-bit sign
-#define QK_TURBO3 32
+// TurboQuant 3-bit KV cache: 3-bit PolarQuant via WHT rotation (no QJL)
+// Block size 128: one block per rotation group, eliminates redundant norms
+// The 3-bit index is split: lower 2 bits in qs[], upper 1 bit in signs[]
+#define QK_TURBO3 128
+#define QK_TURBO3_GROUP 128
+#define NL_TURBO3     (QK_TURBO3 / 16)
+#define NL_TURBO3_VEC (QK_TURBO3 / 4)
 typedef struct {
-    ggml_half norm;
-    uint8_t   qs[QK_TURBO3 / 4];
-    uint8_t   signs[QK_TURBO3 / 8];
-} block_turbo3_0;
-static_assert(sizeof(block_turbo3_0) == sizeof(ggml_half) + QK_TURBO3 / 4 + QK_TURBO3 / 8, "wrong turbo3_0 block size/padding");
+    ggml_half  norm;                    //  2 bytes: corrected L2 norm
+    uint8_t    qs[QK_TURBO3 / 4];      // 32 bytes: lower 2-bit indices (4 per byte)
+    uint8_t    signs[QK_TURBO3 / 8];   // 16 bytes: upper 1-bit of 3-bit index (8 per byte)
+} block_turbo3_0;                       // 50 bytes total
+static_assert(sizeof(block_turbo3_0) == sizeof(ggml_half) + QK_TURBO3/4 + QK_TURBO3/8, "wrong turbo3_0 block size/padding");
 
-// TurboQuant 4-bit KV cache: 3-bit PolarQuant + 1-bit QJL signs
+// TurboQuant 4-bit: 4-bit PolarQuant (16 optimal centroids, nibble packed)
+// TURBO4_USE_4BIT=1 (default): new 4-bit path, dropped dead rnorm (66B)
+// TURBO4_USE_4BIT=0: legacy 3-bit+QJL (68B)
+#ifndef TURBO4_USE_4BIT
+#  define TURBO4_USE_4BIT 1
+#endif
+
 #define QK_TURBO4 128
+
+#if TURBO4_USE_4BIT
 typedef struct {
-    ggml_half norm;
-    ggml_half rnorm;
-    uint8_t   qs[QK_TURBO4 * 3 / 8];
-    uint8_t   signs[QK_TURBO4 / 8];
-} block_turbo4_0;
-static_assert(sizeof(block_turbo4_0) == 2 * sizeof(ggml_half) + QK_TURBO4 * 3 / 8 + QK_TURBO4 / 8, "wrong turbo4_0 block size/padding");
+    ggml_half  norm;                    //  2 bytes
+    uint8_t    qs[QK_TURBO4 / 2];      // 64 bytes: 4-bit PolarQuant indices (nibble packed)
+} block_turbo4_0;                       // 66 bytes total (4.125 bpw)
+static_assert(sizeof(block_turbo4_0) == 66, "wrong turbo4_0 block size");
+#else
+typedef struct {
+    ggml_half  norm;
+    ggml_half  rnorm;
+    uint8_t    qs[QK_TURBO4 * 3 / 8];
+    uint8_t    signs[QK_TURBO4 / 8];
+} block_turbo4_0;                       // 68 bytes total (legacy 3-bit+QJL)
+static_assert(sizeof(block_turbo4_0) == 2*sizeof(ggml_half) + QK_TURBO4*3/8 + QK_TURBO4/8, "wrong turbo4_0 block size");
+#endif
+
+static_assert(QK_TURBO4 == 128, "turbo4 kernels assume QK_TURBO4 == 128");
+
+// TurboQuant 2-bit KV cache: 2-bit PolarQuant via WHT rotation
+// 4 centroids (Lloyd-Max for N(0, 1/128)): {-0.133462, -0.039994, 0.039994, 0.133462}
+#define QK_TURBO2 128
+#define QK_TURBO2_GROUP 128
+#define NL_TURBO2     (QK_TURBO2 / 16)
+#define NL_TURBO2_VEC (QK_TURBO2 / 4)
+typedef struct {
+    ggml_half  norm;                    //  2 bytes: corrected L2 norm
+    uint8_t    qs[QK_TURBO2 / 4];      // 32 bytes: 2-bit indices (4 per byte)
+} block_turbo2_0;                       // 34 bytes total
+static_assert(sizeof(block_turbo2_0) == sizeof(ggml_half) + QK_TURBO2/4, "wrong turbo2_0 block size/padding");
 
 // TurboQuant 3-bit with two half-block scales (4.0 bpw)
 typedef struct {

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -682,6 +682,7 @@ void ggml_compute_forward_add(
         case GGML_TYPE_TQ1_0:
         case GGML_TYPE_TQ2_0:
         case GGML_TYPE_TQ3_0:
+        case GGML_TYPE_TURBO2_0:
         case GGML_TYPE_TURBO3_0:
         case GGML_TYPE_TURBO4_0:
         case GGML_TYPE_TQ3_1S:
@@ -1143,6 +1144,7 @@ void ggml_compute_forward_add1(
         case GGML_TYPE_TQ1_0:
         case GGML_TYPE_TQ2_0:
         case GGML_TYPE_TQ3_0:
+        case GGML_TYPE_TURBO2_0:
         case GGML_TYPE_TURBO3_0:
         case GGML_TYPE_TURBO4_0:
         case GGML_TYPE_TQ3_1S:
@@ -1283,6 +1285,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_TQ1_0:
         case GGML_TYPE_TQ2_0:
         case GGML_TYPE_TQ3_0:
+        case GGML_TYPE_TURBO2_0:
         case GGML_TYPE_TURBO3_0:
         case GGML_TYPE_TURBO4_0:
         case GGML_TYPE_TQ3_1S:
@@ -5754,6 +5757,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_TQ1_0:
         case GGML_TYPE_TQ2_0:
         case GGML_TYPE_TQ3_0:
+        case GGML_TYPE_TURBO2_0:
         case GGML_TYPE_TURBO3_0:
         case GGML_TYPE_TURBO4_0:
         case GGML_TYPE_TQ3_1S:

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -57,6 +57,9 @@
 // While BW spans CC 1000, 1100 & 1200, we are integrating Tensor Core instructions available to 1200 family, see
 // https://docs.nvidia.com/cutlass/media/docs/cpp/blackwell_functionality.html#blackwell-sm120-gemms
 #define GGML_CUDA_CC_BLACKWELL       1200
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_BLACKWELL
+#define BLACKWELL_MMA_AVAILABLE
+#endif
 #define GGML_CUDA_CC_DGX_SPARK       1210
 #define GGML_CUDA_CC_RUBIN           1300
 #define GGML_CUDA_CC_OFFSET_AMD      0x1000000

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -57,7 +57,7 @@
 // While BW spans CC 1000, 1100 & 1200, we are integrating Tensor Core instructions available to 1200 family, see
 // https://docs.nvidia.com/cutlass/media/docs/cpp/blackwell_functionality.html#blackwell-sm120-gemms
 #define GGML_CUDA_CC_BLACKWELL       1200
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_BLACKWELL
+#if !defined(GGML_USE_HIP) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_BLACKWELL
 #define BLACKWELL_MMA_AVAILABLE
 #endif
 #define GGML_CUDA_CC_DGX_SPARK       1210

--- a/ggml/src/ggml-cuda/cpy-utils.cuh
+++ b/ggml/src/ggml-cuda/cpy-utils.cuh
@@ -251,107 +251,109 @@ static __device__ void quantize_f32_tq3_0_block(const float * __restrict__ x, bl
 }
 
 static __device__ void quantize_f32_turbo3_0_block(const float * __restrict__ x, block_turbo3_0 * __restrict__ y) {
+    static constexpr float centroids[8] = {
+        -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+         0.021663f,  0.066822f,  0.118786f,  0.190207f
+    };
+
     float sum_sq = 0.0f;
-    for (int i = 0; i < QK_TURBO3; ++i) {
-        sum_sq += x[i] * x[i];
-    }
-
+    for (int i = 0; i < QK_TURBO3; ++i) sum_sq += x[i] * x[i];
     float norm = sqrtf(sum_sq);
-    if (norm < 1e-10f) {
-        norm = 1.0f;
-    }
-    y->norm = __float2half(norm);
-
+    if (norm < 1e-10f) norm = 1.0f;
     const float inv_norm = 1.0f / norm;
-    for (int i = 0; i < QK_TURBO3 / 4; ++i) {
-        y->qs[i] = 0;
-    }
-    for (int i = 0; i < QK_TURBO3 / 8; ++i) {
-        y->signs[i] = 0;
-    }
 
+    for (int i = 0; i < (int) sizeof(y->qs); ++i) y->qs[i] = 0;
+    for (int i = 0; i < (int) sizeof(y->signs); ++i) y->signs[i] = 0;
+
+    float recon_sq = 0.0f;
     for (int i = 0; i < QK_TURBO3; ++i) {
         const float v = x[i] * inv_norm;
-        uint8_t low2 = 0;
-        if (v > -0.086728f) {
-            low2 = 1;
-        }
-        if (v > 0.0f) {
-            low2 = 2;
-        }
-        if (v > 0.086728f) {
-            low2 = 3;
-        }
-
-        y->qs[i / 4] |= (low2 & 0x3) << ((i % 4) * 2);
-        if (v >= 0.0f) {
-            y->signs[i / 8] |= 1u << (i % 8);
-        }
+        uint8_t idx = 0;
+        if (v >= -0.154496f) idx = 1;
+        if (v >= -0.092804f) idx = 2;
+        if (v >= -0.044243f) idx = 3;
+        if (v >= 0.0f)       idx = 4;
+        if (v >= 0.044243f)  idx = 5;
+        if (v >= 0.092804f)  idx = 6;
+        if (v >= 0.154496f)  idx = 7;
+        const uint8_t low2 = idx & 0x3;
+        const uint8_t hi1  = (idx >> 2) & 0x1;
+        y->qs[i / 4] |= low2 << ((i % 4) * 2);
+        if (hi1) y->signs[i / 8] |= 1u << (i % 8);
+        recon_sq += centroids[idx] * centroids[idx];
     }
+
+    const float recon_norm = sqrtf(recon_sq);
+    y->norm = __float2half((recon_norm > 1e-10f) ? norm / recon_norm : norm);
 }
 
 static __device__ void quantize_f32_turbo4_0_block(const float * __restrict__ x, block_turbo4_0 * __restrict__ y) {
+    static constexpr float centroids[16] = {
+        -0.241529f, -0.182877f, -0.143016f, -0.111036f,
+        -0.083292f, -0.058050f, -0.034299f, -0.011349f,
+         0.011349f,  0.034299f,  0.058050f,  0.083292f,
+         0.111036f,  0.143016f,  0.182877f,  0.241529f
+    };
+
     float norm_sq = 0.0f;
-    float abs_sum = 0.0f;
-    for (int i = 0; i < QK_TURBO4; ++i) {
-        const float v = x[i];
-        norm_sq += v * v;
-        abs_sum += fabsf(v);
-    }
-
+    for (int i = 0; i < QK_TURBO4; ++i) norm_sq += x[i] * x[i];
     float norm = sqrtf(norm_sq);
-    if (norm < 1e-10f) {
-        norm = 1.0f;
-    }
-    y->norm = __float2half(norm);
-    y->rnorm = __float2half(abs_sum / (float) QK_TURBO4);
-
+    if (norm < 1e-10f) norm = 1.0f;
     const float inv_norm = 1.0f / norm;
-    for (int i = 0; i < (int) sizeof(y->qs); ++i) {
-        y->qs[i] = 0;
-    }
-    for (int i = 0; i < (int) sizeof(y->signs); ++i) {
-        y->signs[i] = 0;
-    }
 
+    for (int i = 0; i < (int) sizeof(y->qs); ++i) y->qs[i] = 0;
+
+    float recon_sq = 0.0f;
     for (int i = 0; i < QK_TURBO4; ++i) {
         const float v = x[i] * inv_norm;
         uint8_t idx = 0;
-        if (v > -0.154259f) {
-            idx = 1;
-        }
-        if (v > -0.091775f) {
-            idx = 2;
-        }
-        if (v > -0.043589f) {
-            idx = 3;
-        }
-        if (v > 0.0f) {
-            idx = 4;
-        }
-        if (v > 0.043589f) {
-            idx = 5;
-        }
-        if (v > 0.091775f) {
-            idx = 6;
-        }
-        if (v > 0.154259f) {
-            idx = 7;
-        }
-
-        const int bit_offset = i * 3;
-        const int byte_idx = bit_offset / 8;
-        const int bit_pos = bit_offset % 8;
-
-        y->qs[byte_idx] |= (idx & 0x7) << bit_pos;
-        if (bit_pos > 5 && byte_idx + 1 < (int) sizeof(y->qs)) {
-            y->qs[byte_idx + 1] |= (idx & 0x7) >> (8 - bit_pos);
-        }
-
-        if (v >= 0.0f) {
-            y->signs[i / 8] |= 1u << (i % 8);
-        }
+        if (v >= -0.212203f) idx = 1;
+        if (v >= -0.162947f) idx = 2;
+        if (v >= -0.127026f) idx = 3;
+        if (v >= -0.097164f) idx = 4;
+        if (v >= -0.070671f) idx = 5;
+        if (v >= -0.046174f) idx = 6;
+        if (v >= -0.022824f) idx = 7;
+        if (v >= 0.0f)       idx = 8;
+        if (v >= 0.022824f)  idx = 9;
+        if (v >= 0.046174f)  idx = 10;
+        if (v >= 0.070671f)  idx = 11;
+        if (v >= 0.097164f)  idx = 12;
+        if (v >= 0.127026f)  idx = 13;
+        if (v >= 0.162947f)  idx = 14;
+        if (v >= 0.212203f)  idx = 15;
+        y->qs[i / 2] |= (uint8_t)((idx & 0xF) << ((i % 2) * 4));
+        recon_sq += centroids[idx] * centroids[idx];
     }
+
+    const float recon_norm = sqrtf(recon_sq);
+    y->norm = __float2half((recon_norm > 1e-10f) ? norm / recon_norm : norm);
+}
+
+static __device__ void quantize_f32_turbo2_0_block(const float * __restrict__ x, block_turbo2_0 * __restrict__ y) {
+    static constexpr float centroids[4] = { -0.133462f, -0.039994f, 0.039994f, 0.133462f };
+
+    float norm_sq = 0.0f;
+    for (int i = 0; i < QK_TURBO2; ++i) norm_sq += x[i] * x[i];
+    float norm = sqrtf(norm_sq);
+    if (norm < 1e-10f) norm = 1.0f;
+    const float inv_norm = 1.0f / norm;
+
+    for (int i = 0; i < (int) sizeof(y->qs); ++i) y->qs[i] = 0;
+
+    float recon_sq = 0.0f;
+    for (int i = 0; i < QK_TURBO2; ++i) {
+        const float v = x[i] * inv_norm;
+        uint8_t idx = 0;
+        if (v >= -0.086728f) idx = 1;
+        if (v >= 0.0f)       idx = 2;
+        if (v >= 0.086728f)  idx = 3;
+        y->qs[i / 4] |= (uint8_t)((idx & 0x3) << ((i % 4) * 2));
+        recon_sq += centroids[idx] * centroids[idx];
+    }
+
+    const float recon_norm = sqrtf(recon_sq);
+    y->norm = __float2half((recon_norm > 1e-10f) ? norm / recon_norm : norm);
 }
 
 template<typename src_t, typename dst_t>

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -613,28 +613,15 @@ static __device__ __forceinline__ float vec_dot_fattn_vec_KQ_tq3_0(
 
 template <typename block_t>
 static __device__ __forceinline__ float turbo4_decode_element(const block_t * blk, const int j) {
-    static constexpr float turbo_centroids[8] = {
-        -0.190685f, -0.117832f, -0.065717f, -0.021460f,
-         0.021460f,  0.065717f,  0.117832f,  0.190685f
+    static constexpr float turbo_centroids[16] = {
+        -0.241529f, -0.182877f, -0.143016f, -0.111036f,
+        -0.083292f, -0.058050f, -0.034299f, -0.011349f,
+         0.011349f,  0.034299f,  0.058050f,  0.083292f,
+         0.111036f,  0.143016f,  0.182877f,  0.241529f
     };
-    static constexpr float turbo_qjl_const = 1.2533141373155003f;
-
     const float norm = __half2float(blk->norm);
-    const float rnorm = __half2float(blk->rnorm);
-    const float qjl_scale = turbo_qjl_const / (float) QK_TURBO4 * rnorm;
-
-    const int bit_offset = j * 3;
-    const int byte_idx = bit_offset / 8;
-    const int bit_pos = bit_offset % 8;
-
-    uint16_t raw = (uint16_t) blk->qs[byte_idx];
-    if (byte_idx + 1 < (int) sizeof(blk->qs)) {
-        raw |= (uint16_t) blk->qs[byte_idx + 1] << 8;
-    }
-
-    const uint8_t idx = (raw >> bit_pos) & 0x7;
-    const float sign = (blk->signs[j / 8] & (1u << (j % 8))) ? 1.0f : -1.0f;
-    return (turbo_centroids[idx] + sign * qjl_scale) * norm;
+    const uint8_t idx = (blk->qs[j / 2] >> ((j % 2) * 4)) & 0xF;
+    return turbo_centroids[idx] * norm;
 }
 
 template <int D, int nthreads>
@@ -642,8 +629,8 @@ static __device__ __forceinline__ float vec_dot_fattn_vec_KQ_turbo3_0(
     const char * __restrict__ K_c, const void * __restrict__ Q_v, const int * __restrict__ Q_q8, const void * __restrict__ Q_ds_v) {
 
     static constexpr float turbo_centroids[8] = {
-        -0.190685f, -0.117832f, -0.065717f, -0.021460f,
-         0.021460f,  0.065717f,  0.117832f,  0.190685f
+        -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+         0.021663f,  0.066822f,  0.118786f,  0.190207f
     };
     const block_turbo3_0 * K_turbo = (const block_turbo3_0 *) K_c;
     GGML_UNUSED(Q_q8);
@@ -728,8 +715,8 @@ static __device__ __forceinline__ void dequantize_V_tq3_0(const void * __restric
 template <typename T, int ne>
 static __device__ __forceinline__ void dequantize_V_turbo3_0(const void * __restrict__ vx, void * __restrict__ dst, const int64_t i0) {
     static constexpr float turbo_centroids[8] = {
-        -0.190685f, -0.117832f, -0.065717f, -0.021460f,
-         0.021460f,  0.065717f,  0.117832f,  0.190685f
+        -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+         0.021663f,  0.066822f,  0.118786f,  0.190207f
     };
     const block_turbo3_0 * x = (const block_turbo3_0 *) vx;
     const int ib = i0 / QK_TURBO3;

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common.cuh"
 #include "cp-async.cuh"
 #include "mma.cuh"
@@ -447,6 +449,119 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Turbo KV tile loaders for the MMA decode path.
+// Each dequantizes raw turbo bytes into the SRAM tile_KV in the same half2
+// row-major layout the f16 loader produces, so downstream ldmatrix paths are
+// byte-identical to f16.
+// ---------------------------------------------------------------------------
+
+static __constant__ float TURBO_CENTROIDS_4BIT_FATTN[16] = {
+    -0.241529f, -0.182877f, -0.143016f, -0.111036f,
+    -0.083292f, -0.058050f, -0.034299f, -0.011349f,
+     0.011349f,  0.034299f,  0.058050f,  0.083292f,
+     0.111036f,  0.143016f,  0.182877f,  0.241529f
+};
+
+template<int stride_tile, int nbatch_fa, int nthreads, bool oob_check>
+static __device__ __forceinline__ void flash_attn_ext_turbo4_load_tile(
+        const char * const __restrict__ KV_raw, half2 * const __restrict__ tile_KV,
+        const int D2, const int stride_bytes, const int col_offset, const int i_sup) {
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    const int tid = threadIdx.y * warp_size + threadIdx.x;
+#pragma unroll
+    for (int row = tid; row < nbatch_fa; row += nthreads) {
+        if (oob_check && row >= i_sup) {
+            for (int c = 0; c < D2; ++c) tile_KV[row*stride_tile + c] = make_half2(0.0f, 0.0f);
+            continue;
+        }
+        const char * row_ptr = KV_raw + (int64_t)row * stride_bytes;
+        for (int c = 0; c < D2; ++c) {
+            const int col     = col_offset + c;
+            const int blk_idx = col / (QK_TURBO4 / 2);
+            const int in_blk  = col % (QK_TURBO4 / 2);
+            const block_turbo4_0 * blk = (const block_turbo4_0 *)(row_ptr) + blk_idx;
+            const float norm = __half2float(blk->norm);
+            const uint8_t byte = blk->qs[in_blk];
+            const half lo = __float2half(TURBO_CENTROIDS_4BIT_FATTN[byte & 0xF] * norm);
+            const half hi = __float2half(TURBO_CENTROIDS_4BIT_FATTN[byte >>  4] * norm);
+            tile_KV[row*stride_tile + c] = __halves2half2(lo, hi);
+        }
+    }
+}
+
+static __constant__ float TURBO_CENTROIDS_3BIT_FATTN[8] = {
+    -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+     0.021663f,  0.066822f,  0.118786f,  0.190207f
+};
+
+template<int stride_tile, int nbatch_fa, int nthreads, bool oob_check>
+static __device__ __forceinline__ void flash_attn_ext_turbo3_load_tile(
+        const char * const __restrict__ KV_raw, half2 * const __restrict__ tile_KV,
+        const int D2, const int stride_bytes, const int col_offset, const int i_sup) {
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    const int tid = threadIdx.y * warp_size + threadIdx.x;
+#pragma unroll
+    for (int row = tid; row < nbatch_fa; row += nthreads) {
+        if (oob_check && row >= i_sup) {
+            for (int c = 0; c < D2; ++c) tile_KV[row*stride_tile + c] = make_half2(0.0f, 0.0f);
+            continue;
+        }
+        const char * row_ptr = KV_raw + (int64_t)row * stride_bytes;
+        for (int c = 0; c < D2; ++c) {
+            const int col   = col_offset + c;
+            const int elem0 = col * 2;
+            const int ib    = elem0 / QK_TURBO3;
+            const int j0    = elem0 % QK_TURBO3;
+            const block_turbo3_0 * blk = (const block_turbo3_0 *)(row_ptr) + ib;
+            const float   norm     = __half2float(blk->norm);
+            const uint8_t qs_byte  = blk->qs[j0 / 4];
+            const uint8_t sgn_byte = blk->signs[j0 / 8];
+            const int     shift    = (j0 % 4) * 2;
+            const uint8_t idx0 = ((qs_byte >> shift)     & 0x3) | (((sgn_byte >> (j0 % 8))     & 0x1) << 2);
+            const uint8_t idx1 = ((qs_byte >> (shift+2)) & 0x3) | (((sgn_byte >> (j0 % 8 + 1)) & 0x1) << 2);
+            const half lo = __float2half(TURBO_CENTROIDS_3BIT_FATTN[idx0] * norm);
+            const half hi = __float2half(TURBO_CENTROIDS_3BIT_FATTN[idx1] * norm);
+            tile_KV[row*stride_tile + c] = __halves2half2(lo, hi);
+        }
+    }
+}
+
+static __constant__ float TURBO_CENTROIDS_2BIT_FATTN[4] = {
+    -0.133462f, -0.039994f, 0.039994f, 0.133462f
+};
+
+template<int stride_tile, int nbatch_fa, int nthreads, bool oob_check>
+static __device__ __forceinline__ void flash_attn_ext_turbo2_load_tile(
+        const char * const __restrict__ KV_raw, half2 * const __restrict__ tile_KV,
+        const int D2, const int stride_bytes, const int col_offset, const int i_sup) {
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    const int tid = threadIdx.y * warp_size + threadIdx.x;
+#pragma unroll
+    for (int row = tid; row < nbatch_fa; row += nthreads) {
+        if (oob_check && row >= i_sup) {
+            for (int c = 0; c < D2; ++c) tile_KV[row*stride_tile + c] = make_half2(0.0f, 0.0f);
+            continue;
+        }
+        const char * row_ptr = KV_raw + (int64_t)row * stride_bytes;
+        for (int c = 0; c < D2; ++c) {
+            const int col   = col_offset + c;
+            const int elem0 = col * 2;
+            const int ib    = elem0 / QK_TURBO2;
+            const int j0    = elem0 % QK_TURBO2;
+            const block_turbo2_0 * blk = (const block_turbo2_0 *)(row_ptr) + ib;
+            const float   norm    = __half2float(blk->norm);
+            const uint8_t qs_byte = blk->qs[j0 / 4];
+            const int     shift   = (j0 % 4) * 2;
+            const uint8_t idx0 = (qs_byte >> shift)     & 0x3;
+            const uint8_t idx1 = (qs_byte >> (shift+2)) & 0x3;
+            const half lo = __float2half(TURBO_CENTROIDS_2BIT_FATTN[idx0] * norm);
+            const half hi = __float2half(TURBO_CENTROIDS_2BIT_FATTN[idx1] * norm);
+            tile_KV[row*stride_tile + c] = __halves2half2(lo, hi);
+        }
+    }
+}
+
 template<int ncols1, int nwarps, int nbatch_fa, bool use_cp_async, bool oob_check>
 static __device__ __forceinline__ void flash_attn_ext_f16_load_mask(
         const half * const __restrict__ mask_h, half * const __restrict__ tile_mask,
@@ -529,7 +644,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_mask(
 
 template<int DKQ, int DV, int ncols1, int ncols2, int nwarps,
     bool use_logit_softcap, bool V_is_K_view, bool needs_fixup, bool is_fixup, bool last_iter, bool oob_check,
-    typename T_A_KQ, typename T_B_KQ, typename T_C_KQ, typename T_A_VKQ, typename T_B_VKQ, typename T_C_VKQ>
+    typename T_A_KQ, typename T_B_KQ, typename T_C_KQ, typename T_A_VKQ, typename T_B_VKQ, typename T_C_VKQ,
+    ggml_type type_K = GGML_TYPE_F16, ggml_type type_V = GGML_TYPE_F16>
 static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         const float2 * const __restrict__ Q_f2,
         const half2  * const __restrict__ K_h2,
@@ -566,7 +682,10 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
     constexpr int  nbatch_K2       = ggml_cuda_fattn_mma_get_nbatch_K2(DKQ, DV, ncols);
     constexpr int  nbatch_V2       = ggml_cuda_fattn_mma_get_nbatch_V2(DKQ, DV, ncols);
     constexpr bool Q_in_reg        = ggml_cuda_fattn_mma_get_Q_in_reg (DKQ, DV, ncols);
-    constexpr int  nstages         = ggml_cuda_fattn_mma_get_nstages  (DKQ, DV, ncols1, ncols2);
+    // Turbo KV is dequantized synchronously into SRAM; the cp.async multi-stage pipeline
+    // would copy raw turbo bytes as half2 => garbage. Force single-stage synchronous loading.
+    constexpr bool is_turbo_kv     = (type_K != GGML_TYPE_F16 || type_V != GGML_TYPE_F16);
+    constexpr int  nstages         = is_turbo_kv ? 0 : ggml_cuda_fattn_mma_get_nstages(DKQ, DV, ncols1, ncols2);
 
     constexpr int stride_tile_K = nbatch_K2 + 4;
 
@@ -604,7 +723,25 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
     for (int k0_start = (DKQ/2-1) - (DKQ/2-1) % nbatch_K2; k0_start >= 0; k0_start -= nbatch_K2) {
         const int k0_stop = k0_start + nbatch_K2 < DKQ/2 ? k0_start + nbatch_K2 : DKQ/2;
 
-        if constexpr (nstages <= 1) {
+        if constexpr (is_turbo_kv) {
+            const int k0_diff = k0_stop - k0_start;
+            static_assert(type_K == GGML_TYPE_TURBO4_0 || type_K == GGML_TYPE_TURBO3_0 || type_K == GGML_TYPE_TURBO2_0,
+                          "only turbo2/3/4 K supported on the MMA turbo path");
+            static_assert(nbatch_K2 == DKQ/2, "turbo MMA load assumes full-row K tiles (nbatch_K2==DKQ/2)");
+            constexpr int nthreads_turbo = nwarps * ggml_cuda_get_physical_warp_size();
+            const char * K_raw = (const char *) K_h2 + int64_t(k_VKQ_0) * stride_K;
+            if constexpr (type_K == GGML_TYPE_TURBO4_0) {
+                flash_attn_ext_turbo4_load_tile<stride_tile_K, nbatch_fa, nthreads_turbo, oob_check>
+                    (K_raw, tile_K, k0_diff, stride_K, k0_start, k_VKQ_sup);
+            } else if constexpr (type_K == GGML_TYPE_TURBO3_0) {
+                flash_attn_ext_turbo3_load_tile<stride_tile_K, nbatch_fa, nthreads_turbo, oob_check>
+                    (K_raw, tile_K, k0_diff, stride_K, k0_start, k_VKQ_sup);
+            } else {
+                flash_attn_ext_turbo2_load_tile<stride_tile_K, nbatch_fa, nthreads_turbo, oob_check>
+                    (K_raw, tile_K, k0_diff, stride_K, k0_start, k_VKQ_sup);
+            }
+            __syncthreads();
+        } else if constexpr (nstages <= 1) {
             const int k0_diff = k0_stop - k0_start;
             constexpr bool use_cp_async = nstages == 1;
             flash_attn_ext_f16_load_tile<stride_tile_K, nwarps, nbatch_fa, use_cp_async, oob_check>
@@ -955,7 +1092,26 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         static_assert(DV % (2*nbatch_V2) == 0, "bad loop size");
         const int i0_stop = i0_start + 2*nbatch_V2;
 
-        if constexpr (nstages <= 1) {
+        if constexpr (is_turbo_kv) {
+            const int i0_diff = i0_stop - i0_start;
+            static_assert(type_V == GGML_TYPE_TURBO4_0 || type_V == GGML_TYPE_TURBO3_0 || type_V == GGML_TYPE_TURBO2_0,
+                          "only turbo2/3/4 V supported on the MMA turbo path");
+            static_assert(!V_is_K_view, "turbo MMA path never uses V_is_K_view");
+            static_assert(nbatch_V2 == DV/2, "turbo MMA load assumes full-row V tiles (nbatch_V2==DV/2)");
+            constexpr int nthreads_turbo = nwarps * ggml_cuda_get_physical_warp_size();
+            const char * V_raw = (const char *) V_h2 + int64_t(k_VKQ_0) * stride_V;
+            if constexpr (type_V == GGML_TYPE_TURBO4_0) {
+                flash_attn_ext_turbo4_load_tile<stride_tile_V, nbatch_fa, nthreads_turbo, oob_check>
+                    (V_raw, tile_V, i0_diff/2, stride_V, i0_start/2, k_VKQ_sup);
+            } else if constexpr (type_V == GGML_TYPE_TURBO3_0) {
+                flash_attn_ext_turbo3_load_tile<stride_tile_V, nbatch_fa, nthreads_turbo, oob_check>
+                    (V_raw, tile_V, i0_diff/2, stride_V, i0_start/2, k_VKQ_sup);
+            } else {
+                flash_attn_ext_turbo2_load_tile<stride_tile_V, nbatch_fa, nthreads_turbo, oob_check>
+                    (V_raw, tile_V, i0_diff/2, stride_V, i0_start/2, k_VKQ_sup);
+            }
+            __syncthreads();
+        } else if constexpr (nstages <= 1) {
             const int i0_diff = i0_stop - i0_start;
             if (!V_is_K_view || i0_stop > 2*nbatch_K2) {
                 constexpr bool use_cp_async = nstages == 1;
@@ -1113,7 +1269,8 @@ template<int DV, int ncols> struct mma_tile_sizes {
 };
 #endif // defined(TURING_MMA_AVAILABLE)
 
-template<int DKQ, int DV, int ncols1, int ncols2, int nwarps, bool use_logit_softcap, bool V_is_K_view, bool needs_fixup, bool is_fixup>
+template<int DKQ, int DV, int ncols1, int ncols2, int nwarps, bool use_logit_softcap, bool V_is_K_view, bool needs_fixup, bool is_fixup,
+    ggml_type type_K = GGML_TYPE_F16, ggml_type type_V = GGML_TYPE_F16>
 static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
         const float2 * const __restrict__ Q_f2,
         const half2  * const __restrict__ K_h2,
@@ -1277,7 +1434,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
             constexpr int  k_VKQ_sup = nbatch_fa;
             flash_attn_ext_f16_iter
                 <DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup, last_iter, oob_check,
-                 T_A_KQ, T_B_KQ, T_C_KQ, T_A_VKQ, T_B_VKQ, T_C_VKQ>
+                 T_A_KQ, T_B_KQ, T_C_KQ, T_A_VKQ, T_B_VKQ, T_C_VKQ, type_K, type_V>
                 (Q_f2, K_h2, V_h2, mask_h, dstk, dstk_fixup, scale, slope, logit_softcap,
                  ne01, ne02, stride_K, stride_V, stride_mask, tile_Q, tile_K, tile_V, tile_mask, Q_B, VKQ_C,
                  KQ_max, KQ_rowsum, jt, kb0, k_VKQ_sup);
@@ -1286,7 +1443,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
         const     int  k_VKQ_sup = ne11 - kb0*nbatch_fa;
         flash_attn_ext_f16_iter
             <DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup, last_iter, oob_check,
-              T_A_KQ, T_B_KQ, T_C_KQ, T_A_VKQ, T_B_VKQ, T_C_VKQ>
+              T_A_KQ, T_B_KQ, T_C_KQ, T_A_VKQ, T_B_VKQ, T_C_VKQ, type_K, type_V>
             (Q_f2, K_h2, V_h2, mask_h, dstk, dstk_fixup, scale, slope, logit_softcap,
              ne01, ne02, stride_K, stride_V, stride_mask, tile_Q, tile_K, tile_V, tile_mask, Q_B, VKQ_C,
              KQ_max, KQ_rowsum, jt, kb0, k_VKQ_sup);
@@ -1297,7 +1454,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
             constexpr int  k_VKQ_sup = nbatch_fa;
             flash_attn_ext_f16_iter
                 <DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup, last_iter, oob_check,
-                 T_A_KQ, T_B_KQ, T_C_KQ, T_A_VKQ, T_B_VKQ, T_C_VKQ>
+                 T_A_KQ, T_B_KQ, T_C_KQ, T_A_VKQ, T_B_VKQ, T_C_VKQ, type_K, type_V>
                 (Q_f2, K_h2, V_h2, mask_h, dstk, dstk_fixup, scale, slope, logit_softcap,
                  ne01, ne02, stride_K, stride_V, stride_mask, tile_Q, tile_K, tile_V, tile_mask, Q_B, VKQ_C,
                  KQ_max, KQ_rowsum, jt, kb0, k_VKQ_sup);
@@ -1700,7 +1857,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
 #endif // defined(VOLTA_MMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE)
 }
 
-template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, bool V_is_K_view>
+template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, bool V_is_K_view,
+    ggml_type type_K = GGML_TYPE_F16, ggml_type type_V = GGML_TYPE_F16>
 __launch_bounds__(ggml_cuda_fattn_mma_get_nthreads(DKQ, DV, ncols1*ncols2), ggml_cuda_fattn_mma_get_occupancy(DKQ, DV, ncols1*ncols2))
 static __global__ void flash_attn_ext_f16(
         const char * Q_ptr,
@@ -1829,12 +1987,12 @@ static __global__ void flash_attn_ext_f16(
         constexpr bool is_fixup = false; // All but (potentially) the last iterations write their data to dst rather than the fixup buffer.
         if (kb0_start == 0) {
             constexpr bool needs_fixup = false; // CUDA block is working on an entire tile.
-            flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup>
+            flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup, type_K, type_V>
                 (Q_f2, K_h2, V_h2, mask_h, sinks_f, dstk, dst_meta, scale, slope, logit_softcap,
                  ne01, ne02, gqa_ratio, ne11, stride_Q1, stride_Q2, stride_K, stride_V, stride_mask, jt, zt_gqa, kb0_start, kb0_stop);
         } else {
             constexpr bool needs_fixup = true; // CUDA block is missing the beginning of a tile.
-            flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup>
+            flash_attn_ext_f16_process_tile<DKQ, DV, ncols1, ncols2, nwarps, use_logit_softcap, V_is_K_view, needs_fixup, is_fixup, type_K, type_V>
                 (Q_f2, K_h2, V_h2, mask_h, sinks_f, dstk, dst_meta, scale, slope, logit_softcap,
                  ne01, ne02, gqa_ratio, ne11, stride_Q1, stride_Q2, stride_K, stride_V, stride_mask, jt, zt_gqa, kb0_start, kb0_stop);
         }

--- a/ggml/src/ggml-cuda/fattn-mma-turbo.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-turbo.cuh
@@ -1,0 +1,118 @@
+// Fused turbo4 (4-bit PolarQuant) MMA flash-attention DECODE launcher.
+//
+// This is the host-side case launcher for the GQA-packed MMA path with turbo4 KV.
+// It reuses the f16 MMA device kernel (flash_attn_ext_f16 in fattn-mma-f16.cuh) but
+// instantiates it with type_K/type_V = TURBO4_0 so the in-kernel load tiles dequantize
+// raw turbo4 blocks straight into SRAM. Q is ALREADY rotated at the graph level
+// (src/llama-graph.cpp) and the FA output is inverse-rotated there too — this path does
+// NO inline FWHT and NO src swap (that would double-rotate Q).
+//
+// Differences vs ggml_cuda_flash_attn_ext_mma_f16_case:
+//   * nstages is forced to 0 inside the kernel for turbo (synchronous dequant load), so
+//     here we size shared memory for the 1-stage path.
+//   * launch_fattn is called with need_f16_K = need_f16_V = false, so launch_fattn does
+//     NOT pre-convert K/V to f16; the kernel receives the raw quantized bytes and the
+//     true byte pitch nb11/nb21.
+
+#pragma once
+
+#include "common.cuh"
+#include "fattn-common.cuh"
+#include "fattn-mma-f16.cuh"
+
+template <int DKQ, int DV, int ncols1, int ncols2, ggml_type type_K, ggml_type type_V>
+void ggml_cuda_flash_attn_ext_mma_turbo_case(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * KQV = dst;
+    const int id = ggml_cuda_get_device();
+    const int cc = ggml_cuda_info().devices[id].cc;
+
+    constexpr int ncols = ncols1 * ncols2;
+
+    const int  nthreads       = ggml_cuda_fattn_mma_get_nthreads      (DKQ, DV, ncols, cc);
+    const int  nbatch_fa      = ggml_cuda_fattn_mma_get_nbatch_fa     (DKQ, DV, ncols, cc);
+    const int  nbatch_K2      = ggml_cuda_fattn_mma_get_nbatch_K2     (DKQ, DV, ncols, cc);
+    const int  nbatch_V2      = ggml_cuda_fattn_mma_get_nbatch_V2     (DKQ, DV, ncols, cc);
+    const int  nbatch_combine = ggml_cuda_fattn_mma_get_nbatch_combine(DKQ, DV, ncols, cc);
+    const bool Q_in_reg       = ggml_cuda_fattn_mma_get_Q_in_reg      (DKQ, DV, ncols, cc);
+
+    // turbo path is always single-stage synchronous (nstages forced to 0 in the kernel).
+    const int cols_per_warp = std::min(ncols, get_cols_per_warp(cc));
+    const int warp_size_host = ggml_cuda_info().devices[ctx.device].warp_size;
+    const int nwarps         = nthreads / warp_size_host;
+
+    // turbo4 never aliases V onto K.
+    constexpr bool V_is_K_view = false;
+
+    const size_t nbytes_shared_KV_1stage = nbatch_fa            * std::max(nbatch_K2 + 4,  nbatch_V2 + 4) * sizeof(half2);
+    const size_t nbytes_shared_Q         = ncols                * (DKQ/2 + 4)                             * sizeof(half2);
+    const size_t nbytes_shared_mask      = ncols1               * (nbatch_fa/2 + 4)                       * sizeof(half2);
+    const size_t nbytes_shared_combine   = nwarps*cols_per_warp * (nbatch_combine + 4)                    * sizeof(half2);
+
+    const size_t nbytes_shared_KV = nbytes_shared_KV_1stage;
+
+    const size_t nbytes_shared_total = std::max(nbytes_shared_combine, Q_in_reg ?
+        std::max(nbytes_shared_Q,  nbytes_shared_KV + nbytes_shared_mask) :
+                 nbytes_shared_Q + nbytes_shared_KV + nbytes_shared_mask);
+
+    float logit_softcap;
+    memcpy(&logit_softcap, (const float *) KQV->op_params + 2, sizeof(float));
+
+#if defined(GGML_USE_HIP)
+    using fattn_kernel_ptr_t = const void*;
+#else
+    using fattn_kernel_ptr_t = fattn_kernel_t;
+#endif // defined(GGML_USE_HIP)
+    fattn_kernel_t fattn_kernel;
+    if (logit_softcap == 0.0f) {
+        constexpr bool use_logit_softcap = false;
+        fattn_kernel = flash_attn_ext_f16<DKQ, DV, ncols1, ncols2, use_logit_softcap, V_is_K_view, type_K, type_V>;
+
+#if !defined(GGML_USE_MUSA)
+        static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
+        if (!shared_memory_limit_raised[id]) {
+            CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
+            shared_memory_limit_raised[id] = true;
+        }
+#endif // !defined(GGML_USE_MUSA)
+    } else {
+        constexpr bool use_logit_softcap = true;
+        fattn_kernel = flash_attn_ext_f16<DKQ, DV, ncols1, ncols2, use_logit_softcap, V_is_K_view, type_K, type_V>;
+
+#if !defined(GGML_USE_MUSA)
+        static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
+        if (!shared_memory_limit_raised[id]) {
+            CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
+            shared_memory_limit_raised[id] = true;
+        }
+#endif // !defined(GGML_USE_MUSA)
+    }
+
+    // need_f16_K = need_f16_V = false: launch_fattn does NOT convert turbo bytes to f16;
+    // the kernel receives raw quantized KV + the true byte pitch. stream_k = true.
+    launch_fattn<DV, ncols1, ncols2>
+        (ctx, dst, fattn_kernel, nwarps, nbytes_shared_total, nbatch_fa,
+         /*need_f16_K=*/false, /*need_f16_V=*/false, /*stream_k=*/true, warp_size_host);
+}
+
+
+#define DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, ncols1, ncols2, tK, tV)                  \
+    template void ggml_cuda_flash_attn_ext_mma_turbo_case                           \
+    <DKQ, DV, ncols1, ncols2, tK, tV>(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
+
+// The reachable (ncols1, ncols2) set for Q->ne[1] in {1..4} with turing_mma_available
+// is exactly: (1,8),(2,8),(4,8),(2,4),(4,4),(4,2),(8,1). Declare those externs only.
+#define DECL_FATTN_MMA_TURBO_ALL(DKQ, DV, tK, tV)        \
+    extern DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, 1, 8, tK, tV); \
+    extern DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, 2, 8, tK, tV); \
+    extern DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, 4, 8, tK, tV); \
+    extern DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, 2, 4, tK, tV); \
+    extern DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, 4, 4, tK, tV); \
+    extern DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, 4, 2, tK, tV); \
+    extern DECL_FATTN_MMA_TURBO_CASE(DKQ, DV, 8, 1, tK, tV); \
+
+DECL_FATTN_MMA_TURBO_ALL(128, 128, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_ALL(256, 256, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_ALL(128, 128, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_ALL(256, 256, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_ALL(128, 128, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);
+DECL_FATTN_MMA_TURBO_ALL(256, 256, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -290,6 +290,13 @@ static void ggml_cuda_flash_attn_ext_vec(ggml_backend_cuda_context & ctx, ggml_t
     FATTN_VEC_CASES_ALL_D(GGML_TYPE_TQ3_0, GGML_TYPE_TQ3_0)
     FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO4_0, GGML_TYPE_TQ3_0)
 
+    // Turbo3/4 KV cache with f16 V
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO3_0, GGML_TYPE_F16)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO3_0, GGML_TYPE_Q8_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO4_0, GGML_TYPE_F16)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO4_0, GGML_TYPE_Q8_0)
+
     GGML_ABORT("fatal error");
 }
 
@@ -420,6 +427,15 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
     if (K->type == GGML_TYPE_TURBO4_0 && V->type == GGML_TYPE_TQ3_0) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
+    }
+
+    // Turbo3/4 K type: use vec FA for decode, MMA is not yet implemented for these types.
+    // Restrict to decode (Q <= 4) same as the turbo4+tq3_0 path.
+    if (K->type == GGML_TYPE_TURBO3_0 || K->type == GGML_TYPE_TURBO4_0) {
+        if (Q->ne[1] <= 4) {
+            return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
+        }
+        return BEST_FATTN_KERNEL_NONE;
     }
 
     // If Turing tensor cores are available, use them:

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -364,6 +364,14 @@ static void ggml_cuda_flash_attn_ext_vec(ggml_backend_cuda_context & ctx, ggml_t
     FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO4_0, GGML_TYPE_F16)
     FATTN_VEC_CASES_ALL_D(GGML_TYPE_TURBO4_0, GGML_TYPE_Q8_0)
 
+    // Asymmetric standard K + turbo V (e.g. -ctk q8_0 -ctv turbo3)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_F16,  GGML_TYPE_TURBO3_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q4_0, GGML_TYPE_TURBO3_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q8_0, GGML_TYPE_TURBO3_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_F16,  GGML_TYPE_TURBO4_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q4_0, GGML_TYPE_TURBO4_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q8_0, GGML_TYPE_TURBO4_0)
+
     GGML_ABORT("fatal error");
 }
 
@@ -504,6 +512,14 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     }
 
     if (K->type == GGML_TYPE_TURBO4_0 && V->type == GGML_TYPE_TQ3_0) {
+        return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
+    }
+
+    // Asymmetric turbo V (K != V type): turbo types have no GPU to_fp16 conversion,
+    // so the MMA_F16 tile path would dereference a null function pointer. Force VEC.
+    const bool asymm_turbo_v = (V->type == GGML_TYPE_TURBO3_0 || V->type == GGML_TYPE_TURBO4_0) &&
+                               K->type != V->type;
+    if (asymm_turbo_v) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
     }
 

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -1,6 +1,7 @@
 #include "common.cuh"
 #include "fattn-common.cuh"
 #include "fattn-mma-f16.cuh"
+#include "fattn-mma-turbo.cuh"
 #include "fattn-tile.cuh"
 #include "fattn-vec.cuh"
 #include "fattn-wmma-f16.cuh"
@@ -201,6 +202,72 @@ static void ggml_cuda_flash_attn_ext_mma_f16(ggml_backend_cuda_context & ctx, gg
     }
 }
 
+// ---------------------------------------------------------------------------
+// Fused turbo MMA decode dispatch (mirrors the f16 switch helpers, type-parametric).
+// Only reached from the gate: K==V==turbo, D in {128,256}, Q->ne[1] <= 4, turing MMA.
+// ---------------------------------------------------------------------------
+
+template <int DKQ, int DV, ggml_type type_K, ggml_type type_V>
+static void ggml_cuda_flash_attn_ext_mma_turbo_dispatch_ncols1_8(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * Q = dst->src[0]; // ncols2 == 8: (1,8),(2,8),(4,8)
+    if (Q->ne[1] <= 1) { ggml_cuda_flash_attn_ext_mma_turbo_case<DKQ, DV, 1, 8, type_K, type_V>(ctx, dst); return; }
+    if (Q->ne[1] <= 2) { ggml_cuda_flash_attn_ext_mma_turbo_case<DKQ, DV, 2, 8, type_K, type_V>(ctx, dst); return; }
+    ggml_cuda_flash_attn_ext_mma_turbo_case<DKQ, DV, 4, 8, type_K, type_V>(ctx, dst);
+}
+
+template <int DKQ, int DV, ggml_type type_K, ggml_type type_V>
+static void ggml_cuda_flash_attn_ext_mma_turbo_dispatch_ncols1_4(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * Q = dst->src[0]; // ncols2 == 4: (2,4),(4,4)
+    if (Q->ne[1] <= 2) { ggml_cuda_flash_attn_ext_mma_turbo_case<DKQ, DV, 2, 4, type_K, type_V>(ctx, dst); return; }
+    ggml_cuda_flash_attn_ext_mma_turbo_case<DKQ, DV, 4, 4, type_K, type_V>(ctx, dst);
+}
+
+template <int DKQ, int DV, ggml_type type_K, ggml_type type_V>
+static void ggml_cuda_flash_attn_ext_mma_turbo_switch_ncols2(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * KQV  = dst;
+    const ggml_tensor * Q    = dst->src[0];
+    const ggml_tensor * K    = dst->src[1];
+    const ggml_tensor * mask = dst->src[3];
+
+    float max_bias = 0.0f;
+    memcpy(&max_bias, (const float *) KQV->op_params + 1, sizeof(float));
+
+    bool use_gqa_opt = mask && max_bias == 0.0f && K->ne[1] % FATTN_KQ_STRIDE == 0;
+    const ggml_tensor * tensors_gqa[] = {Q, K, dst->src[2], mask};
+    for (const ggml_tensor * t : tensors_gqa) {
+        if (t == nullptr || ggml_is_quantized(t->type)) { continue; }
+        for (size_t i = 1; i < GGML_MAX_DIMS; ++i) {
+            if (t->nb[i] % 16 != 0) { use_gqa_opt = false; break; }
+        }
+    }
+
+    GGML_ASSERT(Q->ne[2] % K->ne[2] == 0);
+    const int gqa_ratio = Q->ne[2] / K->ne[2];
+
+    if (use_gqa_opt && gqa_ratio > 4) {
+        ggml_cuda_flash_attn_ext_mma_turbo_dispatch_ncols1_8<DKQ, DV, type_K, type_V>(ctx, dst);
+        return;
+    }
+    if (use_gqa_opt && gqa_ratio > 2) {
+        ggml_cuda_flash_attn_ext_mma_turbo_dispatch_ncols1_4<DKQ, DV, type_K, type_V>(ctx, dst);
+        return;
+    }
+    if (use_gqa_opt && gqa_ratio > 1) {
+        ggml_cuda_flash_attn_ext_mma_turbo_case<DKQ, DV, 4, 2, type_K, type_V>(ctx, dst);
+        return;
+    }
+    ggml_cuda_flash_attn_ext_mma_turbo_case<DKQ, DV, 8, 1, type_K, type_V>(ctx, dst);
+}
+
+// Default ON. Set GGML_TURBO_MMA_FUSED=0 to fall back to VEC.
+static bool ggml_cuda_turbo_mma_fused() {
+    static const bool v = [] {
+        const char * s = getenv("GGML_TURBO_MMA_FUSED");
+        return !(s && s[0] == '0');
+    }();
+    return v;
+}
+
 #define FATTN_VEC_CASE(D, type_K, type_V)                                                                        \
     {                                                                                                            \
         const bool type_K_okay = K->type == (type_K) || (K->type == GGML_TYPE_F32 && (type_K) == GGML_TYPE_F16); \
@@ -379,12 +446,17 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
 #ifndef GGML_CUDA_FA_ALL_QUANTS
     if (K->type != V->type) {
+        auto is_kv_compat = [](ggml_type t) {
+            return t == GGML_TYPE_TURBO2_0 || t == GGML_TYPE_TURBO3_0 || t == GGML_TYPE_TURBO4_0
+                || t == GGML_TYPE_Q8_0 || t == GGML_TYPE_F16 || t == GGML_TYPE_BF16;
+        };
         const bool asymm_tq3_ok = (K->type == GGML_TYPE_Q8_0 || K->type == GGML_TYPE_Q4_0 ||
                                    K->type == GGML_TYPE_TURBO4_0) &&
                                   V->type == GGML_TYPE_TQ3_0;
-        if (!asymm_tq3_ok) {
+        if (!asymm_tq3_ok && !is_kv_compat(K->type) && !is_kv_compat(V->type)) {
             return BEST_FATTN_KERNEL_NONE;
         }
+        // tq3_0-V asymmetric path must stay on VEC (not MMA) — handled below
     }
 #endif // GGML_CUDA_FA_ALL_QUANTS
 
@@ -403,7 +475,13 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         case GGML_TYPE_BF16:
         case GGML_TYPE_TQ3_0:
         case GGML_TYPE_TURBO3_0:
+            if (K->ne[0] % 64 != 0) { return BEST_FATTN_KERNEL_NONE; }
+            break;
+        case GGML_TYPE_TURBO2_0:
+            if (K->ne[0] % 64 != 0) { return BEST_FATTN_KERNEL_NONE; }
+            break;
         case GGML_TYPE_TURBO4_0:
+            if (K->ne[0] % 64 != 0) { return BEST_FATTN_KERNEL_NONE; }
             break;
         default:
             return BEST_FATTN_KERNEL_NONE;
@@ -427,15 +505,6 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
     if (K->type == GGML_TYPE_TURBO4_0 && V->type == GGML_TYPE_TQ3_0) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
-    }
-
-    // Turbo3/4 K type: use vec FA for decode, MMA is not yet implemented for these types.
-    // Restrict to decode (Q <= 4) same as the turbo4+tq3_0 path.
-    if (K->type == GGML_TYPE_TURBO3_0 || K->type == GGML_TYPE_TURBO4_0) {
-        if (Q->ne[1] <= 4) {
-            return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
-        }
-        return BEST_FATTN_KERNEL_NONE;
     }
 
     // If Turing tensor cores are available, use them:
@@ -542,6 +611,37 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
 void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     ggml_cuda_set_device(ctx.device);
+
+    // Fused turbo MMA decode gate. Routes K==V==turbo, D in {128,256}, Q<=4, turing MMA
+    // onto the GQA-packed turbo MMA path (raw bytes → SRAM dequant, no f16 pre-conversion).
+    // Kill-switch: GGML_TURBO_MMA_FUSED=0.
+    {
+        const ggml_tensor * Q = dst->src[0];
+        const ggml_tensor * K = dst->src[1];
+        const ggml_tensor * V = dst->src[2];
+        const int cc = ggml_cuda_info().devices[ctx.device].cc;
+        const bool turbo_matched = (K->type == V->type &&
+            (K->type == GGML_TYPE_TURBO4_0 || K->type == GGML_TYPE_TURBO3_0 || K->type == GGML_TYPE_TURBO2_0));
+        if (ggml_cuda_turbo_mma_fused() && turbo_matched
+                && Q->ne[1] <= 4 && V->ne[0] == Q->ne[0] && turing_mma_available(cc)) {
+            if (Q->ne[0] == 128) {
+                switch (K->type) {
+                    case GGML_TYPE_TURBO4_0: ggml_cuda_flash_attn_ext_mma_turbo_switch_ncols2<128, 128, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0>(ctx, dst); return;
+                    case GGML_TYPE_TURBO3_0: ggml_cuda_flash_attn_ext_mma_turbo_switch_ncols2<128, 128, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0>(ctx, dst); return;
+                    case GGML_TYPE_TURBO2_0: ggml_cuda_flash_attn_ext_mma_turbo_switch_ncols2<128, 128, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0>(ctx, dst); return;
+                    default: break;
+                }
+            }
+            if (Q->ne[0] == 256) {
+                switch (K->type) {
+                    case GGML_TYPE_TURBO4_0: ggml_cuda_flash_attn_ext_mma_turbo_switch_ncols2<256, 256, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0>(ctx, dst); return;
+                    case GGML_TYPE_TURBO3_0: ggml_cuda_flash_attn_ext_mma_turbo_switch_ncols2<256, 256, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0>(ctx, dst); return;
+                    default: break;
+                }
+            }
+        }
+    }
+
     switch (ggml_cuda_get_best_fattn_kernel(ggml_cuda_get_device(), dst)) {
         case BEST_FATTN_KERNEL_NONE:
             GGML_ABORT("fatal error");

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5305,6 +5305,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_TQ3_0:
+                    case GGML_TYPE_TURBO2_0:
                     case GGML_TYPE_TURBO3_0:
                     case GGML_TYPE_TURBO4_0:
                     case GGML_TYPE_TQ3_1S:
@@ -5328,7 +5329,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 return (op->type == GGML_TYPE_F32 || op->type == GGML_TYPE_F16 || op->type == GGML_TYPE_BF16 ||
                        op->type == GGML_TYPE_Q4_0 || op->type == GGML_TYPE_Q4_1 || op->type == GGML_TYPE_Q5_0 ||
                        op->type == GGML_TYPE_Q5_1 || op->type == GGML_TYPE_Q8_0 || op->type == GGML_TYPE_IQ4_NL ||
-                       op->type == GGML_TYPE_TQ3_0 || op->type == GGML_TYPE_TURBO3_0 || op->type == GGML_TYPE_TURBO4_0 ||
+                       op->type == GGML_TYPE_TQ3_0 || op->type == GGML_TYPE_TURBO2_0 || op->type == GGML_TYPE_TURBO3_0 || op->type == GGML_TYPE_TURBO4_0 ||
                        op->type == GGML_TYPE_Q4_0_TQ || op->type == GGML_TYPE_Q4_1_TQ) &&
                        op->src[0]->type == GGML_TYPE_F32 &&
                        (op->src[1]->type == GGML_TYPE_I64 || op->src[1]->type == GGML_TYPE_I32);

--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -327,6 +327,16 @@ static void set_rows_cuda(ggml_backend_cuda_context & ctx, const ggml_tensor * s
             nb1, nb2, nb3,
             stream
         );
+    } else if (dst->type == GGML_TYPE_TURBO2_0) {
+        set_rows_cuda_quant<idx_t, block_turbo2_0, QK_TURBO2, quantize_f32_turbo2_0_block>(
+            src0_d, src1_d, (block_turbo2_0*)dst->data,
+            ne00, ne01, ne02, ne03,
+            ne10, ne11, ne12, ne13,
+            nb01, nb02, nb03,
+            nb10, nb11, nb12,
+            nb1, nb2, nb3,
+            stream
+        );
     } else if (dst->type == GGML_TYPE_TURBO3_0) {
         set_rows_cuda_quant<idx_t, block_turbo3_0, QK_TURBO3, quantize_f32_turbo3_0_block>(
             src0_d, src1_d, (block_turbo3_0*)dst->data,

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_1-ncols2_8.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_1-ncols2_8.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 1, 8, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 1, 8, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 1, 8, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_2-ncols2_4.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_2-ncols2_4.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 2, 4, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 2, 4, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 2, 4, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_2-ncols2_8.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_2-ncols2_8.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 2, 8, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 2, 8, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 2, 8, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_4-ncols2_2.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_4-ncols2_2.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 2, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 2, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 2, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_4-ncols2_4.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_4-ncols2_4.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 4, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 4, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 4, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_4-ncols2_8.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_4-ncols2_8.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 8, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 8, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 4, 8, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_8-ncols2_1.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq128-ncols1_8-ncols2_1.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 8, 1, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 8, 1, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(128, 128, 8, 1, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_1-ncols2_8.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_1-ncols2_8.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 1, 8, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 1, 8, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 1, 8, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_2-ncols2_4.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_2-ncols2_4.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 2, 4, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 2, 4, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 2, 4, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_2-ncols2_8.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_2-ncols2_8.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 2, 8, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 2, 8, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 2, 8, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_4-ncols2_2.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_4-ncols2_2.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 2, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 2, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 2, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_4-ncols2_4.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_4-ncols2_4.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 4, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 4, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 4, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_4-ncols2_8.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_4-ncols2_8.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 8, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 8, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 4, 8, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_8-ncols2_1.cu
+++ b/ggml/src/ggml-cuda/template-instances/fattn-mma-turbo-instance-dkq256-ncols1_8-ncols2_1.cu
@@ -1,0 +1,8 @@
+// Hand-created turbo MMA decode instance. Do NOT run generate_cu_files.py over it.
+
+#include "../fattn-mma-f16.cuh"
+#include "../fattn-mma-turbo.cuh"
+
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 8, 1, GGML_TYPE_TURBO4_0, GGML_TYPE_TURBO4_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 8, 1, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO3_0);
+DECL_FATTN_MMA_TURBO_CASE(256, 256, 8, 1, GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO2_0);

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -35,6 +35,7 @@ GGML_API void quantize_row_q8_K_ref(const float * GGML_RESTRICT x, block_q8_K * 
 GGML_API void quantize_row_tq1_0_ref(const float * GGML_RESTRICT x, block_tq1_0 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_tq2_0_ref(const float * GGML_RESTRICT x, block_tq2_0 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_tq3_0_ref(const float * GGML_RESTRICT x, block_tq3_0 * GGML_RESTRICT y, int64_t k);
+GGML_API void quantize_row_turbo2_0_ref(const float * GGML_RESTRICT x, block_turbo2_0 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_turbo3_0_ref(const float * GGML_RESTRICT x, block_turbo3_0 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_tq3_1s_ref(const float * GGML_RESTRICT x, block_tq3_1s * GGML_RESTRICT y, int64_t k);
@@ -72,6 +73,7 @@ GGML_API void dequantize_row_q8_K(const block_q8_K * GGML_RESTRICT x, float * GG
 GGML_API void dequantize_row_tq1_0(const block_tq1_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_tq2_0(const block_tq2_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_tq3_0(const block_tq3_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+GGML_API void dequantize_row_turbo2_0(const block_turbo2_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_turbo3_0(const block_turbo3_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_tq3_1s(const block_tq3_1s * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
@@ -106,6 +108,7 @@ GGML_API size_t quantize_iq3_s  (const float * GGML_RESTRICT src, void * GGML_RE
 GGML_API size_t quantize_tq1_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 GGML_API size_t quantize_tq2_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 GGML_API size_t quantize_tq3_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+GGML_API size_t quantize_turbo2_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 GGML_API size_t quantize_turbo3_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 GGML_API size_t quantize_turbo4_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 GGML_API size_t quantize_tq3_1s(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);

--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -1,117 +1,961 @@
 /*
- * Minimal TurboQuant KV cache reference implementation.
+ * TurboQuant: KV cache compression via PolarQuant + QJL
+ * Based on: arXiv 2504.19874 (ICLR 2026)
  *
- * This ports the CPU/reference storage format for TURBO3_0 and TURBO4_0 so the
- * runtime can parse and allocate these KV cache types on non-Metal builds.
- * Fast-path backend support can be layered on top later.
+ * Implements GGML_TYPE_TURBO2_0 (2-bit), GGML_TYPE_TURBO3_0 (3-bit) and
+ * GGML_TYPE_TURBO4_0 (4-bit) for use as --cache-type-k turboN in llama-server.
  */
 
 #include "ggml-quants.h"
 #include "ggml-common.h"
 #include "ggml-impl.h"
 
-#include <assert.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
+#include <assert.h>
+#include <stdlib.h>
 
-#define TURBO_QJL_CONST 1.2533141373155003f
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
+/* Forward declarations for GGML_API symbols defined in this file (satisfies
+ * -Wmissing-prototypes under upstream CI's -Werror policy). */
+GGML_API void turbo_cpu_fwht_inverse(float * x, int group_size);
+
+/* Global: WHT group size for CPU quantize path (set by CPU SET_ROWS handler) */
+GGML_API int turbo3_cpu_wht_group_size = 0;
+
+/* ---------- constants ---------- */
+
+#define TURBO_SEED_ROTATION 42
+#define TURBO_SEED_QJL      1042
+#define TURBO_D             128  /* rotation group size = head_dim (independent of block size) */
+#define TURBO_QJL_CONST     1.2533141373155003f  /* sqrt(pi/2) */
+
+/* Optimal centroids from paper (scaled by 1/sqrt(d)) */
+/* 2-bit: {±0.453, ±1.51} / sqrt(d) */
+static const float CENTROIDS_2BIT[4] = { -0.133462f, -0.039994f, 0.039994f, 0.133462f };
+
+/* 3-bit: Lloyd-Max for N(0, 1/128), pre-computed (PR #197 corrected values) */
 static const float CENTROIDS_3BIT[8] = {
-    -0.190685f, -0.117832f, -0.065717f, -0.021460f,
-     0.021460f,  0.065717f,  0.117832f,  0.190685f
+    -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+     0.021663f,  0.066822f,  0.118786f,  0.190207f
 };
+
+/* ---------- rotation matrix (lazy init) ---------- */
+
+static float turbo_rotation[TURBO_D * TURBO_D];
+static float turbo_rotation_t[TURBO_D * TURBO_D]; /* transpose */
+static int   turbo_rotation_initialized = 0;
+
+/* Simple LCG PRNG for deterministic rotation generation */
+static uint64_t turbo_prng_state;
+
+static void turbo_prng_seed(uint64_t seed) {
+    turbo_prng_state = seed;
+}
+
+static double turbo_prng_normal(void) {
+    /* Box-Muller transform from uniform LCG */
+    turbo_prng_state = turbo_prng_state * 6364136223846793005ULL + 1442695040888963407ULL;
+    double u1 = (double)(turbo_prng_state >> 11) / (double)(1ULL << 53);
+    if (u1 < 1e-15) u1 = 1e-15;
+    turbo_prng_state = turbo_prng_state * 6364136223846793005ULL + 1442695040888963407ULL;
+    double u2 = (double)(turbo_prng_state >> 11) / (double)(1ULL << 53);
+    return sqrt(-2.0 * log(u1)) * cos(2.0 * M_PI * u2);
+}
+
+static void turbo_init_rotation(void) {
+    if (turbo_rotation_initialized) return;
+
+    const int d = TURBO_D;
+
+    /* Generate random Gaussian matrix */
+    turbo_prng_seed(TURBO_SEED_ROTATION);
+    float G[TURBO_D * TURBO_D];
+    for (int i = 0; i < d * d; i++) {
+        G[i] = (float)turbo_prng_normal();
+    }
+
+    /* QR decomposition via modified Gram-Schmidt */
+    /* Q stored column-major in turbo_rotation */
+    memcpy(turbo_rotation, G, d * d * sizeof(float));
+
+    for (int j = 0; j < d; j++) {
+        /* Normalize column j */
+        float norm = 0.0f;
+        for (int i = 0; i < d; i++) {
+            norm += turbo_rotation[i * d + j] * turbo_rotation[i * d + j];
+        }
+        norm = sqrtf(norm);
+        if (norm > 1e-10f) {
+            for (int i = 0; i < d; i++) {
+                turbo_rotation[i * d + j] /= norm;
+            }
+        }
+
+        /* Orthogonalize remaining columns against j */
+        for (int k = j + 1; k < d; k++) {
+            float dot = 0.0f;
+            for (int i = 0; i < d; i++) {
+                dot += turbo_rotation[i * d + j] * turbo_rotation[i * d + k];
+            }
+            for (int i = 0; i < d; i++) {
+                turbo_rotation[i * d + k] -= dot * turbo_rotation[i * d + j];
+            }
+        }
+    }
+
+    /* Compute transpose */
+    for (int i = 0; i < d; i++) {
+        for (int j = 0; j < d; j++) {
+            turbo_rotation_t[i * d + j] = turbo_rotation[j * d + i];
+        }
+    }
+
+    turbo_rotation_initialized = 1;
+}
+
+/* ---------- QJL projection matrix (lazy init, seed-based) ---------- */
+
+static float turbo_qjl_matrix[TURBO_D * TURBO_D];
+static float turbo_qjl_matrix_t[TURBO_D * TURBO_D];
+static int   turbo_qjl_initialized = 0;
+
+static void turbo_init_qjl(void) {
+    if (turbo_qjl_initialized) return;
+
+    const int d = TURBO_D;
+    turbo_prng_seed(TURBO_SEED_QJL);
+
+    for (int i = 0; i < d * d; i++) {
+        turbo_qjl_matrix[i] = (float)turbo_prng_normal();
+    }
+
+    /* Transpose */
+    for (int i = 0; i < d; i++) {
+        for (int j = 0; j < d; j++) {
+            turbo_qjl_matrix_t[i * d + j] = turbo_qjl_matrix[j * d + i];
+        }
+    }
+
+    turbo_qjl_initialized = 1;
+}
+
+/* ---------- helper: matrix-vector multiply ---------- */
+
+static void matvec(const float * M, const float * x, float * y, int d) {
+    /* y = M @ x, M is row-major d×d */
+    for (int i = 0; i < d; i++) {
+        float sum = 0.0f;
+        for (int j = 0; j < d; j++) {
+            sum += M[i * d + j] * x[j];
+        }
+        y[i] = sum;
+    }
+}
+
+/* ---------- nearest centroid ---------- */
+
+static int nearest_centroid_2bit(float val) {
+    if (val < -0.086728f) return 0;
+    if (val <  0.000000f) return 1;
+    if (val <  0.086728f) return 2;
+    return 3;
+}
+
+static int nearest_centroid_3bit(float val) {
+    if (val < -0.154496f) return 0;
+    if (val < -0.092804f) return 1;
+    if (val < -0.044243f) return 2;
+    if (val <  0.000000f) return 3;
+    if (val <  0.044243f) return 4;
+    if (val <  0.092804f) return 5;
+    if (val <  0.154496f) return 6;
+    return 7;
+}
+
+static int nearest_centroid_4bit(float val) {
+    if (val < -0.212203f) return 0;
+    if (val < -0.162947f) return 1;
+    if (val < -0.127026f) return 2;
+    if (val < -0.097164f) return 3;
+    if (val < -0.070671f) return 4;
+    if (val < -0.046174f) return 5;
+    if (val < -0.022824f) return 6;
+    if (val <  0.000000f) return 7;
+    if (val <  0.022824f) return 8;
+    if (val <  0.046174f) return 9;
+    if (val <  0.070671f) return 10;
+    if (val <  0.097164f) return 11;
+    if (val <  0.127026f) return 12;
+    if (val <  0.162947f) return 13;
+    if (val <  0.212203f) return 14;
+    return 15;
+}
+
+/* ---------- WHT sign arrays (must match CUDA/Metal, seed=42) ---------- */
+
+static const float turbo_cpu_s1[128] = {
+    -1,1,1,-1,-1,1,-1,1,-1,-1,1,1,1,1,1,1,1,-1,1,-1,1,-1,-1,1,1,1,-1,1,1,-1,-1,-1,
+    -1,1,1,-1,1,1,-1,1,-1,1,1,-1,-1,1,-1,1,1,1,1,-1,-1,-1,-1,-1,1,-1,1,1,1,1,-1,1,
+    -1,-1,1,-1,-1,-1,1,-1,-1,-1,1,-1,-1,-1,1,1,1,-1,-1,1,1,1,-1,-1,1,1,-1,1,1,-1,1,-1,
+    -1,1,1,-1,1,-1,1,-1,1,1,1,1,-1,1,-1,1,1,-1,1,1,-1,-1,-1,-1,-1,1,1,-1,1,1,-1,1
+};
+
+static const float turbo_cpu_s2[128] = {
+    1,1,1,1,-1,1,1,-1,1,-1,-1,-1,1,-1,-1,-1,1,1,-1,-1,1,-1,1,-1,1,-1,-1,1,-1,1,1,1,
+    1,1,-1,-1,-1,1,-1,-1,-1,-1,-1,-1,1,1,1,-1,1,-1,1,1,1,-1,-1,1,-1,-1,-1,-1,-1,-1,1,1,
+    1,-1,1,-1,-1,-1,-1,1,-1,1,-1,1,-1,-1,1,1,-1,1,-1,1,1,-1,1,-1,-1,-1,-1,1,-1,-1,1,-1,
+    1,-1,1,1,1,-1,-1,1,-1,1,-1,1,1,-1,-1,1,-1,1,-1,1,1,-1,1,-1,1,-1,-1,-1,-1,-1,1,-1
+};
+
+/* ---------- CPU forward WHT (in-place, group_size elements) ---------- */
+
+static void turbo_cpu_fwht(float * x, int group_size) {
+    const float * s1 = turbo_cpu_s1;
+    const float * s2 = turbo_cpu_s2;
+    const float inv_sqrt = (group_size == 128) ? 0.08838834764831845f : 0.125f;
+
+    for (int i = 0; i < group_size; i++) x[i] *= s1[i];
+
+    for (int h = 1; h < group_size; h *= 2) {
+        for (int i = 0; i < group_size; i += h * 2) {
+            for (int j = i; j < i + h; j++) {
+                float a = x[j], b = x[j + h];
+                x[j]     = a + b;
+                x[j + h] = a - b;
+            }
+        }
+    }
+
+    for (int i = 0; i < group_size; i++) x[i] *= inv_sqrt * s2[i];
+}
+
+/* ---------- CPU inverse WHT ----------
+ * Forward: y = D(s2) * N * H * D(s1) * x
+ * Inverse: x = D(s1) * N * H * D(s2) * y  (s1/s2 swapped)
+ */
+GGML_API void turbo_cpu_fwht_inverse(float * x, int group_size) {
+    const float * s1 = turbo_cpu_s1;
+    const float * s2 = turbo_cpu_s2;
+    const float inv_sqrt = (group_size == 128) ? 0.08838834764831845f : 0.125f;
+
+    for (int i = 0; i < group_size; i++) x[i] *= s2[i];
+
+    for (int h = 1; h < group_size; h *= 2) {
+        for (int i = 0; i < group_size; i += h * 2) {
+            for (int j = i; j < i + h; j++) {
+                float a = x[j], b = x[j + h];
+                x[j]     = a + b;
+                x[j + h] = a - b;
+            }
+        }
+    }
+
+    for (int i = 0; i < group_size; i++) x[i] *= inv_sqrt * s1[i];
+}
+
+/* ---------- TURBO3_0: 3-bit PolarQuant with WHT rotation ---------- */
 
 void quantize_row_turbo3_0_ref(const float * GGML_RESTRICT x, block_turbo3_0 * GGML_RESTRICT y, int64_t k) {
     assert(k % QK_TURBO3 == 0);
-    const int nb = k / QK_TURBO3;
-    for (int i = 0; i < nb; ++i) {
-        float norm = 0.0f;
-        for (int j = 0; j < QK_TURBO3; ++j) {
-            norm += x[i * QK_TURBO3 + j] * x[i * QK_TURBO3 + j];
+
+    extern int turbo3_cpu_wht_group_size;
+    int group_size = turbo3_cpu_wht_group_size;
+    if (group_size != 64 && group_size != 128) {
+        group_size = (k % 128 == 0) ? 128 : 64;
+    }
+    if (k % group_size != 0) group_size = (group_size == 128) ? 64 : 128;
+    assert(k % group_size == 0);
+
+    const int n_groups = k / group_size;
+    const int blocks_per_group = group_size / QK_TURBO3;
+
+    for (int g = 0; g < n_groups; g++) {
+        const float * grp_src = x + g * group_size;
+        block_turbo3_0 * grp_dst = y + g * blocks_per_group;
+
+        float norm_sq = 0.0f;
+        float buf[128];
+        for (int j = 0; j < group_size; j++) {
+            buf[j] = grp_src[j];
+            norm_sq += buf[j] * buf[j];
         }
-        y[i].norm = GGML_FP32_TO_FP16(sqrtf(norm));
-        memset(y[i].qs, 0, sizeof(y[i].qs));
-        memset(y[i].signs, 0, sizeof(y[i].signs));
+        float grp_norm = sqrtf(norm_sq);
+        float inv_norm = (grp_norm > 1e-10f) ? 1.0f / grp_norm : 0.0f;
+
+        for (int j = 0; j < group_size; j++) buf[j] *= inv_norm;
+
+        turbo_cpu_fwht(buf, group_size);
+
+        float recon_sq = 0.0f;
+        for (int b = 0; b < blocks_per_group; b++) {
+            block_turbo3_0 * blk = &grp_dst[b];
+            const int off = b * QK_TURBO3;
+
+            memset(blk->qs, 0, QK_TURBO3 / 4);
+            memset(blk->signs, 0, QK_TURBO3 / 8);
+
+            for (int j = 0; j < QK_TURBO3; j++) {
+                int idx = nearest_centroid_3bit(buf[off + j]);
+                blk->qs[j / 4] |= (idx & 0x3) << ((j % 4) * 2);
+                if (idx & 0x4) {
+                    blk->signs[j / 8] |= (1 << (j % 8));
+                }
+                recon_sq += CENTROIDS_3BIT[idx] * CENTROIDS_3BIT[idx];
+            }
+        }
+
+        float recon_norm = sqrtf(recon_sq);
+        float corrected = (recon_norm > 1e-10f) ? grp_norm / recon_norm : grp_norm;
+        for (int b = 0; b < blocks_per_group; b++) {
+            grp_dst[b].norm = GGML_FP32_TO_FP16(corrected);
+        }
     }
 }
 
 void dequantize_row_turbo3_0(const block_turbo3_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
     assert(k % QK_TURBO3 == 0);
     const int nb = k / QK_TURBO3;
-    for (int block = 0; block < nb; ++block) {
-        const float norm = GGML_FP16_TO_FP32(x[block].norm);
-        for (int j = 0; j < QK_TURBO3; ++j) {
-            const uint8_t low2 = (x[block].qs[j / 4] >> ((j % 4) * 2)) & 0x3;
-            const uint8_t hi1  = (x[block].signs[j / 8] >> (j % 8)) & 0x1;
-            const uint8_t idx  = low2 | (hi1 << 2);
+    for (int block = 0; block < nb; block++) {
+        float norm = GGML_FP16_TO_FP32(x[block].norm);
+        for (int j = 0; j < QK_TURBO3; j++) {
+            uint8_t low2 = (x[block].qs[j/4] >> ((j%4)*2)) & 0x3;
+            uint8_t hi1 = (x[block].signs[j/8] >> (j%8)) & 0x1;
+            uint8_t idx = low2 | (hi1 << 2);
             y[block * QK_TURBO3 + j] = CENTROIDS_3BIT[idx] * norm;
         }
     }
 }
 
-size_t quantize_turbo3_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix) {
+size_t quantize_turbo3_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
+                         int64_t nrows, int64_t n_per_row, const float * imatrix) {
     GGML_UNUSED(imatrix);
     assert(n_per_row % QK_TURBO3 == 0);
-    const size_t row_size = (n_per_row / QK_TURBO3) * sizeof(block_turbo3_0);
-    for (int64_t row = 0; row < nrows; ++row) {
+
+    size_t row_size = (n_per_row / QK_TURBO3) * sizeof(block_turbo3_0);
+    for (int64_t row = 0; row < nrows; row++) {
         quantize_row_turbo3_0_ref(
             src + row * n_per_row,
-            (block_turbo3_0 *) ((char *) dst + row * row_size),
-            n_per_row);
+            (block_turbo3_0 *)((char *)dst + row * row_size),
+            n_per_row
+        );
     }
     return nrows * row_size;
 }
 
+/* ---------- TURBO2_0: 2-bit PolarQuant (no QJL) ---------- */
+
+void quantize_row_turbo2_0_ref(const float * GGML_RESTRICT x, block_turbo2_0 * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TURBO2 == 0);
+
+    extern int turbo3_cpu_wht_group_size;
+    int group_size = turbo3_cpu_wht_group_size;
+    if (group_size != 64 && group_size != 128) {
+        group_size = (k % 128 == 0) ? 128 : 64;
+    }
+    if (k % group_size != 0) group_size = (group_size == 128) ? 64 : 128;
+    assert(k % group_size == 0);
+
+    const int n_groups = k / group_size;
+    const int blocks_per_group = group_size / QK_TURBO2;
+
+    for (int g = 0; g < n_groups; g++) {
+        const float * grp_src = x + g * group_size;
+        block_turbo2_0 * grp_dst = y + g * blocks_per_group;
+
+        float norm_sq = 0.0f;
+        float buf[128];
+        for (int j = 0; j < group_size; j++) {
+            buf[j] = grp_src[j];
+            norm_sq += buf[j] * buf[j];
+        }
+        float grp_norm = sqrtf(norm_sq);
+        float inv_norm = (grp_norm > 1e-10f) ? 1.0f / grp_norm : 0.0f;
+
+        for (int j = 0; j < group_size; j++) buf[j] *= inv_norm;
+
+        turbo_cpu_fwht(buf, group_size);
+
+        float recon_sq = 0.0f;
+        for (int b = 0; b < blocks_per_group; b++) {
+            block_turbo2_0 * blk = &grp_dst[b];
+            const int off = b * QK_TURBO2;
+
+            memset(blk->qs, 0, QK_TURBO2 / 4);
+
+            for (int j = 0; j < QK_TURBO2; j++) {
+                int idx = nearest_centroid_2bit(buf[off + j]);
+                blk->qs[j / 4] |= (idx & 0x3) << ((j % 4) * 2);
+                recon_sq += CENTROIDS_2BIT[idx] * CENTROIDS_2BIT[idx];
+            }
+        }
+
+        float recon_norm = sqrtf(recon_sq);
+        float corrected = (recon_norm > 1e-10f) ? grp_norm / recon_norm : grp_norm;
+        for (int b = 0; b < blocks_per_group; b++) {
+            grp_dst[b].norm = GGML_FP32_TO_FP16(corrected);
+        }
+    }
+}
+
+void dequantize_row_turbo2_0(const block_turbo2_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TURBO2 == 0);
+    const int nb = k / QK_TURBO2;
+    for (int block = 0; block < nb; block++) {
+        float norm = GGML_FP16_TO_FP32(x[block].norm);
+        for (int j = 0; j < QK_TURBO2; j++) {
+            uint8_t idx = (x[block].qs[j/4] >> ((j%4)*2)) & 0x3;
+            y[block * QK_TURBO2 + j] = CENTROIDS_2BIT[idx] * norm;
+        }
+    }
+}
+
+size_t quantize_turbo2_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
+                         int64_t nrows, int64_t n_per_row, const float * imatrix) {
+    GGML_UNUSED(imatrix);
+    assert(n_per_row % QK_TURBO2 == 0);
+
+    size_t row_size = (n_per_row / QK_TURBO2) * sizeof(block_turbo2_0);
+    for (int64_t row = 0; row < nrows; row++) {
+        quantize_row_turbo2_0_ref(
+            src + row * n_per_row,
+            (block_turbo2_0 *)((char *)dst + row * row_size),
+            n_per_row
+        );
+    }
+    return nrows * row_size;
+}
+
+/* ---------- TURBO4_0: 4-bit PolarQuant (TURBO4_USE_4BIT=1, default) ---------- */
+
 void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * GGML_RESTRICT y, int64_t k) {
     assert(k % QK_TURBO4 == 0);
     const int nb = k / QK_TURBO4;
-    for (int block = 0; block < nb; ++block) {
-        const float * src = x + block * QK_TURBO4;
+    const int d  = QK_TURBO4;
+
+    for (int block = 0; block < nb; block++) {
+        const float * src = x + block * d;
+
         float norm_sq = 0.0f;
-        float abs_sum = 0.0f;
-        for (int i = 0; i < QK_TURBO4; ++i) {
-            norm_sq += src[i] * src[i];
-            abs_sum += fabsf(src[i]);
+        for (int i = 0; i < d; i++) norm_sq += src[i] * src[i];
+        float norm = sqrtf(norm_sq);
+
+        float normalized[128];
+        if (norm > 1e-10f) {
+            const float inv = 1.0f / norm;
+            for (int i = 0; i < d; i++) normalized[i] = src[i] * inv;
+        } else {
+            memset(normalized, 0, d * sizeof(float));
         }
-        y[block].norm = GGML_FP32_TO_FP16(sqrtf(norm_sq));
-        y[block].rnorm = GGML_FP32_TO_FP16(abs_sum / (float) QK_TURBO4);
-        memset(y[block].qs, 0, sizeof(y[block].qs));
-        memset(y[block].signs, 0, sizeof(y[block].signs));
+
+        float rotated[128];
+        memcpy(rotated, normalized, d * sizeof(float));
+        turbo_cpu_fwht(rotated, d);
+
+#if TURBO4_USE_4BIT
+        static const float CENTROIDS_4BIT[16] = {
+            -0.241529f, -0.182877f, -0.143016f, -0.111036f,
+            -0.083292f, -0.058050f, -0.034299f, -0.011349f,
+             0.011349f,  0.034299f,  0.058050f,  0.083292f,
+             0.111036f,  0.143016f,  0.182877f,  0.241529f
+        };
+        uint8_t indices[128];
+        for (int i = 0; i < d; i++) {
+            indices[i] = (uint8_t)nearest_centroid_4bit(rotated[i]);
+        }
+
+        float recon_norm_sq = 0.0f;
+        for (int i = 0; i < d; i++) {
+            recon_norm_sq += CENTROIDS_4BIT[indices[i]] * CENTROIDS_4BIT[indices[i]];
+        }
+        float recon_norm = sqrtf(recon_norm_sq);
+        float corrected_norm = (recon_norm > 1e-10f) ? norm / recon_norm : norm;
+        y[block].norm = GGML_FP32_TO_FP16(corrected_norm);
+
+        memset(y[block].qs, 0, d / 2);
+        for (int i = 0; i < d; i++) {
+            y[block].qs[i / 2] |= (uint8_t)((indices[i] & 0xF) << ((i % 2) * 4));
+        }
+#else
+        turbo_init_rotation();
+        turbo_init_qjl();
+
+        uint8_t indices[128];
+        for (int i = 0; i < d; i++) {
+            indices[i] = (uint8_t)nearest_centroid_3bit(rotated[i]);
+        }
+
+        float reconstructed[128];
+        for (int i = 0; i < d; i++) {
+            reconstructed[i] = CENTROIDS_3BIT[indices[i]];
+        }
+        float mse_recon[128];
+        matvec(turbo_rotation_t, reconstructed, mse_recon, d);
+
+        float residual[128];
+        for (int i = 0; i < d; i++) {
+            residual[i] = normalized[i] - mse_recon[i];
+        }
+
+        float projected[128];
+        matvec(turbo_qjl_matrix, residual, projected, d);
+
+        y[block].norm  = GGML_FP32_TO_FP16(norm);
+        y[block].rnorm = GGML_FP32_TO_FP16(0.0f);
+
+        memset(y[block].qs, 0, d * 3 / 8);
+        for (int i = 0; i < d; i++) {
+            int bit_offset = i * 3;
+            int byte_idx   = bit_offset / 8;
+            int bit_pos    = bit_offset % 8;
+            uint16_t val   = (uint16_t)(indices[i] & 0x7);
+            y[block].qs[byte_idx] |= (uint8_t)(val << bit_pos);
+            if (bit_pos > 5 && byte_idx + 1 < d * 3 / 8) {
+                y[block].qs[byte_idx + 1] |= (uint8_t)(val >> (8 - bit_pos));
+            }
+        }
+        memset(y[block].signs, 0, d / 8);
+        for (int i = 0; i < d; i++) {
+            if (projected[i] >= 0.0f) {
+                y[block].signs[i / 8] |= (1 << (i % 8));
+            }
+        }
+#endif
     }
 }
 
 void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
     assert(k % QK_TURBO4 == 0);
     const int nb = k / QK_TURBO4;
-    for (int block = 0; block < nb; ++block) {
-        const float norm = GGML_FP16_TO_FP32(x[block].norm);
-        const float rnorm = GGML_FP16_TO_FP32(x[block].rnorm);
-        const float qjl_scale = TURBO_QJL_CONST / (float) QK_TURBO4 * rnorm;
+    const int d  = QK_TURBO4;
 
-        for (int i = 0; i < QK_TURBO4; ++i) {
-            const int bit_offset = i * 3;
-            const int byte_idx = bit_offset / 8;
-            const int bit_pos = bit_offset % 8;
-            uint16_t raw = (uint16_t) x[block].qs[byte_idx];
-            if (byte_idx + 1 < (int) sizeof(x[block].qs)) {
-                raw |= (uint16_t) x[block].qs[byte_idx + 1] << 8;
+#if TURBO4_USE_4BIT
+    static const float CENTROIDS_4BIT[16] = {
+        -0.241529f, -0.182877f, -0.143016f, -0.111036f,
+        -0.083292f, -0.058050f, -0.034299f, -0.011349f,
+         0.011349f,  0.034299f,  0.058050f,  0.083292f,
+         0.111036f,  0.143016f,  0.182877f,  0.241529f
+    };
+    for (int block = 0; block < nb; block++) {
+        float norm = GGML_FP16_TO_FP32(x[block].norm);
+        float * dst = y + block * d;
+        for (int i = 0; i < d; i++) {
+            uint8_t idx = (x[block].qs[i / 2] >> ((i % 2) * 4)) & 0xF;
+            dst[i] = CENTROIDS_4BIT[idx] * norm;
+        }
+    }
+#else
+    turbo_init_rotation();
+    turbo_init_qjl();
+    for (int block = 0; block < nb; block++) {
+        float norm  = GGML_FP16_TO_FP32(x[block].norm);
+
+        uint8_t indices[128];
+        for (int i = 0; i < d; i++) {
+            int bit_offset = i * 3;
+            int byte_idx   = bit_offset / 8;
+            int bit_pos    = bit_offset % 8;
+            uint16_t raw   = (uint16_t)x[block].qs[byte_idx];
+            if (byte_idx + 1 < d * 3 / 8) {
+                raw |= (uint16_t)x[block].qs[byte_idx + 1] << 8;
             }
-            const uint8_t idx = (raw >> bit_pos) & 0x7;
-            const float sign = (x[block].signs[i / 8] & (1 << (i % 8))) ? 1.0f : -1.0f;
-            y[block * QK_TURBO4 + i] = (CENTROIDS_3BIT[idx] + sign * qjl_scale) * norm;
+            indices[i] = (uint8_t)((raw >> bit_pos) & 0x7);
+        }
+
+        float signs[128];
+        for (int i = 0; i < d; i++) {
+            signs[i] = (x[block].signs[i / 8] & (1 << (i % 8))) ? 1.0f : -1.0f;
+        }
+
+        float rnorm = GGML_FP16_TO_FP32(x[block].rnorm);
+        const float qjl_scale = TURBO_QJL_CONST / (float)d * rnorm;
+
+        float rotated_recon[128];
+        for (int i = 0; i < d; i++) {
+            rotated_recon[i] = CENTROIDS_3BIT[indices[i]];
+        }
+        float mse_recon[128];
+        matvec(turbo_rotation_t, rotated_recon, mse_recon, d);
+
+        float qjl_recon[128];
+        matvec(turbo_qjl_matrix_t, signs, qjl_recon, d);
+        for (int i = 0; i < d; i++) {
+            qjl_recon[i] *= qjl_scale;
+        }
+
+        float * dst = y + block * d;
+        for (int i = 0; i < d; i++) {
+            dst[i] = (mse_recon[i] + qjl_recon[i]) * norm;
+        }
+    }
+#endif
+}
+
+size_t quantize_turbo4_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
+                         int64_t nrows, int64_t n_per_row, const float * imatrix) {
+    GGML_UNUSED(imatrix);
+    assert(n_per_row % QK_TURBO4 == 0);
+
+    size_t row_size = (n_per_row / QK_TURBO4) * sizeof(block_turbo4_0);
+    for (int64_t row = 0; row < nrows; row++) {
+        quantize_row_turbo4_0_ref(
+            src + row * n_per_row,
+            (block_turbo4_0 *)((char *)dst + row * row_size),
+            n_per_row
+        );
+    }
+    return nrows * row_size;
+}
+
+/* ================================================================== */
+/* TQ3_1S / TQ4_1S: WHT-rotated weight quantization                  */
+/* These are already defined in ggml-quants.c in our fork; disabled  */
+/* here to avoid duplicate symbol errors at link time.                */
+/* ================================================================== */
+#if 0
+
+/* Lloyd-Max centroids for N(0,1) */
+static const float TQ3_0_CENTROIDS[8] = {
+    -1.996684f, -1.291398f, -0.740341f, -0.247508f,
+     0.230106f,  0.725222f,  1.277503f,  1.988943f
+};
+
+static const float TQ4_0_CENTROIDS[16] = {
+    -2.732590f, -2.069017f, -1.618046f, -1.256231f,
+    -0.942340f, -0.656759f, -0.388048f, -0.128395f,
+     0.128395f,  0.388048f,  0.656759f,  0.942340f,
+     1.256231f,  1.618046f,  2.069017f,  2.732590f,
+};
+
+static const float TQ3_0_SIGNS[32] = {
+    +1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+    -1.0f, +1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+};
+
+#define TQ_BLOCK_SIZE 32
+#define TQ_INV_SQRT32 0.17677669529663688f  /* 1/sqrt(32) */
+
+static void tq3_0_rht_forward(float * buf) {
+    for (int i = 0; i < TQ_BLOCK_SIZE; i++) buf[i] *= TQ3_0_SIGNS[i];
+    for (int step = 1; step < TQ_BLOCK_SIZE; step <<= 1) {
+        for (int i = 0; i < TQ_BLOCK_SIZE; i += step << 1) {
+            for (int j = i; j < i + step; j++) {
+                float a = buf[j], b = buf[j + step];
+                buf[j]     = a + b;
+                buf[j + step] = a - b;
+            }
+        }
+    }
+    for (int i = 0; i < TQ_BLOCK_SIZE; i++) buf[i] *= TQ_INV_SQRT32;
+}
+
+static void tq3_0_rht_inverse(float * buf) {
+    for (int step = 1; step < TQ_BLOCK_SIZE; step <<= 1) {
+        for (int i = 0; i < TQ_BLOCK_SIZE; i += step << 1) {
+            for (int j = i; j < i + step; j++) {
+                float a = buf[j], b = buf[j + step];
+                buf[j]     = a + b;
+                buf[j + step] = a - b;
+            }
+        }
+    }
+    for (int i = 0; i < TQ_BLOCK_SIZE; i++) buf[i] *= TQ_INV_SQRT32 * TQ3_0_SIGNS[i];
+}
+
+static int tq3_0_choose_index(float val) {
+    if (val < -1.644041f) return 0;
+    if (val < -1.015870f) return 1;
+    if (val < -0.493925f) return 2;
+    if (val < -0.008701f) return 3;
+    if (val <  0.477664f) return 4;
+    if (val <  1.001363f) return 5;
+    if (val <  1.633223f) return 6;
+    return 7;
+}
+
+static int tq4_0_choose_index(float val) {
+    if (val < -2.400804f) return 0;
+    if (val < -1.843532f) return 1;
+    if (val < -1.437139f) return 2;
+    if (val < -1.099286f) return 3;
+    if (val < -0.799550f) return 4;
+    if (val < -0.522404f) return 5;
+    if (val < -0.258222f) return 6;
+    if (val <  0.000000f) return 7;
+    if (val <  0.258222f) return 8;
+    if (val <  0.522404f) return 9;
+    if (val <  0.799550f) return 10;
+    if (val <  1.099286f) return 11;
+    if (val <  1.437139f) return 12;
+    if (val <  1.843532f) return 13;
+    if (val <  2.400804f) return 14;
+    return 15;
+}
+
+void quantize_row_tq3_1s_ref(const float * GGML_RESTRICT x, block_tq3_1s * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TQ3_0 == 0);
+    const int nb = k / QK_TQ3_0;
+
+    for (int block = 0; block < nb; block++) {
+        const float * src_blk = x + block * QK_TQ3_0;
+        block_tq3_1s * blk = &y[block];
+
+        float buf[TQ_BLOCK_SIZE];
+        memcpy(buf, src_blk, TQ_BLOCK_SIZE * sizeof(float));
+        tq3_0_rht_forward(buf);
+
+        float rms0 = 0.0f, rms1 = 0.0f;
+        for (int j = 0; j < 16; j++) rms0 += buf[j] * buf[j];
+        for (int j = 16; j < 32; j++) rms1 += buf[j] * buf[j];
+        rms0 = sqrtf(rms0 / 16.0f);
+        rms1 = sqrtf(rms1 / 16.0f);
+
+        static const float scales[] = { 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.35f, 1.5f };
+        float best_d0 = rms0, best_d1 = rms1;
+        float best_err = 1e30f;
+
+        for (int si = 0; si < 9; si++) {
+            float d0 = rms0 * scales[si];
+            float d1 = rms1 * scales[si];
+            float inv0 = (d0 > 1e-10f) ? 1.0f / d0 : 0.0f;
+            float inv1 = (d1 > 1e-10f) ? 1.0f / d1 : 0.0f;
+
+            float err = 0.0f;
+            for (int j = 0; j < 16; j++) {
+                int idx = tq3_0_choose_index(buf[j] * inv0);
+                float diff = buf[j] - TQ3_0_CENTROIDS[idx] * d0;
+                err += diff * diff;
+            }
+            for (int j = 16; j < 32; j++) {
+                int idx = tq3_0_choose_index(buf[j] * inv1);
+                float diff = buf[j] - TQ3_0_CENTROIDS[idx] * d1;
+                err += diff * diff;
+            }
+            if (err < best_err) {
+                best_err = err;
+                best_d0 = d0;
+                best_d1 = d1;
+            }
+        }
+
+        for (int iter = 0; iter < 6; iter++) {
+            float inv0 = (best_d0 > 1e-10f) ? 1.0f / best_d0 : 0.0f;
+            float inv1 = (best_d1 > 1e-10f) ? 1.0f / best_d1 : 0.0f;
+
+            float num0 = 0.0f, den0 = 0.0f;
+            float num1 = 0.0f, den1 = 0.0f;
+            for (int j = 0; j < 16; j++) {
+                int idx = tq3_0_choose_index(buf[j] * inv0);
+                float c = TQ3_0_CENTROIDS[idx];
+                num0 += buf[j] * c;
+                den0 += c * c;
+            }
+            for (int j = 16; j < 32; j++) {
+                int idx = tq3_0_choose_index(buf[j] * inv1);
+                float c = TQ3_0_CENTROIDS[idx];
+                num1 += buf[j] * c;
+                den1 += c * c;
+            }
+            if (den0 > 1e-10f) best_d0 = num0 / den0;
+            if (den1 > 1e-10f) best_d1 = num1 / den1;
+        }
+
+        float inv0 = (best_d0 > 1e-10f) ? 1.0f / best_d0 : 0.0f;
+        float inv1 = (best_d1 > 1e-10f) ? 1.0f / best_d1 : 0.0f;
+
+        blk->d0 = GGML_FP32_TO_FP16(best_d0);
+        blk->d1 = GGML_FP32_TO_FP16(best_d1);
+        memset(blk->qs, 0, QK_TQ3_0 * 3 / 8);
+
+        for (int g = 0; g < 4; g++) {
+            uint8_t indices[8];
+            for (int i = 0; i < 8; i++) {
+                int j = g * 8 + i;
+                float inv = (j < 16) ? inv0 : inv1;
+                indices[i] = (uint8_t)tq3_0_choose_index(buf[j] * inv);
+            }
+            uint8_t * qp = blk->qs + g * 3;
+            qp[0] = (indices[0] & 7) | ((indices[1] & 7) << 3) | ((indices[2] & 3) << 6);
+            qp[1] = ((indices[2] >> 2) & 1) | ((indices[3] & 7) << 1) | ((indices[4] & 7) << 4) | ((indices[5] & 1) << 7);
+            qp[2] = ((indices[5] >> 1) & 3) | ((indices[6] & 7) << 2) | ((indices[7] & 7) << 5);
         }
     }
 }
 
-size_t quantize_turbo4_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix) {
+void dequantize_row_tq3_1s(const block_tq3_1s * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TQ3_0 == 0);
+    const int nb = k / QK_TQ3_0;
+
+    for (int blk_i = 0; blk_i < nb; blk_i++) {
+        float d0 = GGML_FP16_TO_FP32(x[blk_i].d0);
+        float d1 = GGML_FP16_TO_FP32(x[blk_i].d1);
+
+        float buf[32];
+        for (int g = 0; g < 4; g++) {
+            const uint8_t * qp = x[blk_i].qs + g * 3;
+            uint8_t idx[8];
+            idx[0] =  qp[0]       & 7;
+            idx[1] = (qp[0] >> 3) & 7;
+            idx[2] = ((qp[0] >> 6) | (qp[1] << 2)) & 7;
+            idx[3] = (qp[1] >> 1) & 7;
+            idx[4] = (qp[1] >> 4) & 7;
+            idx[5] = ((qp[1] >> 7) | (qp[2] << 1)) & 7;
+            idx[6] = (qp[2] >> 2) & 7;
+            idx[7] = (qp[2] >> 5) & 7;
+
+            for (int i = 0; i < 8; i++) {
+                int j = g * 8 + i;
+                float d = (j < 16) ? d0 : d1;
+                buf[j] = TQ3_0_CENTROIDS[idx[i]] * d;
+            }
+        }
+
+        tq3_0_rht_inverse(buf);
+
+        memcpy(y + blk_i * QK_TQ3_0, buf, QK_TQ3_0 * sizeof(float));
+    }
+}
+
+size_t quantize_tq3_1s(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
+                        int64_t nrows, int64_t n_per_row, const float * imatrix) {
     GGML_UNUSED(imatrix);
-    assert(n_per_row % QK_TURBO4 == 0);
-    const size_t row_size = (n_per_row / QK_TURBO4) * sizeof(block_turbo4_0);
-    for (int64_t row = 0; row < nrows; ++row) {
-        quantize_row_turbo4_0_ref(
+    assert(n_per_row % QK_TQ3_0 == 0);
+
+    size_t row_size = (n_per_row / QK_TQ3_0) * sizeof(block_tq3_1s);
+    for (int64_t row = 0; row < nrows; row++) {
+        quantize_row_tq3_1s_ref(
             src + row * n_per_row,
-            (block_turbo4_0 *) ((char *) dst + row * row_size),
-            n_per_row);
+            (block_tq3_1s *)((char *)dst + row * row_size),
+            n_per_row
+        );
     }
     return nrows * row_size;
 }
+
+void quantize_row_tq4_1s_ref(const float * GGML_RESTRICT x, block_tq4_1s * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TQ4_1S == 0);
+    const int nb = k / QK_TQ4_1S;
+
+    for (int block = 0; block < nb; block++) {
+        const float * src_blk = x + block * QK_TQ4_1S;
+        block_tq4_1s * blk = &y[block];
+
+        float buf[TQ_BLOCK_SIZE];
+        memcpy(buf, src_blk, TQ_BLOCK_SIZE * sizeof(float));
+        tq3_0_rht_forward(buf);
+
+        float rms0 = 0.0f, rms1 = 0.0f;
+        for (int j = 0; j < 16; j++) rms0 += buf[j] * buf[j];
+        for (int j = 16; j < 32; j++) rms1 += buf[j] * buf[j];
+        rms0 = sqrtf(rms0 / 16.0f);
+        rms1 = sqrtf(rms1 / 16.0f);
+
+        static const float scales[] = { 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.35f, 1.5f };
+        float best_d0 = rms0, best_d1 = rms1;
+        float best_err = 1e30f;
+
+        for (int si = 0; si < 9; si++) {
+            float d0 = rms0 * scales[si];
+            float d1 = rms1 * scales[si];
+            float inv0 = (d0 > 1e-10f) ? 1.0f / d0 : 0.0f;
+            float inv1 = (d1 > 1e-10f) ? 1.0f / d1 : 0.0f;
+
+            float err = 0.0f;
+            for (int j = 0; j < 16; j++) {
+                int idx = tq4_0_choose_index(buf[j] * inv0);
+                float diff = buf[j] - TQ4_0_CENTROIDS[idx] * d0;
+                err += diff * diff;
+            }
+            for (int j = 16; j < 32; j++) {
+                int idx = tq4_0_choose_index(buf[j] * inv1);
+                float diff = buf[j] - TQ4_0_CENTROIDS[idx] * d1;
+                err += diff * diff;
+            }
+            if (err < best_err) {
+                best_err = err;
+                best_d0 = d0;
+                best_d1 = d1;
+            }
+        }
+
+        for (int iter = 0; iter < 6; iter++) {
+            float inv0 = (best_d0 > 1e-10f) ? 1.0f / best_d0 : 0.0f;
+            float inv1 = (best_d1 > 1e-10f) ? 1.0f / best_d1 : 0.0f;
+
+            float num0 = 0.0f, den0 = 0.0f;
+            float num1 = 0.0f, den1 = 0.0f;
+            for (int j = 0; j < 16; j++) {
+                int idx = tq4_0_choose_index(buf[j] * inv0);
+                float c = TQ4_0_CENTROIDS[idx];
+                num0 += buf[j] * c;
+                den0 += c * c;
+            }
+            for (int j = 16; j < 32; j++) {
+                int idx = tq4_0_choose_index(buf[j] * inv1);
+                float c = TQ4_0_CENTROIDS[idx];
+                num1 += buf[j] * c;
+                den1 += c * c;
+            }
+            if (den0 > 1e-10f) best_d0 = num0 / den0;
+            if (den1 > 1e-10f) best_d1 = num1 / den1;
+        }
+
+        float inv0 = (best_d0 > 1e-10f) ? 1.0f / best_d0 : 0.0f;
+        float inv1 = (best_d1 > 1e-10f) ? 1.0f / best_d1 : 0.0f;
+
+        blk->d0 = GGML_FP32_TO_FP16(best_d0);
+        blk->d1 = GGML_FP32_TO_FP16(best_d1);
+        memset(blk->qs, 0, QK_TQ4_1S / 2);
+
+        for (int j = 0; j < QK_TQ4_1S; j++) {
+            float inv = (j < 16) ? inv0 : inv1;
+            int idx = tq4_0_choose_index(buf[j] * inv);
+            blk->qs[j / 2] |= (uint8_t)((idx & 0xF) << ((j & 1) * 4));
+        }
+    }
+}
+
+void dequantize_row_tq4_1s(const block_tq4_1s * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TQ4_1S == 0);
+    const int nb = k / QK_TQ4_1S;
+
+    for (int blk_i = 0; blk_i < nb; blk_i++) {
+        float d0 = GGML_FP16_TO_FP32(x[blk_i].d0);
+        float d1 = GGML_FP16_TO_FP32(x[blk_i].d1);
+
+        float buf[32];
+        for (int j = 0; j < 32; j++) {
+            uint8_t idx = (x[blk_i].qs[j / 2] >> ((j & 1) * 4)) & 0xF;
+            float d = (j < 16) ? d0 : d1;
+            buf[j] = TQ4_0_CENTROIDS[idx] * d;
+        }
+
+        tq3_0_rht_inverse(buf);
+
+        memcpy(y + blk_i * QK_TQ4_1S, buf, QK_TQ4_1S * sizeof(float));
+    }
+}
+
+size_t quantize_tq4_1s(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
+                        int64_t nrows, int64_t n_per_row, const float * imatrix) {
+    GGML_UNUSED(imatrix);
+    assert(n_per_row % QK_TQ4_1S == 0);
+
+    size_t row_size = (n_per_row / QK_TQ4_1S) * sizeof(block_tq4_1s);
+    for (int64_t row = 0; row < nrows; row++) {
+        quantize_row_tq4_1s_ref(
+            src + row * n_per_row,
+            (block_tq4_1s *)((char *)dst + row * row_size),
+            n_per_row
+        );
+    }
+    return nrows * row_size;
+}
+
+#endif /* TQ3_1S + TQ4_1S disabled — weight-type functions already in ggml-quants.c */

--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -25,7 +25,7 @@
 GGML_API void turbo_cpu_fwht_inverse(float * x, int group_size);
 
 /* Global: WHT group size for CPU quantize path (set by CPU SET_ROWS handler) */
-GGML_API int turbo3_cpu_wht_group_size = 0;
+int turbo3_cpu_wht_group_size = 0;
 
 /* ---------- constants ---------- */
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -936,6 +936,14 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .to_float                 = (ggml_to_float_t) dequantize_row_turbo4_0,
         .from_float_ref           = (ggml_from_float_t) quantize_row_turbo4_0_ref,
     },
+    [GGML_TYPE_TURBO2_0] = {
+        .type_name                = "turbo2",
+        .blck_size                = QK_TURBO2,
+        .type_size                = sizeof(block_turbo2_0),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_turbo2_0,
+        .from_float_ref           = (ggml_from_float_t) quantize_row_turbo2_0_ref,
+    },
     [GGML_TYPE_TQ3_1S] = {
         .type_name                = "tq3_1s",
         .blck_size                = QK_TQ3_0,
@@ -7805,6 +7813,7 @@ size_t ggml_quantize_chunk(
         case GGML_TYPE_TQ1_0:   result = quantize_tq1_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_TQ2_0:   result = quantize_tq2_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_TQ3_0:   result = quantize_tq3_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_TURBO2_0: result = quantize_turbo2_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_TURBO3_0: result = quantize_turbo3_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_TURBO4_0: result = quantize_turbo4_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_TQ3_1S:  result = quantize_tq3_1s(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;


### PR DESCRIPTION
## Summary

Ports the turbo2/3/4 KV-cache quantization formats from TheTom's `crush/turbo4` branch (PR #197) and adds a crash fix for asymmetric K≠V configurations.

- **Data-format layer** (`ggml-turbo-quant.c`, `ggml-common.h`): turbo2/3/4 block structs, GGML type IDs (TURBO3_0=201, TURBO4_0=202, TURBO2_0=203), Lloyd-Max centroids corrected to N(0, 1/128) values from PR #197
- **VEC FA kernels** (`fattn-vec-f16.cuh`, `fattn.cu`): `FATTN_VEC_CASES_ALL_D` dispatch wired for turbo3/4; decode-only gate preserves prefill path
- **Fused MMA FA kernels** (`fattn-mma-f16.cuh`, `fattn.cu`): Turing MMA path for symmetric K==V turbo configs; corrected centroid tables in GPU constant memory; hd=128 covers turbo2/3/4, hd=256 covers turbo3/4 only
- **Asymmetric crash fix** (`fattn.cu`): Adds `asymm_turbo_v` guard in `ggml_cuda_get_best_fattn_kernel` to force VEC path when K≠V (e.g. `-ctk q8_0 -ctv turbo3`), blocking a null-pointer dereference in the MMA_F16 prefill path; adds 6 missing VEC dispatch cases (F16/Q4_0/Q8_0 × TURBO3_0/TURBO4_0) that were causing `GGML_ABORT` on decode

## Quality

KLD comparison on Qwen3.6-27B-MTP-TQ3_4S (16 × 512 ctx chunks, wikitext-2), reference = `ctk=q8_0,ctv=tq3_0`:

| Candidate | REFRACT score | mean KLD (nats) |
|-----------|--------------|-----------------|
| `ctv=turbo3` | **98.79 / EXCELLENT** | 0.012221 |

Indistinguishable from tq3_0 at the same 3-bit budget.

## Test plan

- [x] Server starts with `-ctk q8_0 -ctv turbo3` (was crashing before fix)
- [x] Server starts with `-ctk q8_0 -ctv tq3_0` (no regression)
- [x] Symmetric `-ctv turbo3 -ctk turbo3` uses fused Turing MMA path
- [x] KLD comparison: turbo3 scores 98.79 vs tq3_0 reference (REFRACT v0.3.2.3)
- [ ] GX10 smoke test (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)