### PR TITLE
cuda: TQ3_4S Ampere decode +35% (PRMT vec_dot, nwarps, rotate fusion)

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -357,11 +357,9 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
     if (table_id == MMVQ_PARAMETERS_GENERIC) {
         switch (ncols_dst) {
             case 1:
-                if (type == GGML_TYPE_TQ3_4S) {
-                    // TQ3_4S has a heavier vec_dot than simple q4/q8 paths.
-                    // On NVIDIA, 4 warps overpay in shared reduction for bs=1 decode.
-                    return 2;
-                }
+                // TQ3_4S used to run 2 warps here: its old LUT-based vec_dot made 4 warps
+                // overpay in shared reduction. With the PRMT vec_dot the default 4 warps
+                // win (RTX 3090 tg128 43.1 -> 47.4 t/s; 8 warps regresses to 36.9).
                 [[fallthrough]];
             case 2:
             case 3:

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1303,16 +1303,8 @@ void ggml_cuda_mul_mat_vec_q(
 
     const int64_t ne10_padded = GGML_PAD(ne10, MATRIX_ROW_PADDING);
     ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1);
-    if (src0->type == GGML_TYPE_TQ3_4S) {
-        const int64_t n_act = ne13 * ne12 * ne11 * ne10;
-        ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(), n_act);
-        ggml_cuda_tq3_rotate_act(src1_d, src1_rot.get(), n_act, stream);
-
-        const int64_t s11 = src1->nb[1] / ts_src1;
-        const int64_t s12 = src1->nb[2] / ts_src1;
-        const int64_t s13 = src1->nb[3] / ts_src1;
-        quantize_row_q8_1_cuda(src1_rot.get(), nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded, ne11, ne12, ne13, stream);
-    } else {
+    {
+        // TQ3_4S activation rotation is fused into quantize_row_q8_1_cuda (keyed on type_src0).
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
         const int64_t s13 = src1->nb[3] / ts_src1;
@@ -1379,12 +1371,9 @@ void ggml_cuda_op_mul_mat_vec_q(
     const int64_t nrows_dst = id == ctx.device ? ne0 : row_diff;
 
     if (src0->type == GGML_TYPE_TQ3_4S) {
-        const int64_t n_act = src1_ncols * ne10;
-        ggml_cuda_pool_alloc<float> src1_rot(ctx.pool(id), n_act);
-        ggml_cuda_tq3_rotate_act(src1_ddf_i, src1_rot.get(), n_act, stream);
-
+        // Rotation is fused into quantize_row_q8_1_cuda (keyed on type_src0).
         ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(id), src1_ncols * src1_padded_row_size * sizeof(block_q8_1)/QK8_1);
-        quantize_row_q8_1_cuda(src1_rot.get(), nullptr, src1_q8_1.get(), src0->type, ne10, ne10, src1_ncols*ne10, src1_ncols*ne10, src1_padded_row_size, src1_ncols, 1, 1, stream);
+        quantize_row_q8_1_cuda(src1_ddf_i, nullptr, src1_q8_1.get(), src0->type, ne10, ne10, src1_ncols*ne10, src1_ncols*ne10, src1_padded_row_size, src1_ncols, 1, 1, stream);
 
         const int stride_row_x = ne00 / ggml_blck_size(src0->type);
         const int stride_col_y = src1_padded_row_size / QK8_1;

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -100,7 +100,9 @@ __device__ __forceinline__ uint8_t compute_e8m0_scale(float amax) {
 #endif
 
 // Pick the ue4m3 sub-block scale for NVFP4 activation quantization.
-static __device__ __forceinline__ void ggml_cuda_nvfp4_act_scale(
+// [[maybe_unused]]: the only callers live in BLACKWELL_MMA_AVAILABLE blocks, so on
+// non-Blackwell device passes (e.g. sm_89 CI) this is unreferenced under -Werror all-warnings.
+[[maybe_unused]] static __device__ __forceinline__ void ggml_cuda_nvfp4_act_scale(
         const float * vals, const float amax, uint8_t & fp8_code, float & subblock_scale) {
     const int first_fp8_code = (int) ggml_cuda_fp32_to_ue4m3(amax / 6.0f);
 #if GGML_CUDA_NVFP4_ACT_CANDIDATES <= 1

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -1,6 +1,8 @@
 #include "quantize.cuh"
+#include "tq3-native.cuh"
 #include <cstdint>
 
+template <bool tq3_rotate>
 __launch_bounds__(CUDA_QUANTIZE_BLOCK_SIZE, 1)
 static __global__ void quantize_q8_1(
         const float * x_ptr, void * vy_ptr,
@@ -32,7 +34,21 @@ static __global__ void quantize_q8_1(
     const int64_t iqs = i_cont % QK8_1; // quant index
 
     ggml_cuda_pdl_sync();
-    const float xi = i0 < ne00 ? x[i03*s03 + i02*s02 + i01*s01 + i00] : 0.0f;
+    float xi = i0 < ne00 ? x[i03*s03 + i02*s02 + i01*s01 + i00] : 0.0f;
+
+    if constexpr (tq3_rotate) {
+        // Fused TQ3 activation rotation: each q8_1 block is exactly one 32-point
+        // Walsh-Hadamard group (ne0 % QK8_1 == 0), so the butterfly runs on the
+        // same warp lanes that reduce the block. Matches ggml_cuda_tq3_rotate_act.
+        float val = xi * ggml_cuda_tq3_sign(iqs);
+#pragma unroll
+        for (int step = 1; step < QK8_1; step <<= 1) {
+            const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
+            val = (iqs & step) ? (other - val) : (other + val);
+        }
+        xi = val / sqrtf((float) QK8_1);
+    }
+
     float amax = fabsf(xi);
     float sum = xi;
 
@@ -591,8 +607,12 @@ void quantize_row_q8_1_cuda(
     const dim3 num_blocks(block_num_x, ne1, ne2*ne3);
     const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
     const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(num_blocks, block_size, 0, stream);
-    ggml_cuda_kernel_launch(quantize_q8_1, launch_params, x, vy, ne00, s01, s02, s03, ne0, ne1, ne2_fastdiv);
-    GGML_UNUSED(type_src0);
+    if (type_src0 == GGML_TYPE_TQ3_4S) {
+        // TQ3_4S activations get the Walsh-Hadamard rotation fused into quantization.
+        ggml_cuda_kernel_launch(quantize_q8_1<true>, launch_params, x, vy, ne00, s01, s02, s03, ne0, ne1, ne2_fastdiv);
+    } else {
+        ggml_cuda_kernel_launch(quantize_q8_1<false>, launch_params, x, vy, ne00, s01, s02, s03, ne0, ne1, ne2_fastdiv);
+    }
 }
 
 void quantize_mmq_q8_1_cuda(

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1453,31 +1453,22 @@ static __device__ __forceinline__ float tq3_4s_ratio4s(const uint8_t byte) {
     return __uint_as_float(bits);
 }
 
+// Int8 centroid levels {-127,-79,-45,-14,14,45,79,127} packed into two registers so a
+// single PRMT (__byte_perm) maps four 3-bit indices to four dp4a-ready int8 weights.
+#define TQ3_4S_LEVELS_LO 0xF2D3B181u // bytes {-127, -79, -45, -14}
+#define TQ3_4S_LEVELS_HI 0x7F4F2D0Eu // bytes {  14,  45,  79, 127}
+
 static __device__ __forceinline__ float tq3_4s_dot_subgroup_q8_1(
-    const block_tq3_4s * __restrict__ bq,
+    const uint32_t packed,
     const block_q8_1 * __restrict__ bq8_1,
     const int subgroup) {
 
-    // Int8 centroid levels matching the float centroids scaled to [-127,127]
-    static constexpr int8_t levels[8] = {-127, -79, -45, -14, 14, 45, 79, 127};
-
-    const uint8_t * qp = bq->qs + subgroup * 3;
-    const uint32_t packed = (uint32_t)qp[0] | ((uint32_t)qp[1] << 8) | ((uint32_t)qp[2] << 16);
-    const float d = tq3_4s_ratio4s(bq->d[subgroup]);
-
-    // Unpack 8 3-bit indices into 8 int8 weight values
-    const int8_t w0 = levels[(packed >>  0) & 7];
-    const int8_t w1 = levels[(packed >>  3) & 7];
-    const int8_t w2 = levels[(packed >>  6) & 7];
-    const int8_t w3 = levels[(packed >>  9) & 7];
-    const int8_t w4 = levels[(packed >> 12) & 7];
-    const int8_t w5 = levels[(packed >> 15) & 7];
-    const int8_t w6 = levels[(packed >> 18) & 7];
-    const int8_t w7 = levels[(packed >> 21) & 7];
-
-    // Pack into two int32 for dp4a
-    const int w_lo = (uint8_t)w0 | ((uint8_t)w1 << 8) | ((uint8_t)w2 << 16) | ((uint8_t)w3 << 24);
-    const int w_hi = (uint8_t)w4 | ((uint8_t)w5 << 8) | ((uint8_t)w6 << 16) | ((uint8_t)w7 << 24);
+    // Spread the eight 3-bit indices of `packed` into two PRMT selector words
+    // (one 4-bit selector nibble per output byte; index bit 3 stays 0 so no sign-fill).
+    const uint32_t sel_lo = (packed         & 7) | ((packed << 1) & 0x70) | ((packed << 2) & 0x700) | ((packed << 3) & 0x7000);
+    const uint32_t sel_hi = ((packed >> 12) & 7) | ((packed >> 11) & 0x70) | ((packed >> 10) & 0x700) | ((packed >> 9) & 0x7000);
+    const int w_lo = __byte_perm(TQ3_4S_LEVELS_LO, TQ3_4S_LEVELS_HI, sel_lo);
+    const int w_hi = __byte_perm(TQ3_4S_LEVELS_LO, TQ3_4S_LEVELS_HI, sel_hi);
 
     // Pack activation q8 values (already int8 in bq8_1->qs)
     const int q8 = subgroup * 8;
@@ -1488,7 +1479,7 @@ static __device__ __forceinline__ float tq3_4s_dot_subgroup_q8_1(
     int sumi = ggml_cuda_dp4a(w_lo, a_lo, 0);
     sumi     = ggml_cuda_dp4a(w_hi, a_hi, sumi);
 
-    return (float)sumi * d;
+    return (float)sumi;
 }
 
 #define VDR_TQ3_4S_Q8_1_MMVQ 8
@@ -1496,16 +1487,27 @@ static __device__ __forceinline__ float vec_dot_tq3_4s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
 
     const block_tq3_4s * bq = (const block_tq3_4s *) vbq + kbx;
-    const int subgroup0 = iqs / 4;
+
+    // One 16-byte load covers the whole block: x = the 4 E3M5 scales, y/z/w = the 12 index bytes.
+    // block_tq3_4s is 16 bytes and rows are whole blocks, so the pointer is always 16-aligned.
+    const uint4 b = *(const uint4 *) bq;
+
+    const int g0 = iqs / 4; // this call covers subgroups g0 and g0+1, with g0 in {0, 2}
+    const bool hi = g0 != 0;
+
+    // Funnel-shift the two 24-bit index groups out of the loaded words.
+    const uint32_t p0 = __funnelshift_r(hi ? b.z : b.y, hi ? b.w : b.z, hi ? 16 :  0) & 0xFFFFFF;
+    const uint32_t p1 = __funnelshift_r(hi ? b.w : b.y, hi ? b.w : b.z, hi ?  8 : 24) & 0xFFFFFF;
+
+    const float d0 = tq3_4s_ratio4s((b.x >> (8*g0    )) & 0xFF);
+    const float d1 = tq3_4s_ratio4s((b.x >> (8*g0 + 8)) & 0xFF);
+
     const float2 ds8 = __half22float2(bq8_1->ds);
     // Hoist the activation-side scale once per block instead of reloading it per subgroup.
     const float scale = (2.1519f / 127.0f) * ds8.x;
-    float sum = 0.0f;
 
-#pragma unroll
-    for (int s = 0; s < VDR_TQ3_4S_Q8_1_MMVQ / 4; ++s) {
-        sum += tq3_4s_dot_subgroup_q8_1(bq, bq8_1, subgroup0 + s);
-    }
+    const float sum = tq3_4s_dot_subgroup_q8_1(p0, bq8_1, g0    ) * d0
+                    + tq3_4s_dot_subgroup_q8_1(p1, bq8_1, g0 + 1) * d1;
 
     return sum * scale;
 }


### PR DESCRIPTION
## Summary

TQ3_4S single-stream decode on Ampere (RTX 3090) was **compute/LSU-bound, not bandwidth-bound** — the opposite of GB10, where the same kernels sit at ~95% of DRAM peak. ncu on the 3090 showed the mat-vec kernels at 87–93% SM throughput while DRAM sat at only 50–57%. This PR reworks the hot path accordingly.

**RTX 3090, Qwen3.6-27B TQ3_4S, tg128: 35.61 → 48.12 t/s (+35%).**

## Changes

1. **PRMT-based `vec_dot_tq3_4s_q8_1`** (`af69b73e0`, 35.61 → 43.08): one `LDG.128` loads the whole 16-byte block instead of 8 narrow byte loads; funnel-shift extracts the two 24-bit index groups; `__byte_perm` maps four 3-bit indices to four dp4a-ready int8 levels per instruction (levels table packed into two constant registers). Bit-exact with the old LUT path.
2. **Drop the TQ3 `nwarps=2` special case** in the generic mmvq table (`d7bd29735`, → 47.40): the override was tuned around the old expensive vec_dot; with the PRMT version the default 4 warps win. 8 warps regresses on both kernels.
3. **Fuse the Walsh–Hadamard activation rotation into `quantize_q8_1`** (`9614dfdfa`, → 48.12): each q8_1 block is exactly one 32-point WHT group, so the butterfly runs on the warp lanes that already reduce the block — eliminating ~430 separate `tq3_rotate_act` launches per token. Also fixes a latent bug where the old pre-rotate path quantized a contiguous rotated temp using the original non-contiguous `src1` strides.

## Validation

- **Bit-exact quality**: wikitext PPL at `ub=1` and `ub=8` matches the pre-change build to every printed digit for both the PRMT vec_dot and the rotate fusion. The nwarps change only alters reduction order (PPL delta ~0.006/chunk, well under the ~0.05 MMQ-vs-MMVQ path spread).
- **BenchLoop partial (3090, MTP spec-decode, per SOP)**: toolcall 96.7 (14/15, only the accepted tc-15 miss), coding 100.0 (12/12), overall 91.5 — all gates pass, quality 98.3.
- **Prefill unaffected**: pp512 = 1106 t/s, MMQ-path PPL identical to `origin/main`.
- **GB10 regression check**: tg128 15.22 → 15.42–15.56 (flat, as expected — bandwidth-bound there); prefill path untouched. FP4 on/off makes no difference to decode (15.56 vs 15.54), confirming it's a prefill-only path.

## Notes

- `test-backend-ops` has no `tq3_4s` MUL_MAT coverage (shapes unsupported), so the PPL digit-match is the real correctness gate. Pre-existing `q1_0` failures are present on `origin/main` and unrelated.
- Report with full ncu/nsys data: `docs/turboquant/active/2026-07-02_3090_tq3_decode_prmt_vecdot.md` (in the ai_workspace repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
