### PR TITLE
cuda: trim NVFP4 activation scale search to one ue4m3 candidate (+5% GB10 prefill)

### DIFF
--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -74,6 +74,55 @@ __device__ __forceinline__ uint8_t compute_e8m0_scale(float amax) {
     return static_cast<uint8_t>(biased);
 }
 
+// Number of ue4m3 scale candidates tested per NVFP4 sub-block when quantizing
+// activations: 1 = use ue4m3(amax/6) directly, 3 = also test the {-1,+1}
+// neighboring codes, 5 = also test {-2,+2}. More candidates reduce activation
+// quantization error at the cost of extra ALU per thread; on bandwidth-lean
+// parts (GB10) the search dominates the quantizer's runtime.
+#ifndef GGML_CUDA_NVFP4_ACT_CANDIDATES
+#define GGML_CUDA_NVFP4_ACT_CANDIDATES 1
+#endif
+
+// Pick the ue4m3 sub-block scale for NVFP4 activation quantization.
+static __device__ __forceinline__ void ggml_cuda_nvfp4_act_scale(
+        const float * vals, const float amax, uint8_t & fp8_code, float & subblock_scale) {
+    const int first_fp8_code = (int) ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
+#if GGML_CUDA_NVFP4_ACT_CANDIDATES <= 1
+    GGML_UNUSED(vals);
+    fp8_code       = (uint8_t) min(first_fp8_code, 0x7e);
+    subblock_scale = ggml_cuda_ue4m3_to_fp32(fp8_code);
+#else
+    static constexpr int test_offsets[5] = { 0, -1, 1, -2, 2 };
+
+    float best_err = FLT_MAX;
+    fp8_code       = 0;
+    subblock_scale = 0.0f;
+
+#pragma unroll // Check neighboring codes to find the one with the lowest NVFP4 activation loss.
+    for (int i = 0; i < GGML_CUDA_NVFP4_ACT_CANDIDATES; i++) {
+        const int test_code = first_fp8_code + test_offsets[i];
+        if (test_code < 0 || test_code > 0x7e) {
+            continue;
+        }
+        const float test_scale = ggml_cuda_ue4m3_to_fp32((uint8_t) test_code);
+        const float test_inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
+        float cur_err = 0.0f;
+#pragma unroll
+        for (int k = 0; k < QK_NVFP4_SUB; ++k) {
+            const float v = vals[k];
+            const uint8_t q = ggml_cuda_float_to_fp4_e2m1(v, test_inv_scale);
+            const float err_diff = fabsf(v) - fabsf(kvalues_mxfp4[q & 0x7]) * test_scale;
+            cur_err = fmaf(err_diff, err_diff, cur_err);
+        }
+
+        if (cur_err < best_err) {
+            best_err       = cur_err;
+            fp8_code       = (uint8_t) test_code;
+            subblock_scale = test_scale;
+        }
+    }
+#endif // GGML_CUDA_NVFP4_ACT_CANDIDATES <= 1
+}
 
 static __global__ void quantize_mmq_nvfp4(
         const float * __restrict__ x, const int32_t * __restrict__ ids, void * __restrict__ vy,
@@ -117,37 +166,9 @@ static __global__ void quantize_mmq_nvfp4(
         }
     }
 
-    static constexpr int test_offsets[5] = { 0, -1, 1, -2, 2};
-    const int first_fp8_code = (int) ggml_cuda_fp32_to_ue4m3(amax_raw / 6.0f);
-
-    float best_err = FLT_MAX;
     uint8_t fp8_code = 0;
     float subblock_scale = 0.0f;
-
-#pragma unroll // Check +/- 2 to find best code to reduce NVFP4 activation loss. Negligible overhead on Blackwell.
-    for (int i = 0; i < 5; i++) {
-        const int test_code = first_fp8_code + test_offsets[i];
-        if (test_code < 0 || test_code > 0x7e) {
-            continue;
-        }
-        const uint8_t code = (uint8_t) test_code;
-        const float test_scale = ggml_cuda_ue4m3_to_fp32(code);
-        const float test_inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
-        float cur_err = 0.0f;
-#pragma unroll
-        for (int k = 0; k < QK_NVFP4_SUB; ++k) {
-            const float v = vals_raw[k];
-            const uint8_t q = ggml_cuda_float_to_fp4_e2m1(v, test_inv_scale);
-            const float err_diff = fabsf(v) - fabsf(kvalues_mxfp4[q & 0x7]) * test_scale;
-            cur_err = fmaf(err_diff, err_diff, cur_err);
-        }
-
-        if (cur_err < best_err) {
-            best_err = cur_err;
-            fp8_code = test_code;
-            subblock_scale = test_scale;
-        }
-    }
+    ggml_cuda_nvfp4_act_scale(vals_raw, amax_raw, fp8_code, subblock_scale);
 
     const float inv_scale = subblock_scale > 0.0f ? 0.5f / subblock_scale : 0.0f;
     uint32_t q0 = 0;
@@ -219,7 +240,6 @@ static __global__ void quantize_mmq_nvfp4_rot(
     }
 
     const int64_t blocks_per_col = (ne0 + QK_K - 1) / QK_K;
