### PR TITLE
cuda: fuse TQ3_4S rotate into NVFP4 quantizer (GB10 FP4 beats 3090)

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -365,7 +365,11 @@ void ggml_cuda_mul_mat_q(
             const int64_t s13 = src1->nb[3] / ts_src1;
             const float * src1_quant = src1_d;
             ggml_cuda_pool_alloc<float> src1_rot(ctx.pool());
-            if (src0->type == GGML_TYPE_TQ3_4S) {
+            // For TQ3_4S the activations need a Walsh-Hadamard rotation. On the
+            // native FP4 path we fuse it into the NVFP4 quantizer (no separate
+            // rotate kernel/buffer); the Q8 path still rotates out-of-place.
+            const bool fuse_rot = (src0->type == GGML_TYPE_TQ3_4S) && use_native_fp4;
+            if (src0->type == GGML_TYPE_TQ3_4S && !fuse_rot) {
                 const int64_t n_act = ne13 * ne12 * ne11 * ne10;
                 src1_rot.alloc(n_act);
                 ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
@@ -375,7 +379,7 @@ void ggml_cuda_mul_mat_q(
                 static_assert(sizeof(block_fp4_mmq) == 4 * sizeof(block_q8_1));
                 quantize_mmq_fp4_cuda(src1_quant, nullptr, src1_q8_1.get(), activation_fp4_type,
                                       ne10, s11, s12, s13, ne10_padded,
-                                      ne11, ne12, ne13, stream);
+                                      ne11, ne12, ne13, stream, fuse_rot);
 
             } else {
                 quantize_mmq_q8_1_cuda(src1_quant, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded,
@@ -441,7 +445,8 @@ void ggml_cuda_mul_mat_q(
         const int64_t s13 = src1->nb[3] / ts_src1;
         const float * src1_quant = src1_d;
         ggml_cuda_pool_alloc<float> src1_rot(ctx.pool());
-        if (src0->type == GGML_TYPE_TQ3_4S) {
+        const bool fuse_rot = (src0->type == GGML_TYPE_TQ3_4S) && use_native_fp4;
+        if (src0->type == GGML_TYPE_TQ3_4S && !fuse_rot) {
             const int64_t n_act = ne13 * ne12 * ne11 * ne10;
             src1_rot.alloc(n_act);
             ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
@@ -451,7 +456,7 @@ void ggml_cuda_mul_mat_q(
         if (use_native_fp4) {
             quantize_mmq_fp4_cuda(src1_quant, ids_src1.get(), src1_q8_1.get(), activation_fp4_type,
                                   ne10, s11, s12, s13,
-                                  ne10_padded, ne11_flat, ne12_flat, ne13_flat, stream);
+                                  ne10_padded, ne11_flat, ne12_flat, ne13_flat, stream, fuse_rot);
         } else {
             quantize_mmq_q8_1_cuda(src1_quant, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
                                    ne10_padded, ne11_flat, ne12_flat, ne13_flat, stream);

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -368,8 +368,7 @@ void ggml_cuda_mul_mat_q(
             if (src0->type == GGML_TYPE_TQ3_4S) {
                 const int64_t n_act = ne13 * ne12 * ne11 * ne10;
                 src1_rot.alloc(n_act);
-                CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-                ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+                ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
                 src1_quant = src1_rot.get();
             }
             if (use_native_fp4) {
@@ -445,8 +444,7 @@ void ggml_cuda_mul_mat_q(
         if (src0->type == GGML_TYPE_TQ3_4S) {
             const int64_t n_act = ne13 * ne12 * ne11 * ne10;
             src1_rot.alloc(n_act);
-            CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-            ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+            ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
             src1_quant = src1_rot.get();
         }
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1308,8 +1308,7 @@ void ggml_cuda_mul_mat_vec_q(
     if (src0->type == GGML_TYPE_TQ3_4S) {
         const int64_t n_act = ne13 * ne12 * ne11 * ne10;
         ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(), n_act);
-        CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_d, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-        ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+        ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
 
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
@@ -1384,8 +1383,7 @@ void ggml_cuda_op_mul_mat_vec_q(
     if (src0->type == GGML_TYPE_TQ3_4S) {
         const int64_t n_act = src1_ncols * ne10;
         ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(id), n_act);
-        CUDA_CHECK(cudaMemcpyAsync(src1_rot.get(), src1_ddf_i, n_act*sizeof(float), cudaMemcpyDeviceToDevice, stream));
-        ggml_cuda_tq3_rotate_act(src1_rot.get(), n_act, stream);
+        ggml_cuda_tq3_rotate_act(src1_ddf_i, src1_rot.get(), n_act, stream);
 
         ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(id), src1_ncols * src1_padded_row_size * sizeof(block_q8_1)/QK8_1);
         quantize_row_q8_1_cuda(src1_rot.get(), nullptr, src1_q8_1.get(), src0->type, ne10, ne10, src1_ncols*ne10, src1_ncols*ne10, src1_padded_row_size, src1_ncols, 1, 1, stream);

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -170,6 +170,121 @@ static __global__ void quantize_mmq_nvfp4(
 
 }
 
+// Fused TQ3_4S rotate (Walsh-Hadamard per 32-group) + NVFP4 activation quantize.
+// Each thread owns one 32-value rotation group == 2 NVFP4 sub-blocks, reads the
+// RAW (unrotated) activations, rotates in-register, then quantizes. Replaces the
+// separate cudaMemcpy + tq3_rotate_act kernel + buffer with a single pass.
+// Assumes ne00 (== n_embd) is a multiple of QK_TQ3_0 (matches tq3_rotate_act).
+static __global__ void quantize_mmq_nvfp4_rot(
+        const float * __restrict__ x, const int32_t * __restrict__ ids, void * __restrict__ vy,
+        const int64_t ne00, const int64_t s01, const int64_t s02, const int64_t s03,
+        const int64_t ne0, const int64_t ne1, const int64_t ne2) {
+#if defined(BLACKWELL_MMA_AVAILABLE)
+    const int64_t g_base = ((int64_t) blockDim.x * blockIdx.y + threadIdx.x) * QK_TQ3_0;
+    if (g_base >= ne0) {
+        return;
+    }
+
+    const int64_t i1  = blockIdx.x;
+    const int64_t i2  = blockIdx.z % ne2;
+    const int64_t i3  = blockIdx.z / ne2;
+    const int64_t i01 = ids ? ids[i1] : i1;
+    const int64_t base_idx = i3 * s03 + i2 * s02 + i01 * s01;
+
+    // Load the 32-value rotation group (zero-padded past ne00), apply sign, then
+    // the in-register Walsh-Hadamard butterfly (new_i = a+b, new_j = a-b).
+    float v[QK_TQ3_0];
+#pragma unroll
+    for (int k = 0; k < QK_TQ3_0; k++) {
+        const int64_t i00 = g_base + k;
+        const float xk = (i00 < ne00) ? x[base_idx + i00] : 0.0f;
+        v[k] = xk * ggml_cuda_tq3_sign(k);
+    }
+#pragma unroll
+    for (int step = 1; step < QK_TQ3_0; step <<= 1) {
+#pragma unroll
+        for (int i = 0; i < QK_TQ3_0; i++) {
+            if ((i & step) == 0) {
+                const int jj = i | step;
+                const float a = v[i], b = v[jj];
+                v[i]  = a + b;
+                v[jj] = a - b;
+            }
+        }
+    }
+    const float rnorm = rsqrtf((float) QK_TQ3_0);
+#pragma unroll
+    for (int k = 0; k < QK_TQ3_0; k++) {
+        v[k] *= rnorm;
+    }
+
+    const int64_t blocks_per_col = (ne0 + QK_K - 1) / QK_K;
+    static constexpr int test_offsets[5] = { 0, -1, 1, -2, 2 };
+
+    // Quantize the two 16-value NVFP4 sub-blocks. Both share one block_fp4_mmq
+    // (QK_TQ3_0 divides QK_K, so a 32-group never straddles a 256-superblock).
+#pragma unroll
+    for (int sb = 0; sb < 2; sb++) {
+        const int64_t i0_base = g_base + sb * QK_NVFP4_SUB;
+        const int64_t k_block = i0_base / QK_K;
+        if (k_block >= blocks_per_col) {
+            continue;
+        }
+        const int64_t ib = blockIdx.z * ((int64_t) blocks_per_col * ne1) + k_block * ne1 + blockIdx.x;
+        block_fp4_mmq * yb = (block_fp4_mmq *) vy + ib;
+        const int sub = (int) ((i0_base % QK_K) / QK_NVFP4_SUB);
+
+        const float * vals_raw = v + sb * QK_NVFP4_SUB;
+        float amax_raw = 0.0f;
+#pragma unroll
+        for (int k = 0; k < QK_NVFP4_SUB; k++) {
+            amax_raw = fmaxf(amax_raw, fabsf(vals_raw[k]));
+        }
+        const int first_fp8_code = (int) ggml_cuda_fp32_to_ue4m3(amax_raw / 6.0f);
+        float best_err = FLT_MAX;
+        uint8_t fp8_code = 0;
+        float subblock_scale = 0.0f;
+#pragma unroll
+        for (int i = 0; i < 5; i++) {
+            const int test_code = first_fp8_code + test_offsets[i];
+            if (test_code < 0 || test_code > 0x7e) {
+                continue;
+            }
+            const float test_scale = ggml_cuda_ue4m3_to_fp32((uint8_t) test_code);
+            const float test_inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
+            float cur_err = 0.0f;
+#pragma unroll
+            for (int k = 0; k < QK_NVFP4_SUB; ++k) {
+                const float vv = vals_raw[k];
+                const uint8_t q = ggml_cuda_float_to_fp4_e2m1(vv, test_inv_scale);
+                const float err_diff = fabsf(vv) - fabsf(kvalues_mxfp4[q & 0x7]) * test_scale;
+                cur_err = fmaf(err_diff, err_diff, cur_err);
+            }
+            if (cur_err < best_err) {
+                best_err = cur_err;
+                fp8_code = (uint8_t) test_code;
+                subblock_scale = test_scale;
+            }
+        }
+        const float inv_scale = subblock_scale > 0.0f ? 0.5f / subblock_scale : 0.0f;
+        uint32_t q0 = 0, q1 = 0;
+#pragma unroll
+        for (int k = 0; k < QK_NVFP4_SUB / 4; ++k) {
+            q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals_raw[k +  0], inv_scale) << (8 * k);
+            q0 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals_raw[k +  8], inv_scale) << (8 * k + 4);
+            q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals_raw[k +  4], inv_scale) << (8 * k);
+            q1 |= (uint32_t) ggml_cuda_float_to_fp4_e2m1(vals_raw[k + 12], inv_scale) << (8 * k + 4);
+        }
+        uint32_t * yqs = reinterpret_cast<uint32_t *>(yb->qs);
+        yqs[2 * sub + 0] = q0;
+        yqs[2 * sub + 1] = q1;
+        reinterpret_cast<uint8_t *>(yb->d4)[sub] = fp8_code;
+    }
+#else
+    NO_DEVICE_CODE;
+#endif // defined(BLACKWELL_MMA_AVAILABLE)
+}
+
 static __global__ void quantize_tq3_4s_to_nvfp4(
         const block_tq3_4s * __restrict__ x, block_nvfp4 * __restrict__ y,
         const int64_t blocks_per_row, const int64_t nv_blocks_per_row,
@@ -516,18 +631,28 @@ void quantize_mmq_q8_1_cuda(
 void quantize_mmq_fp4_cuda(
         const float * x, const int32_t * ids, void * vy, const ggml_type type_src0,
         const int64_t ne00, const int64_t s01, const int64_t s02, const int64_t s03,
-        const int64_t ne0, const int64_t ne1, const int64_t ne2, const int64_t ne3, cudaStream_t stream) {
+        const int64_t ne0, const int64_t ne1, const int64_t ne2, const int64_t ne3, cudaStream_t stream,
+        bool rotate) {
     GGML_ASSERT(type_src0 == GGML_TYPE_MXFP4 || type_src0 == GGML_TYPE_NVFP4);
     GGML_ASSERT(ne0 > 0);
+    GGML_ASSERT(!rotate || type_src0 == GGML_TYPE_NVFP4); // fused TQ3 rotate is NVFP4-only
 
     if (type_src0 == GGML_TYPE_NVFP4) {
         GGML_ASSERT(ne00 % QK_NVFP4 == 0);
         constexpr int nvfp4_block_size = 128;
-        const int64_t block_num_y = (ne0 + QK_NVFP4_SUB * nvfp4_block_size - 1) / (QK_NVFP4_SUB * nvfp4_block_size);
         const dim3 block_size(nvfp4_block_size, 1, 1);
-        const dim3 num_blocks(ne1, block_num_y, ne2 * ne3);
-        quantize_mmq_nvfp4<<<num_blocks, block_size, 0, stream>>>(
-            x, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
+        if (rotate) {
+            // fused rotate+quantize: one thread per 32-value rotation group
+            const int64_t block_num_y = (ne0 + QK_TQ3_0 * nvfp4_block_size - 1) / (QK_TQ3_0 * nvfp4_block_size);
+            const dim3 num_blocks(ne1, block_num_y, ne2 * ne3);
+            quantize_mmq_nvfp4_rot<<<num_blocks, block_size, 0, stream>>>(
+                x, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
+        } else {
+            const int64_t block_num_y = (ne0 + QK_NVFP4_SUB * nvfp4_block_size - 1) / (QK_NVFP4_SUB * nvfp4_block_size);
+            const dim3 num_blocks(ne1, block_num_y, ne2 * ne3);
+            quantize_mmq_nvfp4<<<num_blocks, block_size, 0, stream>>>(
+                x, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
+        }
     } else {
         GGML_ASSERT(ne0 % (2 * QK_MXFP4) == 0);
 

--- a/ggml/src/ggml-cuda/quantize.cuh
+++ b/ggml/src/ggml-cuda/quantize.cuh
@@ -38,6 +38,7 @@ void quantize_mmq_fp4_cuda(const float *   x,
                              int64_t         ne1,
                              int64_t         ne2,
                              int64_t         ne3,
-                             cudaStream_t    stream);
+                             cudaStream_t    stream,
+                             bool            rotate = false);
 
 void quantize_tq3_4s_to_nvfp4_cuda(const void * x, void * y, int64_t ne00, int64_t nrows, cudaStream_t stream);

--- a/ggml/src/ggml-cuda/tq3-native.cu
+++ b/ggml/src/ggml-cuda/tq3-native.cu
@@ -15,18 +15,21 @@ __global__ void ggml_cuda_native_tq3_dot_kernel(
     out[blk] = vec_dot_tq3_0_q8_0_native_block(in + blk, act + blk);
 }
 
-static __global__ void tq3_rotate_act_kernel(float * __restrict__ x, int64_t n) {
+static __global__ void tq3_rotate_act_kernel(const float * __restrict__ src, float * __restrict__ dst, int64_t n) {
     const int64_t base = (int64_t)blockIdx.x * QK_TQ3_0;
     if (base >= n) return;
     const int lane = threadIdx.x;
-    float val = x[base + lane] * ggml_cuda_tq3_sign(lane);
+    float val = src[base + lane] * ggml_cuda_tq3_sign(lane);
     for (int step = 1; step < QK_TQ3_0; step <<= 1) {
         const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
         val = (lane & step) ? (other - val) : (other + val);
     }
-    x[base + lane] = val / sqrtf((float)QK_TQ3_0);
+    dst[base + lane] = val / sqrtf((float)QK_TQ3_0);
 }
 
-void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream) {
-    tq3_rotate_act_kernel<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(x, n);
+// Out-of-place: reads src, writes dst (src and dst may alias for in-place use).
+// Callers previously did cudaMemcpy(dst, src) + in-place rotate; folding the copy
+// into the kernel halves the activation-rotation memory traffic.
+void ggml_cuda_tq3_rotate_act(const float * src, float * dst, int64_t n, cudaStream_t stream) {
+    tq3_rotate_act_kernel<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(src, dst, n);
 }

--- a/ggml/src/ggml-cuda/tq3-native.cuh
+++ b/ggml/src/ggml-cuda/tq3-native.cuh
@@ -100,5 +100,6 @@ __global__ void ggml_cuda_native_tq3_dot_kernel(
         float * __restrict__ out,
         int nblocks);
 
-// Rotate activations in-place (declaration - implementation in tq3-native.cu)
-void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream);
+// Rotate activations out-of-place: dst = rotate(src). Folds the previous
+// cudaMemcpy+in-place-rotate into one pass. src and dst may be equal.
+void ggml_cuda_tq3_rotate_act(const float * src, float * dst, int64_t n, cudaStream_t stream);


### PR DESCRIPTION
Builds on #55 (out-of-place rotate). Fuses the TQ3_4S Walsh-Hadamard activation rotation **into** the NVFP4 activation quantizer (`quantize_mmq_nvfp4_rot`): each thread owns one 32-value rotation group (2 NVFP4 sub-blocks), signs + rotates + normalizes in-register, then quantizes — eliminating the separate `tq3_rotate_act` kernel launch and the `src1_rot` round-trip on the FP4 path. Q8 path keeps the out-of-place rotate.

## Results (GB10 sm_121a, Qwen3.6-27B-MTP-TQ3_4S, pp2048, idle GPU)

| Config | baseline | +#55 (memcpy) | **+fusion** |
|---|---:|---:|---:|
| FP4 cache-on | 920 | 1002 | **1090** |
| FP4 Option E (0 GiB) | 681 | 729 | **775** |

**FP4 cache-on now beats a same-model RTX 3090 (1082 t/s dp4a)** at pp2048, and ties it at pp16384 (1010). +18.5% cache-on / +14% Option E over baseline.

## Motivation

nsys showed the FP4 MMA was only ~42% of GPU time, with ~22% in shared TQ3/FP4 activation overhead (`tq3_rotate_act` 9.6% + `quantize_mmq_nvfp4` 8.3% + copy). This folds the rotate into the quantize pass.

## Correctness

`test-backend-ops test -o MUL_MAT -p tq3_4s` passes 2/2 (incl. non-512-K k=2880). The WHT is exact; assumes ne00 (n_embd) is a multiple of QK_TQ3_0 (same as the original rotate kernel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)