### PR TITLE
feat: TQ3_4S → NVFP4 Blackwell FP4 MMA path with low-VRAM guard (~1.7× prefill speedup on GB10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Getting started with llama.cpp is straightforward. Here are several ways to inst
 - Install `llama.cpp` using [brew, nix, winget, or conda-forge](docs/install.md)
 - Run with Docker - see our [Docker documentation](docs/docker.md)
 - Download pre-built binaries from the [releases page](https://github.com/ggml-org/llama.cpp/releases)
-- Build from source by cloning this repository - check out [our build guide](docs/build.md)
+- Build from source by cloning this repository - check out [our build guide](docs/build.md), including [Windows CUDA build notes](docs/build.md#windows-cuda-builds)
 
 Once installed, you'll need a model to work with. Head to the [Obtaining and quantizing models](#obtaining-and-quantizing-models) section to learn more.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -174,6 +174,33 @@ cmake -B build -DGGML_CUDA=ON
 cmake --build build --config Release
 ```
 
+#### Windows CUDA builds
+
+On Windows, build from a Visual Studio developer environment so that `cl.exe`, `link.exe`, the Windows SDK, `cmake`, and `ninja` are all visible. For example, open "x64 Native Tools Command Prompt for VS 2022" or run `vcvars64.bat` before configuring.
+
+```cmd
+call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+set "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin;%PATH%"
+
+cmake -S . -B build-cuda-win -G Ninja ^
+  -DGGML_CUDA=ON ^
+  -DGGML_CUDA_FA=ON ^
+  -DCMAKE_CUDA_ARCHITECTURES=120 ^
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build-cuda-win --config Release
+```
+
+For Blackwell GPUs, CUDA 12.8 or newer is required. Passing `-DCMAKE_CUDA_ARCHITECTURES=120` is accepted; the CUDA CMake logic rewrites `120` to the architecture-specific `120a` form required for native Blackwell FP4 instructions. To verify the generated build, check that `build.ninja` contains `compute_120a` and `sm_120a`.
+
+When running from a shell or service, make sure both the build output directory and the CUDA `bin` directory are on `PATH`, otherwise the CUDA backend DLLs may not load and the program will silently run CPU-only:
+
+```cmd
+set "PATH=C:\path\to\llama.cpp\build-cuda-win\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin;%PATH%"
+build-cuda-win\bin\llama-server.exe --model model.gguf -ngl 99
+```
+
+The startup log should list a CUDA device and include CUDA backend features such as `BLACKWELL_NATIVE_FP4` on supported Blackwell builds.
+
 ### Non-Native Builds
 
 By default llama.cpp will be built for the hardware that is connected to the system at that time.

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1658,7 +1658,11 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
     }
 
     cudaFuncAttributes attr = {};
-    CUDA_CHECK(cudaFuncGetAttributes(&attr, kernel));
+    cudaError_t err = cudaFuncGetAttributes(&attr, kernel);
+    if (err != cudaSuccess) {
+        // Cannot determine PDL support (e.g. Blackwell + CUDA 13.0). Fall back to standard launch.
+        return false;
+    }
 
     // PDL device-side primitives are emitted only for PTX versions >= 90.
     // We have to guard on a loaded kernel's PTX version so a kernel forward-JIT'ed

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1457,6 +1457,16 @@ struct ggml_backend_cuda_context {
 
     int curr_stream_no = 0;
 
+    struct tq3_4s_nvfp4_cache_entry {
+        void * data = nullptr;
+        size_t size = 0;
+        size_t src_size = 0;
+        const void * src_data = nullptr;
+    };
+
+    std::mutex tq3_4s_nvfp4_cache_mutex;
+    std::unordered_map<const void *, tq3_4s_nvfp4_cache_entry> tq3_4s_nvfp4_cache;
+
 #ifdef USE_CUDA_GRAPH
     // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)
@@ -1701,4 +1711,3 @@ static __inline__ void ggml_cuda_kernel_launch(Kernel kernel, const ggml_cuda_ke
     kernel<<<launch_params.block_nums, launch_params.block_dims, launch_params.shmem, launch_params.stream>>>(std::forward<Args>(args)... );
     CUDA_CHECK(cudaGetLastError());
 }
-

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -610,6 +610,16 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     std::unique_lock<std::mutex> lock(ggml_cuda_lock);
     ggml_cuda_lock_cv.wait(lock, []{ return ggml_cuda_lock_counter.load(std::memory_order_relaxed) == 0; });
 
+    if (!tq3_4s_nvfp4_cache.empty()) {
+        ggml_cuda_set_device(device);
+        for (auto & it : tq3_4s_nvfp4_cache) {
+            if (it.second.data != nullptr) {
+                CUDA_CHECK(cudaFree(it.second.data));
+            }
+        }
+        tq3_4s_nvfp4_cache.clear();
+    }
+
     if (copy_event != nullptr) {
         CUDA_CHECK(cudaEventDestroy(copy_event));
     }

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -123,7 +123,9 @@ void ggml_cuda_mul_mat_q(
                             || GGML_CUDA_CC_IS_CDNA(cc);
 
     // TODO: tighter pool buffer size vs q8 path
-    const bool use_native_mxfp4 = blackwell_mma_available(cc) && src0->type == GGML_TYPE_MXFP4;
+    const bool use_native_fp4 = blackwell_mma_available(cc) &&
+        (src0->type == GGML_TYPE_MXFP4 || src0->type == GGML_TYPE_NVFP4 || src0->type == GGML_TYPE_TQ3_4S);
+    const ggml_type activation_fp4_type = src0->type == GGML_TYPE_MXFP4 ? GGML_TYPE_MXFP4 : GGML_TYPE_NVFP4;
 
     if (!ids) {
         const size_t nbytes_src1_q8_1 = ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1 +
@@ -143,9 +145,10 @@ void ggml_cuda_mul_mat_q(
                 ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
                 src1_quant = src1_rot.get();
             }
-            if (use_native_mxfp4) {
+            if (use_native_fp4) {
                 static_assert(sizeof(block_fp4_mmq) == 4 * sizeof(block_q8_1));
-                quantize_mmq_fp4_cuda(src1_quant, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded,
+                quantize_mmq_fp4_cuda(src1_quant, nullptr, src1_q8_1.get(), activation_fp4_type,
+                                      ne10, s11, s12, s13, ne10_padded,
                                       ne11, ne12, ne13, stream);
 
             } else {
@@ -156,7 +159,7 @@ void ggml_cuda_mul_mat_q(
         }
 
         // Stride depends on quantization format
-        const int64_t s12 = use_native_mxfp4 ?
+        const int64_t s12 = use_native_fp4 ?
                                 ne11 * ne10_padded * sizeof(block_fp4_mmq) /
                                     (8 * QK_MXFP4 * sizeof(int))  // block_fp4_mmq holds 256 values (8 blocks of 32)
                                 :
@@ -217,8 +220,9 @@ void ggml_cuda_mul_mat_q(
             src1_quant = src1_rot.get();
         }
 
-        if (use_native_mxfp4) {
-            quantize_mmq_fp4_cuda(src1_quant, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
+        if (use_native_fp4) {
+            quantize_mmq_fp4_cuda(src1_quant, ids_src1.get(), src1_q8_1.get(), activation_fp4_type,
+                                  ne10, s11, s12, s13,
                                   ne10_padded, ne11_flat, ne12_flat, ne13_flat, stream);
         } else {
             quantize_mmq_q8_1_cuda(src1_quant, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
@@ -227,8 +231,8 @@ void ggml_cuda_mul_mat_q(
         CUDA_CHECK(cudaGetLastError());
     }
 
-    const int64_t s12 = use_native_mxfp4 ? ne11 * ne10_padded * sizeof(block_fp4_mmq) / (8 * QK_MXFP4 * sizeof(int)) :
-                                           ne11 * ne10_padded * sizeof(block_q8_1) / (QK8_1 * sizeof(int));
+    const int64_t s12 = use_native_fp4 ? ne11 * ne10_padded * sizeof(block_fp4_mmq) / (8 * QK_MXFP4 * sizeof(int)) :
+                                        ne11 * ne10_padded * sizeof(block_q8_1) / (QK8_1 * sizeof(int));
     const int64_t s13 = ne12*s12;
 
     // Note that ne02 is used instead of ne12 because the number of y channels determines the z dimension of the CUDA grid.

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -75,6 +75,46 @@ static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, con
     }
 }
 
+static const char * ggml_cuda_tq3_4s_nvfp4_cache_get(
+        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const int64_t ne00, cudaStream_t stream) {
+    GGML_ASSERT(src0->type == GGML_TYPE_TQ3_4S);
+    GGML_ASSERT(src0->view_src == nullptr);
+    GGML_ASSERT(ggml_is_contiguous(src0));
+    GGML_ASSERT(ne00 % QK_NVFP4 == 0);
+
+    const int64_t nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const int64_t tq_blocks_per_row = ne00 / QK_TQ3_0;
+    const int64_t nv_blocks_per_row = ne00 / QK_NVFP4;
+    GGML_ASSERT(tq_blocks_per_row == 2 * nv_blocks_per_row);
+
+    const size_t src_size = (size_t) nrows * tq_blocks_per_row * sizeof(block_tq3_4s);
+    const size_t cache_size = (size_t) nrows * nv_blocks_per_row * sizeof(block_nvfp4);
+    const void * key = src0;
+
+    std::lock_guard<std::mutex> lock(ctx.tq3_4s_nvfp4_cache_mutex);
+    auto & entry = ctx.tq3_4s_nvfp4_cache[key];
+    if (entry.data != nullptr && entry.size == cache_size && entry.src_size == src_size && entry.src_data == src0->data) {
+        return (const char *) entry.data;
+    }
+
+    ggml_cuda_set_device(ctx.device);
+    if (entry.data != nullptr) {
+        CUDA_CHECK(cudaFree(entry.data));
+        entry = {};
+    }
+
+    CUDA_CHECK(cudaMalloc(&entry.data, cache_size));
+    entry.size = cache_size;
+    entry.src_size = src_size;
+    entry.src_data = src0->data;
+
+    quantize_tq3_4s_to_nvfp4_cuda(src0->data, entry.data, ne00, nrows, stream);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    return (const char *) entry.data;
+}
+
 void ggml_cuda_mul_mat_q(
         ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst) {
     GGML_ASSERT(        src1->type == GGML_TYPE_F32);
@@ -122,9 +162,16 @@ void ggml_cuda_mul_mat_q(
     const bool use_stream_k = (GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA)
                             || GGML_CUDA_CC_IS_CDNA(cc);
 
+    const bool use_tq3_4s_native_fp4_cache = blackwell_mma_available(cc) &&
+        src0->type == GGML_TYPE_TQ3_4S && src0->view_src == nullptr && ggml_is_contiguous(src0) && ne00 % QK_NVFP4 == 0;
+    if (blackwell_mma_available(cc) && src0->type == GGML_TYPE_TQ3_4S) {
+        GGML_ASSERT(use_tq3_4s_native_fp4_cache);
+        src0_d = ggml_cuda_tq3_4s_nvfp4_cache_get(ctx, src0, ne00, stream);
+    }
+
     // TODO: tighter pool buffer size vs q8 path
     const bool use_native_fp4 = blackwell_mma_available(cc) &&
-        (src0->type == GGML_TYPE_MXFP4 || src0->type == GGML_TYPE_NVFP4 || src0->type == GGML_TYPE_TQ3_4S);
+        (src0->type == GGML_TYPE_MXFP4 || src0->type == GGML_TYPE_NVFP4 || use_tq3_4s_native_fp4_cache);
     const ggml_type activation_fp4_type = src0->type == GGML_TYPE_MXFP4 ? GGML_TYPE_MXFP4 : GGML_TYPE_NVFP4;
 
     if (!ids) {

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -4,6 +4,9 @@
 #include "mmid.cuh"
 #include "tq3-native.cuh"
 
+#include <cstdlib>
+#include <cstring>
+
 static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
     switch (args.type_x) {
         case GGML_TYPE_Q4_0:
@@ -75,6 +78,66 @@ static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, con
     }
 }
 
+static int ggml_cuda_tq3_4s_nvfp4_cache_override() {
+    const char * env = getenv("GGML_CUDA_TQ3_4S_NVFP4_CACHE");
+    if (env == nullptr || env[0] == '\0') {
+        return -1;
+    }
+
+    if (strcmp(env, "0") == 0 || strcmp(env, "off") == 0 || strcmp(env, "false") == 0 || strcmp(env, "no") == 0) {
+        return 0;
+    }
+
+    if (strcmp(env, "1") == 0 || strcmp(env, "on") == 0 || strcmp(env, "true") == 0 || strcmp(env, "yes") == 0) {
+        return 1;
+    }
+
+    return -1;
+}
+
+static bool ggml_cuda_tq3_4s_nvfp4_cache_has_budget(
+        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const size_t cache_size) {
+    const int override = ggml_cuda_tq3_4s_nvfp4_cache_override();
+    if (override == 0) {
+        return false;
+    }
+    if (override == 1) {
+        return true;
+    }
+
+    constexpr size_t mib = 1024 * 1024;
+    size_t free_mem = 0;
+    size_t total_mem = 0;
+
+    ggml_cuda_set_device(ctx.device);
+    CUDA_CHECK(cudaMemGetInfo(&free_mem, &total_mem));
+
+    const size_t source_buffer_size = src0->buffer != nullptr ? ggml_backend_buffer_get_size(src0->buffer) : 0;
+    const size_t min_margin = 2ull * 1024 * mib;
+    const size_t fraction_margin = total_mem / 8;
+    const size_t margin = fraction_margin > min_margin ? fraction_margin : min_margin;
+    const bool fits_model_cache = source_buffer_size == 0 || total_mem > source_buffer_size + source_buffer_size + margin;
+    const bool fits_current_free = free_mem > cache_size + margin;
+    if (fits_model_cache && fits_current_free) {
+        return true;
+    }
+
+    static bool warned[GGML_CUDA_MAX_DEVICES] = {};
+    if (!warned[ctx.device]) {
+        constexpr double mib = 1024.0 * 1024.0;
+        GGML_LOG_WARN(
+            "%s: disabling TQ3_4S native NVFP4 cache on device %d: requested %.2f MiB, model buffer %.2f MiB, free %.2f MiB, total %.2f MiB. Set GGML_CUDA_TQ3_4S_NVFP4_CACHE=1 to force.\n",
+            __func__, ctx.device,
+            (double) cache_size / mib,
+            (double) source_buffer_size / mib,
+            (double) free_mem / mib,
+            (double) total_mem / mib);
+        warned[ctx.device] = true;
+    }
+
+    return false;
+}
+
 static const char * ggml_cuda_tq3_4s_nvfp4_cache_get(
         ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const int64_t ne00, cudaStream_t stream) {
     GGML_ASSERT(src0->type == GGML_TYPE_TQ3_4S);
@@ -95,6 +158,10 @@ static const char * ggml_cuda_tq3_4s_nvfp4_cache_get(
     auto & entry = ctx.tq3_4s_nvfp4_cache[key];
     if (entry.data != nullptr && entry.size == cache_size && entry.src_size == src_size && entry.src_data == src0->data) {
         return (const char *) entry.data;
+    }
+
+    if (!ggml_cuda_tq3_4s_nvfp4_cache_has_budget(ctx, src0, cache_size)) {
+        return nullptr;
     }
 
     ggml_cuda_set_device(ctx.device);
@@ -162,11 +229,15 @@ void ggml_cuda_mul_mat_q(
     const bool use_stream_k = (GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA)
                             || GGML_CUDA_CC_IS_CDNA(cc);
 
-    const bool use_tq3_4s_native_fp4_cache = blackwell_mma_available(cc) &&
+    bool use_tq3_4s_native_fp4_cache = false;
+    const bool can_use_tq3_4s_native_fp4_cache = blackwell_mma_available(cc) &&
         src0->type == GGML_TYPE_TQ3_4S && src0->view_src == nullptr && ggml_is_contiguous(src0) && ne00 % QK_NVFP4 == 0;
-    if (blackwell_mma_available(cc) && src0->type == GGML_TYPE_TQ3_4S) {
-        GGML_ASSERT(use_tq3_4s_native_fp4_cache);
-        src0_d = ggml_cuda_tq3_4s_nvfp4_cache_get(ctx, src0, ne00, stream);
+    if (can_use_tq3_4s_native_fp4_cache) {
+        const char * cached_src0_d = ggml_cuda_tq3_4s_nvfp4_cache_get(ctx, src0, ne00, stream);
+        if (cached_src0_d != nullptr) {
+            src0_d = cached_src0_d;
+            use_tq3_4s_native_fp4_cache = true;
+        }
     }
 
     // TODO: tighter pool buffer size vs q8 path

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3645,8 +3645,8 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     float am = 1e-10f;
     for (int j = 0; j < 16; j++) { float a = fabsf(fv[j]); if (a > am) am = a; }
     float sn = am / 12.0f;
-    uint8_t su = ggml_fp32_to_ue4m3(sn);
-    float si = 1.0f / ggml_ue4m3_to_fp32(su);
+    uint8_t su = ggml_cuda_fp32_to_ue4m3(sn);
+    float si = 1.0f / ggml_cuda_ue4m3_to_fp32(su);
     uint32_t * xu = (uint32_t *)x_tile;
     xu[64 + kbx + (row * 0)] = get_int_b4((const uint8_t *)&su, 0);
     uint8_t pk[8];

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -4,7 +4,6 @@
 #include "vecdotq.cuh"
 #include "mma.cuh"
 
-#include <cfloat>
 #include <climits>
 #include <cstdint>
 
@@ -3609,7 +3608,6 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     constexpr int rows_per_warp = warp_size / blocks_per_row;
     constexpr float tq3_centroids[8] = { -1.996684f, -1.291398f, -0.740341f, -0.247508f,
                                           0.230106f,  0.725222f,  1.277503f,  1.988943f };
-    constexpr int scale_offsets[5] = { 0, -1, 1, -2, 2 };
 
     const auto decode_tq3_scale = [] __device__ (const uint8_t sb) {
         if (sb == 0) {
@@ -3660,38 +3658,26 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
                 }
             }
 
-            const int first_scale_code = (int) ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
-            float best_error = FLT_MAX;
-            uint8_t scale_code = 0;
-            float scale = 0.0f;
-
-#pragma unroll
-            for (int candidate = 0; candidate < 5; ++candidate) {
-                const int test_code = first_scale_code + scale_offsets[candidate];
-                if (test_code < 0 || test_code > 0x7e) {
-                    continue;
-                }
-
-                const float test_scale = ggml_cuda_ue4m3_to_fp32((uint8_t) test_code);
-                const float inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
-                float error = 0.0f;
-#pragma unroll
-                for (int j = 0; j < QK_NVFP4_SUB; ++j) {
-                    const uint8_t q = ggml_cuda_float_to_fp4_e2m1(vals[j], inv_scale);
-                    const float diff = fabsf(vals[j]) - fabsf(kvalues_mxfp4[q & 7]) * test_scale;
-                    error = fmaf(diff, diff, error);
-                }
-
-                if (error < best_error) {
-                    best_error = error;
-                    scale_code = (uint8_t) test_code;
-                    scale = test_scale;
-                }
-            }
-
+            const uint8_t scale_code = ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
+            const float scale = ggml_cuda_ue4m3_to_fp32(scale_code);
             const float inv_scale = scale > 0.0f ? 0.5f / scale : 0.0f;
             uint32_t q0 = 0;
             uint32_t q1 = 0;
+#if CUDART_VERSION >= 12080
+#pragma unroll
+            for (int j = 0; j < QK_NVFP4_SUB / 2; j += 2) {
+                const __nv_fp4x4_e2m1 packed(make_float4(
+                    vals[j + 0] * inv_scale, vals[j + 8] * inv_scale,
+                    vals[j + 1] * inv_scale, vals[j + 9] * inv_scale));
+                const char2 q = *reinterpret_cast<const char2 *>(&packed);
+                const uint32_t pair = (uint8_t) q.x | ((uint32_t) (uint8_t) q.y << 8);
+                if (j < 4) {
+                    q0 |= pair << (8 * j);
+                } else {
+                    q1 |= pair << (8 * (j - 4));
+                }
+            }
+#else
 #pragma unroll
             for (int j = 0; j < QK_NVFP4_SUB / 4; ++j) {
                 q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 0],  inv_scale) << (8 * j);
@@ -3699,6 +3685,7 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
                 q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 4],  inv_scale) << (8 * j);
                 q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 12], inv_scale) << (8 * j + 4);
             }
+#endif // CUDART_VERSION >= 12080
 
             x_u32[q_base + 2 * sub + 0] = q0;
             x_u32[q_base + 2 * sub + 1] = q1;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -4,6 +4,7 @@
 #include "vecdotq.cuh"
 #include "mma.cuh"
 
+#include <cfloat>
 #include <climits>
 #include <cstdint>
 
@@ -3608,6 +3609,7 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     constexpr int rows_per_warp = warp_size / blocks_per_row;
     constexpr float tq3_centroids[8] = { -1.996684f, -1.291398f, -0.740341f, -0.247508f,
                                           0.230106f,  0.725222f,  1.277503f,  1.988943f };
+    constexpr int scale_offsets[5] = { 0, -1, 1, -2, 2 };
 
     const auto decode_tq3_scale = [] __device__ (const uint8_t sb) {
         if (sb == 0) {
@@ -3658,34 +3660,65 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
                 }
             }
 
-            const uint8_t scale_code = ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
-            const float scale = ggml_cuda_ue4m3_to_fp32(scale_code);
-            const float inv_scale = scale > 0.0f ? 0.5f / scale : 0.0f;
+            const int first_scale_code = (int) ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
+            float best_error = FLT_MAX;
+            uint8_t scale_code = 0;
             uint32_t q0 = 0;
             uint32_t q1 = 0;
+
+#pragma unroll
+            for (int candidate = 0; candidate < 5; ++candidate) {
+                const int test_code = first_scale_code + scale_offsets[candidate];
+                if (test_code < 0 || test_code > 0x7e) {
+                    continue;
+                }
+
+                const float test_scale = ggml_cuda_ue4m3_to_fp32((uint8_t) test_code);
+                const float inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
+                uint32_t candidate_q0 = 0;
+                uint32_t candidate_q1 = 0;
 #if CUDART_VERSION >= 12080
 #pragma unroll
-            for (int j = 0; j < QK_NVFP4_SUB / 2; j += 2) {
-                const __nv_fp4x4_e2m1 packed(make_float4(
-                    vals[j + 0] * inv_scale, vals[j + 8] * inv_scale,
-                    vals[j + 1] * inv_scale, vals[j + 9] * inv_scale));
-                const char2 q = *reinterpret_cast<const char2 *>(&packed);
-                const uint32_t pair = (uint8_t) q.x | ((uint32_t) (uint8_t) q.y << 8);
-                if (j < 4) {
-                    q0 |= pair << (8 * j);
-                } else {
-                    q1 |= pair << (8 * (j - 4));
+                for (int j = 0; j < QK_NVFP4_SUB / 2; j += 2) {
+                    const __nv_fp4x4_e2m1 packed(make_float4(
+                        vals[j + 0] * inv_scale, vals[j + 8] * inv_scale,
+                        vals[j + 1] * inv_scale, vals[j + 9] * inv_scale));
+                    const char2 q = *reinterpret_cast<const char2 *>(&packed);
+                    const uint32_t pair = (uint8_t) q.x | ((uint32_t) (uint8_t) q.y << 8);
+                    if (j < 4) {
+                        candidate_q0 |= pair << (8 * j);
+                    } else {
+                        candidate_q1 |= pair << (8 * (j - 4));
+                    }
                 }
-            }
 #else
 #pragma unroll
-            for (int j = 0; j < QK_NVFP4_SUB / 4; ++j) {
-                q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 0],  inv_scale) << (8 * j);
-                q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 8],  inv_scale) << (8 * j + 4);
-                q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 4],  inv_scale) << (8 * j);
-                q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 12], inv_scale) << (8 * j + 4);
-            }
+                for (int j = 0; j < QK_NVFP4_SUB / 4; ++j) {
+                    candidate_q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 0],  inv_scale) << (8 * j);
+                    candidate_q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 8],  inv_scale) << (8 * j + 4);
+                    candidate_q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 4],  inv_scale) << (8 * j);
+                    candidate_q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 12], inv_scale) << (8 * j + 4);
+                }
 #endif // CUDART_VERSION >= 12080
+
+                float error = 0.0f;
+#pragma unroll
+                for (int j = 0; j < QK_NVFP4_SUB / 2; ++j) {
+                    const uint32_t packed = j < 4 ? candidate_q0 : candidate_q1;
+                    const uint8_t q = packed >> (8 * (j % 4));
+                    const float diff0 = fabsf(vals[j]) - fabsf(kvalues_mxfp4[q & 7]) * test_scale;
+                    const float diff1 = fabsf(vals[j + 8]) - fabsf(kvalues_mxfp4[(q >> 4) & 7]) * test_scale;
+                    error = fmaf(diff0, diff0, error);
+                    error = fmaf(diff1, diff1, error);
+                }
+
+                if (error < best_error) {
+                    best_error = error;
+                    scale_code = (uint8_t) test_code;
+                    q0 = candidate_q0;
+                    q1 = candidate_q1;
+                }
+            }
 
             x_u32[q_base + 2 * sub + 0] = q0;
             x_u32[q_base + 2 * sub + 1] = q1;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -149,7 +149,7 @@ static int get_mmq_y_host(const int cc) {
 
 static constexpr __device__ int get_iter_k([[maybe_unused]] const ggml_type type) {
 #if defined(BLACKWELL_MMA_AVAILABLE)
-if (type == GGML_TYPE_NVFP4 || type == GGML_TYPE_MXFP4) {
+if (type == GGML_TYPE_NVFP4 || type == GGML_TYPE_MXFP4 || type == GGML_TYPE_TQ3_4S) {
     return MMQ_ITER_K_FP4;
 }
 #endif // defined(BLACKWELL_MMA_AVAILABLE)
@@ -268,7 +268,11 @@ static constexpr __host__ __device__ int mmq_get_mma_tile_x_k(ggml_type type) {
         case GGML_TYPE_IQ1_S:   return MMQ_MMA_TILE_X_K_Q8_0;
         case GGML_TYPE_IQ4_XS:  return MMQ_MMA_TILE_X_K_Q8_0;
         case GGML_TYPE_IQ4_NL:  return MMQ_MMA_TILE_X_K_Q8_0;
+#if defined(BLACKWELL_MMA_AVAILABLE)
+        case GGML_TYPE_TQ3_4S:  return MMQ_MMA_TILE_X_K_FP4;
+#else
         case GGML_TYPE_TQ3_4S:  return MMQ_MMA_TILE_X_K_Q8_0;
+#endif // defined(BLACKWELL_MMA_AVAILABLE)
         case GGML_TYPE_Q4_0_TQ: return MMQ_MMA_TILE_X_K_Q3_K;
         case GGML_TYPE_Q4_1_TQ: return MMQ_MMA_TILE_X_K_Q3_K;
         default:                return 0;
@@ -1006,8 +1010,8 @@ static __device__ __forceinline__ void vec_dot_fp4_fp4_mma(const int * __restric
                                                            const int * __restrict__ y,
                                                            float * __restrict__ sum,
                                                            const int k00) {
-    static_assert(type == GGML_TYPE_MXFP4 || type == GGML_TYPE_NVFP4,
-                  "vec_dot_fp4_fp4_mma: type must be MXFP4 or NVFP4");
+    static_assert(type == GGML_TYPE_MXFP4 || type == GGML_TYPE_NVFP4 || type == GGML_TYPE_TQ3_4S,
+                  "vec_dot_fp4_fp4_mma: type must be MXFP4, NVFP4, or TQ3_4S");
 
     typedef tile<16, 8, int>   tile_A;
     typedef tile<8, 8, int>    tile_B;
@@ -3595,6 +3599,66 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     }
 }
 
+#if defined(BLACKWELL_MMA_AVAILABLE)
+template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_tq3_4s_to_nvfp4(
+    const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
+    constexpr float tq3_centroids[8] = { -1.996684f, -1.291398f, -0.740341f, -0.247508f,
+                                          0.230106f,  0.725222f,  1.277503f,  1.988943f };
+    constexpr float e2m1_pos[8] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 6.0f, 8.0f, 12.0f};
+    constexpr int tpr = QK_NVFP4 / QK_NVFP4_SUB / 2;
+    const int warp = threadIdx.x / 32;
+    const int tid  = threadIdx.x % 32;
+    const int row  = warp * 2 + tid / 16;
+    if (row >= mmq_y || row > i_max) return;
+    auto decode_scale = [](uint8_t b) -> float {
+        return ldexpf(1.0f + (float)(b & 0x1f) / 32.0f, ((b >> 5) & 7) - 10);
+    };
+    auto e2m1_code = [&](float v) -> int {
+        float av = fabsf(v);
+        if (av < 0.042f) return 0;
+        int s = (v < 0.0f) ? 8 : 0;
+        int bi = 0;
+        float bd = fabsf(av - e2m1_pos[0]);
+        for (int k = 1; k < 8; k++) {
+            float d = fabsf(av - e2m1_pos[k]);
+            if (d < bd) { bd = d; bi = k; }
+        }
+        return s | bi;
+    };
+    const int kbx = kbx0 + tid % tpr;
+    const int idx = kbx * QK_NVFP4 + (tid / tpr) * QK_NVFP4_SUB;
+    const int bi  = idx / QK_TQ3_0;
+    const int sl  = (idx % QK_TQ3_0) / 8;
+    if (kbx * QK_NVFP4 >= stride) return;
+    const block_tq3_4s * bx = (const block_tq3_4s *)x + bi;
+    const uint8_t * qp = (const uint8_t *)bx->qs;
+    float sc[4];
+    for (int g = 0; g < 4; g++) sc[g] = decode_scale(bx->d[g]);
+    float fv[16];
+    for (int g = 0; g < 2; g++) {
+        int gi = sl + g;
+        if (gi >= 4) break;
+        int bo = (gi / 4) * 12 + (gi % 4) * 3;
+        uint32_t pk = (uint32_t)qp[bo] | ((uint32_t)qp[bo+1] << 8) | ((uint32_t)qp[bo+2] << 16);
+        for (int j = 0; j < 8; j++) fv[g*8+j] = tq3_centroids[(pk >> (j*3)) & 7] * sc[gi];
+    }
+    float am = 1e-10f;
+    for (int j = 0; j < 16; j++) { float a = fabsf(fv[j]); if (a > am) am = a; }
+    float sn = am / 12.0f;
+    uint8_t su = ggml_fp32_to_ue4m3(sn);
+    float si = 1.0f / ggml_ue4m3_to_fp32(su);
+    uint32_t * xu = (uint32_t *)x_tile;
+    xu[64 + kbx + (row * 0)] = get_int_b4((const uint8_t *)&su, 0);
+    uint8_t pk[8];
+    for (int j = 0; j < 16; j += 2) {
+        pk[j/2] = (uint8_t)((e2m1_code(fv[j+1] * si) << 4) | e2m1_code(fv[j] * si));
+    }
+    int qb = row * MMQ_MMA_TILE_X_K_NVFP4 + 8 * kbx;
+    xu[qb] = ((uint32_t*)pk)[0];
+    xu[qb+1] = ((uint32_t*)pk)[1];
+    __syncwarp();
+}
+#endif // defined(BLACKWELL_MMA_AVAILABLE)
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q4_0_tq(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
     constexpr int nwarps = mmq_get_nwarps_device();
@@ -3885,8 +3949,13 @@ struct mmq_type_traits<mmq_x, mmq_y, need_check, GGML_TYPE_NVFP4> {
 template <int mmq_x, int mmq_y, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, need_check, GGML_TYPE_TQ3_4S> {
     static constexpr int              vdr          = VDR_Q8_0_Q8_1_MMQ;
+#ifdef BLACKWELL_MMA_AVAILABLE
+    static constexpr load_tiles_mmq_t load_tiles   = load_tiles_tq3_4s_to_nvfp4<mmq_y, need_check>;
+    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_fp4_fp4_mma<mmq_x, mmq_y, GGML_TYPE_TQ3_4S>;
+#else
     static constexpr load_tiles_mmq_t load_tiles   = load_tiles_tq3_4s<mmq_y, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q8_0_q8_1_mma<mmq_x, mmq_y, MMQ_Q8_1_DS_LAYOUT_D4>;
+#endif // BLACKWELL_MMA_AVAILABLE
     static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q8_0_q8_1_dp4a<mmq_x, mmq_y>;
 };
 

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -4,6 +4,7 @@
 #include "vecdotq.cuh"
 #include "mma.cuh"
 
+#include <cfloat>
 #include <climits>
 #include <cstdint>
 
@@ -3602,61 +3603,110 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 #if defined(BLACKWELL_MMA_AVAILABLE)
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_tq3_4s_to_nvfp4(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
+    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int blocks_per_row = MMQ_ITER_K_FP4 / QK_NVFP4;
+    constexpr int rows_per_warp = warp_size / blocks_per_row;
     constexpr float tq3_centroids[8] = { -1.996684f, -1.291398f, -0.740341f, -0.247508f,
                                           0.230106f,  0.725222f,  1.277503f,  1.988943f };
-    constexpr float e2m1_pos[8] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 6.0f, 8.0f, 12.0f};
-    constexpr int tpr = QK_NVFP4 / QK_NVFP4_SUB / 2;
-    const int warp = threadIdx.x / 32;
-    const int tid  = threadIdx.x % 32;
-    const int row  = warp * 2 + tid / 16;
-    if (row >= mmq_y || row > i_max) return;
-    auto decode_scale = [](uint8_t b) -> float {
-        return ldexpf(1.0f + (float)(b & 0x1f) / 32.0f, ((b >> 5) & 7) - 10);
-    };
-    auto e2m1_code = [&](float v) -> int {
-        float av = fabsf(v);
-        if (av < 0.042f) return 0;
-        int s = (v < 0.0f) ? 8 : 0;
-        int bi = 0;
-        float bd = fabsf(av - e2m1_pos[0]);
-        for (int k = 1; k < 8; k++) {
-            float d = fabsf(av - e2m1_pos[k]);
-            if (d < bd) { bd = d; bi = k; }
+    constexpr int scale_offsets[5] = { 0, -1, 1, -2, 2 };
+
+    const auto decode_tq3_scale = [] __device__ (const uint8_t sb) {
+        if (sb == 0) {
+            return 0.0f;
         }
-        return s | bi;
+        const uint32_t bits = (((uint32_t) (sb >> 5) + 118u) << 23) | ((uint32_t) (sb & 31u) << 18);
+        return __uint_as_float(bits);
     };
-    const int kbx = kbx0 + tid % tpr;
-    const int idx = kbx * QK_NVFP4 + (tid / tpr) * QK_NVFP4_SUB;
-    const int bi  = idx / QK_TQ3_0;
-    const int sl  = (idx % QK_TQ3_0) / 8;
-    if (kbx * QK_NVFP4 >= stride) return;
-    const block_tq3_4s * bx = (const block_tq3_4s *)x + bi;
-    const uint8_t * qp = (const uint8_t *)bx->qs;
-    float sc[4];
-    for (int g = 0; g < 4; g++) sc[g] = decode_scale(bx->d[g]);
-    float fv[16];
-    for (int g = 0; g < 2; g++) {
-        int gi = sl + g;
-        if (gi >= 4) break;
-        int bo = (gi / 4) * 12 + (gi % 4) * 3;
-        uint32_t pk = (uint32_t)qp[bo] | ((uint32_t)qp[bo+1] << 8) | ((uint32_t)qp[bo+2] << 16);
-        for (int j = 0; j < 8; j++) fv[g*8+j] = tq3_centroids[(pk >> (j*3)) & 7] * sc[gi];
+
+    uint32_t * x_u32 = reinterpret_cast<uint32_t *>(x_tile);
+    uint32_t * x_sc = x_u32 + 2 * MMQ_TILE_NE_K;
+
+    const int kbx = threadIdx.x % blocks_per_row;
+    const int row_in_warp = threadIdx.x / blocks_per_row;
+    const block_tq3_4s * bxi_base = reinterpret_cast<const block_tq3_4s *>(x) + kbx0 + 2 * kbx;
+
+#pragma unroll
+    for (int i0 = 0; i0 < mmq_y; i0 += rows_per_warp * nwarps) {
+        int i = i0 + threadIdx.y * rows_per_warp + row_in_warp;
+
+        if constexpr (need_check) {
+            i = min(i, i_max);
+        }
+
+        const block_tq3_4s * bxi = bxi_base + i * stride;
+        const int row_base = i * MMQ_MMA_TILE_X_K_FP4;
+        const int q_base = row_base + 8 * kbx;
+        uint32_t packed_scales = 0;
+
+#pragma unroll
+        for (int sub = 0; sub < QK_NVFP4 / QK_NVFP4_SUB; ++sub) {
+            const block_tq3_4s * block = bxi + sub / 2;
+            const int group_base = (sub % 2) * 2;
+            float vals[QK_NVFP4_SUB];
+            float amax = 0.0f;
+
+#pragma unroll
+            for (int group = 0; group < 2; ++group) {
+                const int g = group_base + group;
+                const uint8_t * qp = block->qs + 3 * g;
+                const uint32_t packed = (uint32_t) qp[0] | ((uint32_t) qp[1] << 8) | ((uint32_t) qp[2] << 16);
+                const float d = decode_tq3_scale(block->d[g]);
+#pragma unroll
+                for (int j = 0; j < 8; ++j) {
+                    const float value = tq3_centroids[(packed >> (3 * j)) & 7] * d;
+                    vals[8 * group + j] = value;
+                    amax = fmaxf(amax, fabsf(value));
+                }
+            }
+
+            const int first_scale_code = (int) ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
+            float best_error = FLT_MAX;
+            uint8_t scale_code = 0;
+            float scale = 0.0f;
+
+#pragma unroll
+            for (int candidate = 0; candidate < 5; ++candidate) {
+                const int test_code = first_scale_code + scale_offsets[candidate];
+                if (test_code < 0 || test_code > 0x7e) {
+                    continue;
+                }
+
+                const float test_scale = ggml_cuda_ue4m3_to_fp32((uint8_t) test_code);
+                const float inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
+                float error = 0.0f;
+#pragma unroll
+                for (int j = 0; j < QK_NVFP4_SUB; ++j) {
+                    const uint8_t q = ggml_cuda_float_to_fp4_e2m1(vals[j], inv_scale);
+                    const float diff = fabsf(vals[j]) - fabsf(kvalues_mxfp4[q & 7]) * test_scale;
+                    error = fmaf(diff, diff, error);
+                }
+
+                if (error < best_error) {
+                    best_error = error;
+                    scale_code = (uint8_t) test_code;
+                    scale = test_scale;
+                }
+            }
+
+            const float inv_scale = scale > 0.0f ? 0.5f / scale : 0.0f;
+            uint32_t q0 = 0;
+            uint32_t q1 = 0;
+#pragma unroll
+            for (int j = 0; j < QK_NVFP4_SUB / 4; ++j) {
+                q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 0],  inv_scale) << (8 * j);
+                q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 8],  inv_scale) << (8 * j + 4);
+                q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 4],  inv_scale) << (8 * j);
+                q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 12], inv_scale) << (8 * j + 4);
+            }
+
+            x_u32[q_base + 2 * sub + 0] = q0;
+            x_u32[q_base + 2 * sub + 1] = q1;
+            packed_scales |= (uint32_t) scale_code << (8 * sub);
+        }
+
+        x_sc[row_base + kbx] = packed_scales;
     }
-    float am = 1e-10f;
-    for (int j = 0; j < 16; j++) { float a = fabsf(fv[j]); if (a > am) am = a; }
-    float sn = am / 12.0f;
-    uint8_t su = ggml_cuda_fp32_to_ue4m3(sn);
-    float si = 1.0f / ggml_cuda_ue4m3_to_fp32(su);
-    uint32_t * xu = (uint32_t *)x_tile;
-    xu[64 + kbx + (row * 0)] = get_int_b4((const uint8_t *)&su, 0);
-    uint8_t pk[8];
-    for (int j = 0; j < 16; j += 2) {
-        pk[j/2] = (uint8_t)((e2m1_code(fv[j+1] * si) << 4) | e2m1_code(fv[j] * si));
-    }
-    int qb = row * MMQ_MMA_TILE_X_K_NVFP4 + 8 * kbx;
-    xu[qb] = ((uint32_t*)pk)[0];
-    xu[qb+1] = ((uint32_t*)pk)[1];
-    __syncwarp();
 }
 #endif // defined(BLACKWELL_MMA_AVAILABLE)
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q4_0_tq(
@@ -4109,7 +4159,8 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
 #if defined(BLACKWELL_MMA_AVAILABLE)
     // FP4 tile stores 8 blocks
-    constexpr int ne_block = (type == GGML_TYPE_MXFP4 || type == GGML_TYPE_NVFP4) ? QK_K : 4 * QK8_1;
+    constexpr int ne_block =
+        (type == GGML_TYPE_MXFP4 || type == GGML_TYPE_NVFP4 || type == GGML_TYPE_TQ3_4S) ? QK_K : 4 * QK8_1;
 #else
     constexpr int ne_block = 4 * QK8_1;
 #endif  // defined(BLACKWELL_MMA_AVAILABLE)

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1002,6 +1002,53 @@ static __device__ __forceinline__ void load_tiles_nvfp4_nvfp4(const char * __res
     }
 }
 
+template <int mmq_y, bool need_check>
+static __device__ __forceinline__ void load_tiles_tq3_4s_cached_nvfp4(const char * __restrict__ x,
+                                                                      int * __restrict__ x_tile,
+                                                                      const int kbx0,
+                                                                      const int i_max,
+                                                                      const int stride) {
+    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int iter_k = get_iter_k(GGML_TYPE_NVFP4);
+    constexpr int threads_per_row = iter_k / QK_NVFP4;
+    constexpr int rows_per_warp = warp_size / threads_per_row;
+
+    uint32_t * x_u32 = (uint32_t *) x_tile;
+
+    const int txi = threadIdx.x;
+    const int kbx = txi % threads_per_row;
+    const int row_in_warp = txi / threads_per_row;
+
+    const int nv_kbx0 = kbx0 >> 1;
+    const int nv_stride = stride >> 1;
+    const block_nvfp4 * bxi_base = (const block_nvfp4 *) x + nv_kbx0 + kbx;
+    uint32_t * x_u32_scale = x_u32 + 64 + kbx;
+
+#pragma unroll
+    for (int i0 = 0; i0 < mmq_y; i0 += rows_per_warp * nwarps) {
+        int i = i0 + threadIdx.y * rows_per_warp + row_in_warp;
+
+        if constexpr (need_check) {
+            i = min(i, i_max);
+        }
+
+        const block_nvfp4 * bxi = bxi_base + i * nv_stride;
+        const int row_base = i * MMQ_MMA_TILE_X_K_FP4;
+        const int q_base = row_base + 8 * kbx;
+
+        const uint32_t * src_qs = reinterpret_cast<const uint32_t *>(bxi->qs);
+
+#pragma unroll
+        for (int sub = 0; sub < QK_NVFP4 / QK_NVFP4_SUB; ++sub) {
+            x_u32[q_base + 2 * sub + 0] = src_qs[2 * sub + 0];
+            x_u32[q_base + 2 * sub + 1] = src_qs[2 * sub + 1];
+        }
+
+        x_u32_scale[row_base] = get_int_b4(bxi->d, 0);
+    }
+}
+
 // Shared MMA kernel for MXFP4 and NVFP4 on Blackwell.
 // Both quantizations encode values as e2m1 (FP4) and produce one uint32 scale per
 // m16n8k64 MMA call; only the PTX kind (scale_vec::2X ue8m0 vs scale_vec::4X ue4m3)
@@ -4020,7 +4067,7 @@ template <int mmq_x, int mmq_y, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, need_check, GGML_TYPE_TQ3_4S> {
     static constexpr int              vdr          = VDR_Q8_0_Q8_1_MMQ;
 #ifdef BLACKWELL_MMA_AVAILABLE
-    static constexpr load_tiles_mmq_t load_tiles   = load_tiles_tq3_4s_to_nvfp4<mmq_y, need_check>;
+    static constexpr load_tiles_mmq_t load_tiles   = load_tiles_tq3_4s_cached_nvfp4<mmq_y, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_fp4_fp4_mma<mmq_x, mmq_y, GGML_TYPE_TQ3_4S>;
 #else
     static constexpr load_tiles_mmq_t load_tiles   = load_tiles_tq3_4s<mmq_y, need_check>;

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -170,6 +170,124 @@ static __global__ void quantize_mmq_nvfp4(
 
 }
 
+static __global__ void quantize_tq3_4s_to_nvfp4(
+        const block_tq3_4s * __restrict__ x, block_nvfp4 * __restrict__ y,
+        const int64_t blocks_per_row, const int64_t nv_blocks_per_row, const int64_t nrows) {
+#if defined(BLACKWELL_MMA_AVAILABLE)
+    constexpr float tq3_centroids[8] = { -1.996684f, -1.291398f, -0.740341f, -0.247508f,
+                                          0.230106f,  0.725222f,  1.277503f,  1.988943f };
+    constexpr int scale_offsets[5] = { 0, -1, 1, -2, 2 };
+
+    const auto decode_tq3_scale = [] __device__ (const uint8_t sb) {
+        if (sb == 0) {
+            return 0.0f;
+        }
+        const uint32_t bits = (((uint32_t) (sb >> 5) + 118u) << 23) | ((uint32_t) (sb & 31u) << 18);
+        return __uint_as_float(bits);
+    };
+
+    const int64_t idx = (int64_t) blockIdx.x * blockDim.x + threadIdx.x;
+    const int64_t nblocks = nv_blocks_per_row * nrows;
+    if (idx >= nblocks) {
+        return;
+    }
+
+    const int64_t row = idx / nv_blocks_per_row;
+    const int64_t col = idx - row * nv_blocks_per_row;
+    const block_tq3_4s * src = x + row * blocks_per_row + 2 * col;
+    block_nvfp4 * dst = y + idx;
+
+#pragma unroll
+    for (int sub = 0; sub < QK_NVFP4 / QK_NVFP4_SUB; ++sub) {
+        const block_tq3_4s * block = src + sub / 2;
+        const int group_base = (sub % 2) * 2;
+        float vals[QK_NVFP4_SUB];
+        float amax = 0.0f;
+
+#pragma unroll
+        for (int group = 0; group < 2; ++group) {
+            const int g = group_base + group;
+            const uint8_t * qp = block->qs + 3 * g;
+            const uint32_t packed = (uint32_t) qp[0] | ((uint32_t) qp[1] << 8) | ((uint32_t) qp[2] << 16);
+            const float d = decode_tq3_scale(block->d[g]);
+#pragma unroll
+            for (int j = 0; j < 8; ++j) {
+                const float value = tq3_centroids[(packed >> (3 * j)) & 7] * d;
+                vals[8 * group + j] = value;
+                amax = fmaxf(amax, fabsf(value));
+            }
+        }
+
+        const int first_scale_code = (int) ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
+        float best_error = FLT_MAX;
+        uint8_t scale_code = 0;
+        uint32_t q0 = 0;
+        uint32_t q1 = 0;
+
+#pragma unroll
+        for (int candidate = 0; candidate < 5; ++candidate) {
+            const int test_code = first_scale_code + scale_offsets[candidate];
+            if (test_code < 0 || test_code > 0x7e) {
+                continue;
+            }
+
+            const float test_scale = ggml_cuda_ue4m3_to_fp32((uint8_t) test_code);
+            const float inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
+            uint32_t candidate_q0 = 0;
+            uint32_t candidate_q1 = 0;
+#if CUDART_VERSION >= 12080
+#pragma unroll
+            for (int j = 0; j < QK_NVFP4_SUB / 2; j += 2) {
+                const __nv_fp4x4_e2m1 packed(make_float4(
+                    vals[j + 0] * inv_scale, vals[j + 8] * inv_scale,
+                    vals[j + 1] * inv_scale, vals[j + 9] * inv_scale));
+                const char2 q = *reinterpret_cast<const char2 *>(&packed);
+                const uint32_t pair = (uint8_t) q.x | ((uint32_t) (uint8_t) q.y << 8);
+                if (j < 4) {
+                    candidate_q0 |= pair << (8 * j);
+                } else {
+                    candidate_q1 |= pair << (8 * (j - 4));
+                }
+            }
+#else
+#pragma unroll
+            for (int j = 0; j < QK_NVFP4_SUB / 4; ++j) {
+                candidate_q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 0],  inv_scale) << (8 * j);
+                candidate_q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 8],  inv_scale) << (8 * j + 4);
+                candidate_q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 4],  inv_scale) << (8 * j);
+                candidate_q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals[j + 12], inv_scale) << (8 * j + 4);
+            }
+#endif // CUDART_VERSION >= 12080
+
+            float error = 0.0f;
+#pragma unroll
+            for (int j = 0; j < QK_NVFP4_SUB / 2; ++j) {
+                const uint32_t packed = j < 4 ? candidate_q0 : candidate_q1;
+                const uint8_t q = packed >> (8 * (j % 4));
+                const float diff0 = fabsf(vals[j]) - fabsf(kvalues_mxfp4[q & 7]) * test_scale;
+                const float diff1 = fabsf(vals[j + 8]) - fabsf(kvalues_mxfp4[(q >> 4) & 7]) * test_scale;
+                error = fmaf(diff0, diff0, error);
+                error = fmaf(diff1, diff1, error);
+            }
+
+            if (error < best_error) {
+                best_error = error;
+                scale_code = (uint8_t) test_code;
+                q0 = candidate_q0;
+                q1 = candidate_q1;
+            }
+        }
+
+        uint32_t * dst_qs = reinterpret_cast<uint32_t *>(dst->qs);
+        dst_qs[2 * sub + 0] = q0;
+        dst_qs[2 * sub + 1] = q1;
+        dst->d[sub] = scale_code;
+    }
+#else
+    NO_DEVICE_CODE;
+#endif // defined(BLACKWELL_MMA_AVAILABLE)
+}
+
 // quantize values in the format mxfp4 is stored which is interleaved nibbles
 // i.e. a block a0-a31 is represented as a0a16,a1a17 ...a15a31
 static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
@@ -447,4 +565,18 @@ void quantize_mmq_fp4_cuda(
 
         quantize_mmq_mxfp4<<<num_blocks, block_size, 0, stream>>>(x, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
     }
+}
+
+void quantize_tq3_4s_to_nvfp4_cuda(const void * x, void * y, const int64_t ne00, const int64_t nrows, cudaStream_t stream) {
+    GGML_ASSERT(ne00 % QK_NVFP4 == 0);
+    GGML_ASSERT(nrows > 0);
+
+    const int64_t blocks_per_row = ne00 / QK_TQ3_0;
+    const int64_t nv_blocks_per_row = ne00 / QK_NVFP4;
+    const int64_t nblocks = nv_blocks_per_row * nrows;
+
+    constexpr int block_size = 256;
+    const dim3 num_blocks((nblocks + block_size - 1) / block_size, 1, 1);
+    quantize_tq3_4s_to_nvfp4<<<num_blocks, block_size, 0, stream>>>(
+        (const block_tq3_4s *) x, (block_nvfp4 *) y, blocks_per_row, nv_blocks_per_row, nrows);
 }

--- a/ggml/src/ggml-cuda/quantize.cuh
+++ b/ggml/src/ggml-cuda/quantize.cuh
@@ -39,3 +39,5 @@ void quantize_mmq_fp4_cuda(const float *   x,
                              int64_t         ne2,
                              int64_t         ne3,
                              cudaStream_t    stream);
+
+void quantize_tq3_4s_to_nvfp4_cuda(const void * x, void * y, int64_t ne00, int64_t nrows, cudaStream_t stream);

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -24,8 +24,14 @@ static int ffs(int x) {
     unsigned long i;
     return _BitScanForward(&i, (unsigned long)x) ? (int)(i + 1) : 0;
 }
+static int ggml_popcount_u(unsigned x) {
+    return (int)__popcnt(x);
+}
 #else
 #include <strings.h>
+static int ggml_popcount_u(unsigned x) {
+    return __builtin_popcount(x);
+}
 #endif
 
 #define GROUP_MAX_EPS 1e-15f
@@ -6860,7 +6866,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
             {
                 const block_tq3_1s_ap1 * q = (const block_tq3_1s_ap1 *) data;
                 for (size_t i = 0; i < nb; ++i) {
-                    if (__builtin_popcount((unsigned) q[i].mask) != 1) {
+                    if (ggml_popcount_u((unsigned) q[i].mask) != 1) {
                         return false;
                     }
                 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4017,7 +4017,8 @@ struct test_mul_mat : public test_case {
 
     double max_nmse_err(ggml_backend_t backend) override {
         // for blackwell we quantize activations to mxfp4 instead of q8_1 so we add higher tolerance
-        if ((type_a == GGML_TYPE_MXFP4 || type_a == GGML_TYPE_NVFP4) && backend_has_feature(backend, "BLACKWELL_NATIVE_FP4")) {
+        if ((type_a == GGML_TYPE_MXFP4 || type_a == GGML_TYPE_NVFP4 || type_a == GGML_TYPE_TQ3_4S) &&
+            backend_has_feature(backend, "BLACKWELL_NATIVE_FP4")) {
             return 2e-2;
         }
         return max_nmse_err();
@@ -4206,7 +4207,8 @@ struct test_mul_mat_id : public test_case {
 
     double max_nmse_err(ggml_backend_t backend) override {
         // for blackwell we quantize activations to mxfp4 instead of q8_1 so we add higher tolerance
-        if ((type_a == GGML_TYPE_MXFP4 || type_a == GGML_TYPE_NVFP4) && backend_has_feature(backend, "BLACKWELL_NATIVE_FP4")) {
+        if ((type_a == GGML_TYPE_MXFP4 || type_a == GGML_TYPE_NVFP4 || type_a == GGML_TYPE_TQ3_4S) &&
+            backend_has_feature(backend, "BLACKWELL_NATIVE_FP4")) {
             return 2e-2;
         }
         return max_nmse_err();
@@ -8428,6 +8430,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2880, 32, 2880, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2880, 32, 2880, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_MXFP4, GGML_TYPE_F32, 2880, 32, 2880, {1, 1}, {1, 1}));
+
+    // Batched shapes exercise Blackwell native FP4 MMQ instead of MMVQ.
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_4S, GGML_TYPE_F32, 2880,  32, 2880, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_4S, GGML_TYPE_F32, 4096, 128, 4096, {1, 1}, {1, 1}));
 
 
 #if 0


### PR DESCRIPTION
## Summary

Enables TQ3_4S (4.0 bpw) to use native Blackwell FP4 tensor core MMA instead of dp4a at runtime. **Primary target: RTX 5060 Ti (`sm_120`).** No disk format change — same TQ3_4S blocks on disk, conversion happens in the CUDA tile loader at compute time.

- **`load_tiles_tq3_4s_to_nvfp4`** (`mmq.cuh`): new tile loader under `BLACKWELL_MMA_AVAILABLE`. Decodes 3-bit centroid indices → nearest E2M1 FP4 values, computes per-16-block UE4M3 scales, packs as NVFP4 tile for `vec_dot_fp4_fp4_mma`.
- **`get_iter_k` / `mmq_get_mma_tile_x_k` / `mmq_type_traits<TQ3_4S>`** (`mmq.cuh`): Blackwell path wired to FP4 loader + MMA kernel; non-Blackwell path unchanged (dp4a).
- **`ggml_cuda_fp32_to_ue4m3`** (`common.cuh`): device-compatible UE4M3 conversion used in tile loader.
- **`BLACKWELL_MMA_AVAILABLE` HIP guard** (`common.cuh`): early definition now has `!defined(GGML_USE_HIP)` to prevent false-positive on AMD builds.

## Benchmark — Qwen3.6-27B-MTP-TQ3_4S on GB10 (CC 12.1, CUDA 13.0)

Benchmarked on `.44` dev box (GB10, `sm_121`). RTX 5060 Ti (`sm_120`) is the production target — build with `-DCMAKE_CUDA_ARCHITECTURES=120`.

| Batch | dp4a (sm_86) | FP4 MMA (sm_121) | Speedup |
|------:|-------------:|-----------------:|--------:|
| pp1   | 13.8 t/s     | 13.9 t/s         | 1.0×    |
| pp32  | 287 t/s      | 769 t/s          | **2.7×** |
| pp128 | 681 t/s      | 1201 t/s         | **1.76×** |
| pp256 | 699 t/s      | 1198 t/s         | **1.71×** |
| pp512 | 689 t/s      | 1170 t/s         | **1.70×** |
| pp1024 | 691 t/s    | 1171 t/s         | **1.70×** |
| pp2048 | 693 t/s    | 1159 t/s         | **1.67×** |

**~1.7× faster on prefill across all batch sizes ≥ 128.** Decode (pp1) is memory-bandwidth-bound — no change expected or observed.

## Test plan

- [x] FP4 MMA path runs without crash on GB10 (`build-sm121`)
- [x] dp4a path unchanged on non-Blackwell GPUs
- [x] HIP build no longer hits `__nv_fp8_e4m3` (BLACKWELL guard fix)
- [x] Benchmark confirms ~1.7× prefill speedup vs dp4a baseline
- [ ] Smoke test on RTX 5060 Ti (`sm_120`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Local No-Cache Timing

RTX 5060 Ti 16GB, CUDA 12.8, MSVC, `ngl=99`, `fa=1`, `ctk=q4_0`, `ctv=tq3_0`, `GGML_CUDA_TQ3_4S_NVFP4_CACHE=0`.

| model | main | PR51 no-cache | speedup |
| --- | ---: | ---: | ---: |
| dense Qwen3.5 9B TQ3_4S | 2455 tok/s | 3367 tok/s | +37% |
| dense Qwopus3.6 27B TQ3_4S | 738 tok/s | 1220 tok/s | +65% |