-    static constexpr int test_offsets[5] = { 0, -1, 1, -2, 2 };
 
     // Quantize the two 16-value NVFP4 sub-blocks. Both share one block_fp4_mmq
     // (QK_TQ3_0 divides QK_K, so a 32-group never straddles a 256-superblock).
@@ -240,32 +260,9 @@ static __global__ void quantize_mmq_nvfp4_rot(
         for (int k = 0; k < QK_NVFP4_SUB; k++) {
             amax_raw = fmaxf(amax_raw, fabsf(vals_raw[k]));
         }
-        const int first_fp8_code = (int) ggml_cuda_fp32_to_ue4m3(amax_raw / 6.0f);
-        float best_err = FLT_MAX;
         uint8_t fp8_code = 0;
         float subblock_scale = 0.0f;
-#pragma unroll
-        for (int i = 0; i < 5; i++) {
-            const int test_code = first_fp8_code + test_offsets[i];
-            if (test_code < 0 || test_code > 0x7e) {
-                continue;
-            }
-            const float test_scale = ggml_cuda_ue4m3_to_fp32((uint8_t) test_code);
-            const float test_inv_scale = test_scale > 0.0f ? 0.5f / test_scale : 0.0f;
-            float cur_err = 0.0f;
-#pragma unroll
-            for (int k = 0; k < QK_NVFP4_SUB; ++k) {
-                const float vv = vals_raw[k];
-                const uint8_t q = ggml_cuda_float_to_fp4_e2m1(vv, test_inv_scale);
-                const float err_diff = fabsf(vv) - fabsf(kvalues_mxfp4[q & 0x7]) * test_scale;
-                cur_err = fmaf(err_diff, err_diff, cur_err);
-            }
-            if (cur_err < best_err) {
-                best_err = cur_err;
-                fp8_code = (uint8_t) test_code;
-                subblock_scale = test_scale;
-            }
-        }
+        ggml_cuda_nvfp4_act_scale(vals_raw, amax_raw, fp8_code, subblock_scale);
         const float inv_scale = subblock_scale > 0.0f ? 0.5f / subblock_scale : 0.0f;
         uint32_t q0 = 0, q1 = 0;
 #pragma unroll


### PR DESCRIPTION
## What

Stacked on #56. The NVFP4 activation quantizers (`quantize_mmq_nvfp4` and the fused `quantize_mmq_nvfp4_rot`) tested **5 ue4m3 scale candidates** per sub-block. This PR uses `ue4m3(amax/6)` directly and factors the scale pick into a shared helper; the candidate count remains available at compile time via `GGML_CUDA_NVFP4_ACT_CANDIDATES` (1/3/5, default 1).

## Why

nsys on GB10 (Qwen3.6-27B-MTP-TQ3_4S, pp2048, FP4 cache-on) showed the fused rot kernel **compute/latency-bound, not bandwidth-bound**:

| shape | launches | avg | eff. BW | headroom vs 273 GB/s floor |
|---|---|---|---|---|
| ne0=5120 (attn/gate/up) | 3328 | 100.7 µs | ~119 GB/s (44%) | 2.3× |
| ne0≈17408 (ffn_down) | 512 | 276.8 µs | ~147 GB/s (54%) | 1.9× |

The search costs 2 sub-blocks × 5 cands × 16 `float_to_fp4_e2m1` = **160 conversions + 160 FMAs per thread**, and drives register pressure to **80 regs/thread** (~37% occupancy).

## Results (idle GB10, FP4 cache-on, r=3)

| test | before (#56) | after | RTX 3090 |
|---|---|---|---|
| pp2048 | 1090.70 | **1146.28 ± 1.49** (+5.1%) | 1082 |
| pp16384 | 1010.45 | **1060.09 ± 0.74** (+4.9%) | 1010 |

Kernel: ne0=5120 shape 100.7 → **62.6 µs** (~191 GB/s, 70% of peak), **48 regs/thread**. (The ne0=17408 shape is unchanged at ~275 µs — it was not ALU-bound; separate follow-up.)

## Quality

The FP4 activation path is `BLACKWELL_MMA_AVAILABLE`-only, so the gate ran **on GB10**, wikitext-2 test, 20 chunks, against the **FP4-off** run of the same model as reference:

| variant | PPL | mean KLD vs FP4-off | same top-p |
|---|---|---|---|
| FP4-off (reference) | 7.343 | — | — |
| 5-cand (before) | 8.141 | 0.0839 ± 0.0032 | 89.3% |
| 3-cand | 8.120 | 0.0805 ± 0.0032 | 88.9% |
| 1-cand (this PR) | 8.130 | 0.0857 ± 0.0051 | 89.1% |

All three are within each other's error bars: the search operated **below the FP4 activation quantization noise floor** and bought no measurable end quality. (Side observation: the FP4 activation path itself costs ~+10.6% PPL vs FP4-off on this model — independent of this PR, documented separately.)

`test-backend-ops -o MUL_MAT -p tq3_4s`: 2/2 (CUDA0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAGdgPvV57yJTCSeYrAqQ
