### PR TITLE
cuda: rotate TQ3_4S activations out-of-place (+7-9% FP4 prefill)

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -368,8 +368,7 @@ void ggml_cuda_mul_mat_q(
             if (src0->type == GGML_TYPE_TQ3_4S) {
                 const int64_t n_act = ne13 * ne12 * ne11 * ne10;
                 src1_rot.alloc(n_act);
-                CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-                ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+                ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
                 src1_quant = src1_rot.get();
             }
             if (use_native_fp4) {
@@ -445,8 +444,7 @@ void ggml_cuda_mul_mat_q(
         if (src0->type == GGML_TYPE_TQ3_4S) {
             const int64_t n_act = ne13 * ne12 * ne11 * ne10;
             src1_rot.alloc(n_act);
-            CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-            ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+            ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
             src1_quant = src1_rot.get();
         }
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1308,8 +1308,7 @@ void ggml_cuda_mul_mat_vec_q(
     if (src0->type == GGML_TYPE_TQ3_4S) {
         const int64_t n_act = ne13 * ne12 * ne11 * ne10;
         ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(), n_act);
-        CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-        ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+        ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
 
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
@@ -1384,8 +1383,7 @@ void ggml_cuda_op_mul_mat_vec_q(
     if (src0->type == GGML_TYPE_TQ3_4S) {
         const int64_t n_act = src1_ncols * ne10;
         ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(id), n_act);
-        CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_ddf_i, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-        ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+        ggml_cuda_tq3_rotate_act(src1_ddf_i, src1_rot.get(), n_act, stream);
 
         ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(id), src1_ncols * src1_padded_row_size * sizeof(block_q8_1)/QK8_1);
         quantize_row_q8_1_cuda(src1_rot.get(), nullptr, src1_q8_1.get(), src0->type, ne10, ne10, src1_ncols*ne10, src1_ncols*ne10, src1_padded_row_size, src1_ncols, 1, 1, stream);

--- a/ggml/src/ggml-cuda/tq3-native.cu
+++ b/ggml/src/ggml-cuda/tq3-native.cu
@@ -15,18 +15,21 @@ __global__ void ggml_cuda_native_tq3_dot_kernel(
     out[blk] = vec_dot_tq3_0_q8_0_native_block(in + blk, act + blk);
 }
 
-static __global__ void tq3_rotate_act_kernel(float * __restrict__ x, int64_t n) {
+static __global__ void tq3_rotate_act_kernel(const float * __restrict__ src, float * __restrict__ dst, int64_t n) {
     const int64_t base = (int64_t)blockIdx.x * QK_TQ3_0;
     if (base >= n) return;
     const int lane = threadIdx.x;
-    float val = x[base + lane] * ggml_cuda_tq3_sign(lane);
+    float val = src[base + lane] * ggml_cuda_tq3_sign(lane);
     for (int step = 1; step < QK_TQ3_0; step <<= 1) {
         const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         val = (lane & step) ? (other - val) : (other + val);
     }
-    x[base + lane] = val / sqrtf((float)QK_TQ3_0);
+    dst[base + lane] = val / sqrtf((float)QK_TQ3_0);
 }
 
-void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream) {
-    tq3_rotate_act_kernel<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(x, n);
+// Out-of-place: reads src, writes dst (src and dst may alias for in-place use).
+// Callers previously did cudaMemcpy(dst, src) + in-place rotate; folding the copy
+// into the kernel halves the activation-rotation memory traffic.
+void ggml_cuda_tq3_rotate_act(const float * src, float * dst, int64_t n, cudaStream_t stream) {
+    tq3_rotate_act_kernel<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(src, dst, n);
 }

--- a/ggml/src/ggml-cuda/tq3-native.cuh
+++ b/ggml/src/ggml-cuda/tq3-native.cuh
@@ -100,5 +100,6 @@ __global__ void ggml_cuda_native_tq3_dot_kernel(
         float * __restrict__ out,
         int nblocks);
 
-// Rotate activations in-place (declaration - implementation in tq3-native.cu)
-void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream);
+// Rotate activations out-of-place: dst = rotate(src). Folds the previous
+// cudaMemcpy+in-place-rotate into one pass. src and dst may be equal.
+void ggml_cuda_tq3_rotate_act(const float * src, float * dst, int64_t n, cudaStream_t stream);


### PR DESCRIPTION
## Summary

The TQ3_4S activation rotation ran as three passes over the activations per matmul:
`cudaMemcpy(src1 -> rot)` + in-place `tq3_rotate_act` + quantize. This folds the
copy into the rotate kernel (read src1, write rot), halving the rotation-stage
memory traffic. Applied at all 4 call sites (mmq x2, mmvq x2).

## Motivation

nsys profiling of GB10 FP4 prefill showed the activation-rotation stage (a full
device-to-device copy of the activations before every TQ3_4S matmul, plus the
rotate kernel) as meaningful overhead — the FP4 MMA itself was only ~42% of GPU
time, with shared TQ3/FP4 activation overhead ~22%.

## Results (GB10 sm_121a, Qwen3.6-27B-MTP-TQ3_4S, pp2048, idle GPU)

| Config | before | after | gain |
|---|---:|---:|---:|
| FP4 cache-on | 920 | 1002 | +8.9% |
| FP4 Option E (transient, 0 GiB) | 681 | 729 | +7.0% |

Correctness: `test-backend-ops test -o MUL_MAT -p tq3_4s` passes 2/2 (incl. the
non-512-K k=2880 case). The rotation math is unchanged — only the redundant copy
is removed.

## Follow-up

Fully fusing `tq3_rotate_act` into `quantize_mmq_nvfp4` (rotate in-registers
during quantization) would reclaim most of the remaining ~9.6% rotate kernel too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)