### PR TITLE
metal: add TQ3_4S GPU support

### DIFF
--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -73,6 +73,39 @@ jobs:
           cd build
           ctest -L main -E "test-llama-archs" --verbose --timeout 900
 
+  macos-latest-arm64-no-metal:
+    runs-on: macos-latest
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v6
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: apple-arm64-no-metal
+          evict-old-files: 1d
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+
+      - name: Build
+        id: cmake_build
+        run: |
+          sysctl -a
+          cmake -B build \
+            -DCMAKE_BUILD_RPATH="@loader_path" \
+            -DLLAMA_FATAL_WARNINGS=ON \
+            -DLLAMA_BUILD_BORINGSSL=ON \
+            -DGGML_METAL=OFF \
+            -DGGML_RPC=ON
+          time cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
+
+      - name: Test
+        id: cmake_test
+        run: |
+          cd build
+          ctest -L main -E "test-llama-archs" --verbose --timeout 900
+
   macos-latest-x64:
     runs-on: macos-15-intel
 

--- a/docs/backend/Metal-TQ3.md
+++ b/docs/backend/Metal-TQ3.md
@@ -1,0 +1,83 @@
+# Running TurboQuant `TQ3_4S` on Apple Silicon (Metal)
+
+`TQ3_4S` (ggml type 46) was originally CUDA-only. This documents the Metal GPU
+support and how to run a `TQ3_4S` model on an Apple Silicon Mac.
+
+## Build
+
+```bash
+cmake -S . -B build-metal -DCMAKE_BUILD_TYPE=Release -DGGML_METAL=ON
+cmake --build build-metal --target llama-completion llama-server -j
+```
+
+### Troubleshooting: `unknown type name 'uuid_string_t'`
+
+If the build fails compiling Accelerate/CoreServices users (`ggml-cpu/vec.cpp`,
+`ggml-blas.cpp`) with `error: unknown type name 'uuid_string_t'` in the macOS SDK
+`hfs/hfs_format.h`, a Homebrew package (commonly `util-linux`) has force-linked a
+`uuid/uuid.h` into `/usr/local/include`, which clang searches before the SDK and
+which lacks `uuid_string_t`. Fix by unlinking it:
+
+```bash
+brew unlink util-linux      # keg-only; reversible with: brew link --force util-linux
+# verify it now resolves to the Xcode SDK header:
+echo '#include <uuid/uuid.h>' | clang -E -x c - | grep -m1 uuid/uuid.h
+```
+
+## Run
+
+```bash
+build-metal/bin/llama-completion \
+  -m model-TQ3_4S.gguf \
+  -ngl 99 -c 4096 \
+  -p "your prompt"
+```
+
+Notes:
+- This fork's CLI is `llama-completion` (it rejects `-no-cnv`; use it directly).
+- Some `qwen35`/`qwen36` `TQ3_4S` quants drop the MTP/`nextn` layer while still
+  declaring `nextn_predict_layers > 0`. If loading fails with
+  `missing tensor 'blk.N.attn_norm.weight'`, add:
+  `--override-kv llama.nomtp_trunk_only=bool:true`.
+
+## What is accelerated
+
+| Op | Metal path |
+| --- | --- |
+| `MUL_MAT`, decode (`ne11 == 1`) | coalesced mat-vec (`kernel_mul_mv_tq3_4s_f32`) |
+| `MUL_MAT`, batch (`ne11 > 1`, prefill / spec verify) | `simdgroup_matrix` GEMM (`kernel_mul_mm_tq3_4s_f32`) |
+| `GET_ROWS` | `kernel_get_rows_tq3_4s` |
+
+TQ3_4S dequant applies a per-32-element randomized Hadamard transform (RHT). To
+keep the weight matmul coalesced, the RHT is applied once to the activation in a
+pre-pass (`kernel_tq3_4s_rht_f32`); by RHT orthogonality the weights then need
+only a local codebook lookup. No MoE `_id` kernels yet (dense models only).
+
+Indicative throughput on an M3 Pro (150 GB/s) for a dense 27B `TQ3_4S`:
+decode ~6.4 tok/s, prefill ~32 tok/s (short) up to ~85 tok/s (longer prompts).
+Decode is fundamentally bounded by reading the weights once per token
+(~12.5 GB / 150 GB/s).
+
+## Speculative decoding (draft model)
+
+The GEMM makes batched verification cheap, so draft-model speculation works. The
+draft must share the target's tokenizer (e.g. a small Qwen3.5 model for a Qwen3.5
+target — same 248320 vocab). Tuned example:
+
+```bash
+build-metal/bin/llama-speculative-simple \
+  -m target-TQ3_4S.gguf -ngl 99 \
+  -md draft-Qwen3.5-small.gguf -ngld 99 \
+  --spec-type draft-simple \
+  --spec-draft-n-max 12 --spec-draft-n-min 3 --spec-draft-p-min 0.6 \
+  -fa on -ctk q8_0 -ctv q8_0 \
+  -c 8192 --override-kv llama.nomtp_trunk_only=bool:true \
+  -p "your prompt"
+```
+
+Caveats for hybrid (SSM / gated-delta-net) targets such as `qwen35`: the
+recurrent cache does not support partial sequence removal, so speculation falls
+back to full-state checkpoints. The gain is therefore modest and very sensitive
+to draft acceptance — on an M3 Pro, tuned speculation reaches ~7 tok/s (73%
+acceptance) vs ~6.4 plain. High absolute numbers reported elsewhere (>100 tok/s)
+are high-bandwidth GPUs / Ultra-class Macs, not an M3 Pro.

--- a/ggml/src/ggml-metal/ggml-metal-context.m
+++ b/ggml/src/ggml-metal/ggml-metal-context.m
@@ -706,6 +706,9 @@ void ggml_metal_set_n_cb(ggml_metal_t ctx, int n_cb) {
 
         for (int idx = 0; idx < ggml_metal_op_n_nodes(ctx_op); ++idx) {
             const int res = ggml_metal_op_encode(ctx_op, idx);
+            if (res < 0) {
+                GGML_ABORT("metal op encoding returned invalid fused node count");
+            }
             if (res == 0) {
                 break;
             }

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -160,6 +160,21 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_get_rows(ggml_me
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_tq3_rht(ggml_metal_library_t lib) {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_tq3_4s_rht_f32");
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_set_rows(ggml_metal_library_t lib, ggml_type tidx, ggml_type tdst) {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -909,6 +909,11 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv(ggml_meta
                 nr0 = N_R0_IQ4_XS;
                 smem = 32*sizeof(float);
             } break;
+        case GGML_TYPE_TQ3_4S:
+            {
+                nsg = N_SG_TQ3_4S;
+                nr0 = N_R0_TQ3_4S;
+            } break;
         default:
             {
                 GGML_LOG_ERROR("Asserting on type %d\n", (int) tsrc0);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -112,6 +112,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy      
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_1d           (ggml_metal_library_t lib, const struct ggml_tensor * op, enum ggml_op_pool op_pool);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_2d           (ggml_metal_library_t lib, const struct ggml_tensor * op, enum ggml_op_pool op_pool);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_get_rows          (ggml_metal_library_t lib, enum ggml_type tsrc);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_tq3_rht           (ggml_metal_library_t lib);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_set_rows          (ggml_metal_library_t lib, enum ggml_type tidx, enum ggml_type tdst);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_diag              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_repeat            (ggml_metal_library_t lib, enum ggml_type tsrc);

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1306,7 +1306,6 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                             default:
                                 return false;
                         }
-                    case GGML_TYPE_Q1_0:
                     case GGML_TYPE_Q4_0:
                     case GGML_TYPE_Q4_1:
                     case GGML_TYPE_Q5_0:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1333,6 +1333,10 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                     return false;
                 }
 
+                if (op->src[1]->type != GGML_TYPE_I32 && op->src[1]->type != GGML_TYPE_I64) {
+                    return false;
+                }
+
                 switch (op->type) {
                     case GGML_TYPE_F32:
                     case GGML_TYPE_F16:

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -84,8 +84,8 @@
 #define N_R0_IQ4_XS 2
 #define N_SG_IQ4_XS 2
 
-#define N_R0_TQ3_4S 8
-#define N_SG_TQ3_4S 2
+#define N_R0_TQ3_4S 4
+#define N_SG_TQ3_4S 4
 
 // function constants offsets
 #define FC_FLASH_ATTN_EXT_PAD          100
@@ -933,6 +933,18 @@ typedef struct {
     uint64_t nb2;
     uint64_t nb3;
 } ggml_metal_kargs_get_rows;
+
+// forward randomized Hadamard transform of activations (TQ3_4S mat-mul pre-pass)
+typedef struct {
+    int32_t  nb;    // number of 32-element blocks along K
+    int32_t  ne12;  // src1 dim2 (to unflatten the batch grid index)
+    uint64_t nb11;  // src1 strides (input activation)
+    uint64_t nb12;
+    uint64_t nb13;
+    uint64_t ob11;  // dst strides (contiguous transformed activation)
+    uint64_t ob12;
+    uint64_t ob13;
+} ggml_metal_kargs_tq3_rht;
 
 typedef struct {
     int32_t  nk0;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -84,6 +84,9 @@
 #define N_R0_IQ4_XS 2
 #define N_SG_IQ4_XS 2
 
+#define N_R0_TQ3_4S 8
+#define N_SG_TQ3_4S 2
+
 // function constants offsets
 #define FC_FLASH_ATTN_EXT_PAD          100
 #define FC_FLASH_ATTN_EXT_BLK          200

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1209,7 +1209,7 @@ int ggml_metal_op_set_rows(ggml_metal_op_t ctx, int idx) {
     auto pipeline = ggml_metal_library_get_pipeline_set_rows(lib, op->src[1]->type, op->type);
     if (!pipeline.pipeline) {
         GGML_LOG_ERR("%s: missing set_rows pipeline for dst type %s and idx type %s\n", __func__, ggml_type_name(op->type), ggml_type_name(op->src[1]->type));
-        return 0;
+        return -1;
     }
 
     const int32_t nk0 = ne0/ggml_blck_size(op->type);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1170,9 +1170,17 @@ int ggml_metal_op_get_rows(ggml_metal_op_t ctx, int idx) {
         /*.nb3   =*/ nb3,
     };
 
-    const int nth = std::min(args.ne00t, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+    int nth = std::min(args.ne00t, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
 
-    const int nw0 = (args.ne00t + nth - 1)/nth;
+    int nw0 = (args.ne00t + nth - 1)/nth;
+
+    // TQ3_4S uses a custom kernel that processes one 32-element block per 32-lane
+    // SIMD-group (inverse RHT via simd_shuffle_xor). Dispatch exactly one
+    // SIMD-group per gathered row so each row is handled by a single threadgroup.
+    if (op->src[0]->type == GGML_TYPE_TQ3_4S) {
+        nth = 32;
+        nw0 = 1;
+    }
 
     ggml_metal_encoder_set_pipeline(enc, pipeline);
     ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
@@ -2165,6 +2173,9 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         !ggml_is_transposed(op->src[1]) &&
         // for now the matrix-matrix multiplication kernel only works on A14+/M1+ SoCs
         // AMD GPU and older A-chips will reuse matrix-vector multiplication kernel
+        // TQ3_4S has no mat-mat kernel yet (the block-wide inverse RHT only lives
+        // in the mat-vec kernel), so force it through the mat-vec path below.
+        op->src[0]->type != GGML_TYPE_TQ3_4S &&
         props_dev->has_simdgroup_mm && ne00 >= 64 && ne11 > ne11_mm_min) {
         //GGML_LOG_INFO("matrix: ne00 = %6d, ne01 = %6d, ne02 = %6d, ne11 = %6d, ne12 = %6d\n", ne00, ne01, ne02, ne11, ne12);
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2108,11 +2108,51 @@ static int ggml_metal_op_mul_mat_tq3_4s(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_dispatch_threadgroups(enc, ne10/32, ne11, ne12*ne13, 32, 1, 1);
     }
 
-    // the mat-vec must wait for the transformed activation
+    // the matmul must wait for the transformed activation
     ggml_metal_op_concurrency_reset(ctx);
 
-    // 2) coalesced mat-vec over local-dequant weights, reading the transformed activation
-    {
+    // 2) matmul over local-dequant weights, reading the transformed activation.
+    //    Batch (ne11 > 1: prefill or speculative-decode verification) -> simdgroup
+    //    GEMM, which amortizes the weight reads across the batch. Single column
+    //    (decode) -> the coalesced mat-vec.
+    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
+    const bool use_mm = props_dev->has_simdgroup_mm && ne00 >= 64 && ne11 > 1;
+
+    if (use_mm) {
+        auto pipeline = ggml_metal_library_get_pipeline_mul_mm(lib, op);
+
+        ggml_metal_kargs_mul_mm args = {
+            /*.ne00 =*/ ne00,
+            /*.ne02 =*/ ne02,
+            /*.nb01 =*/ nb01,
+            /*.nb02 =*/ nb02,
+            /*.nb03 =*/ nb03,
+            /*.ne12 =*/ ne12,
+            /*.nb10 =*/ sizeof(float),
+            /*.nb11 =*/ ob11,
+            /*.nb12 =*/ ob12,
+            /*.nb13 =*/ ob13,
+            /*.ne0  =*/ ne0,
+            /*.ne1  =*/ ne1,
+            /*.r2   =*/ r2,
+            /*.r3   =*/ r3,
+        };
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, bid_src0, 1);
+        ggml_metal_encoder_set_buffer  (enc, bid_w1,   2);
+        ggml_metal_encoder_set_buffer  (enc, bid_dst,  3);
+
+        const size_t smem = pipeline.smem;
+        ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
+
+        const int nr0 = pipeline.nr0;
+        const int nr1 = pipeline.nr1;
+        const int nsg = pipeline.nsg;
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, ((ne11 + nr1 - 1)/nr1), ((ne01 + nr0 - 1)/nr0), ne12*ne13, 32, nsg, 1);
+    } else {
         auto pipeline = ggml_metal_library_get_pipeline_mul_mv(lib, op);
 
         const int nr0 = pipeline.nr0;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1208,7 +1208,7 @@ int ggml_metal_op_set_rows(ggml_metal_op_t ctx, int idx) {
 
     auto pipeline = ggml_metal_library_get_pipeline_set_rows(lib, op->src[1]->type, op->type);
     if (!pipeline.pipeline) {
-        GGML_LOG_ERR("%s: missing set_rows pipeline for dst type %s and idx type %s\n", __func__, ggml_type_name(op->type), ggml_type_name(op->src[1]->type));
+        GGML_LOG_ERROR("%s: missing set_rows pipeline for dst type %s and idx type %s\n", __func__, ggml_type_name(op->type), ggml_type_name(op->src[1]->type));
         return -1;
     }
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2040,6 +2040,119 @@ int ggml_metal_op_pool_2d(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
+size_t ggml_metal_op_mul_mat_extra_w1(const ggml_tensor * op) {
+    if (op->op != GGML_OP_MUL_MAT || op->src[0]->type != GGML_TYPE_TQ3_4S) {
+        return 0;
+    }
+
+    // contiguous f32 copy of the RHT-pre-transformed activation
+    const ggml_tensor * src1 = op->src[1];
+    return (size_t) src1->ne[0]*src1->ne[1]*src1->ne[2]*src1->ne[3]*sizeof(float);
+}
+
+// TQ3_4S matmul: pre-transform the activation with the forward RHT, then run the
+// coalesced mat-vec on the local-dequant weights. Kept as a dedicated path so the
+// generic mul_mat code is untouched for every other type.
+static int ggml_metal_op_mul_mat_tq3_4s(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
+    GGML_TENSOR_LOCALS( int32_t, ne1, op->src[1], ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb1, op->src[1], nb);
+    GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
+
+    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+    GGML_ASSERT(ne00 % 32 == 0); // QK_TQ3_0
+
+    const int16_t r2 = ne12/ne02;
+    const int16_t r3 = ne13/ne03;
+
+    const ggml_metal_buffer_id bid_src0 = ggml_metal_get_buffer_id(op->src[0]);
+    const ggml_metal_buffer_id bid_src1 = ggml_metal_get_buffer_id(op->src[1]);
+    const ggml_metal_buffer_id bid_dst  = ggml_metal_get_buffer_id(op);
+
+    // scratch for the transformed activation, carved right after the dst tensor
+    ggml_metal_buffer_id bid_w1 = bid_dst;
+    bid_w1.offs += ggml_nbytes(op);
+
+    // contiguous strides of the transformed-activation buffer
+    const uint64_t ob11 = (uint64_t) ne10*sizeof(float);
+    const uint64_t ob12 = ob11*ne11;
+    const uint64_t ob13 = ob12*ne12;
+
+    // 1) forward RHT of the activation (per 32-element K-block)
+    {
+        ggml_metal_kargs_tq3_rht args = {
+            /*.nb   =*/ ne10/32,
+            /*.ne12 =*/ ne12,
+            /*.nb11 =*/ nb11,
+            /*.nb12 =*/ nb12,
+            /*.nb13 =*/ nb13,
+            /*.ob11 =*/ ob11,
+            /*.ob12 =*/ ob12,
+            /*.ob13 =*/ ob13,
+        };
+
+        auto pipeline = ggml_metal_library_get_pipeline_tq3_rht(lib);
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, bid_src1, 1);
+        ggml_metal_encoder_set_buffer  (enc, bid_w1,   2);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, ne10/32, ne11, ne12*ne13, 32, 1, 1);
+    }
+
+    // the mat-vec must wait for the transformed activation
+    ggml_metal_op_concurrency_reset(ctx);
+
+    // 2) coalesced mat-vec over local-dequant weights, reading the transformed activation
+    {
+        auto pipeline = ggml_metal_library_get_pipeline_mul_mv(lib, op);
+
+        const int nr0 = pipeline.nr0;
+        const int nr1 = pipeline.nr1;
+        const int nsg = pipeline.nsg;
+
+        ggml_metal_kargs_mul_mv args = {
+            /*.ne00 =*/ ne00,
+            /*.ne01 =*/ ne01,
+            /*.ne02 =*/ ne02,
+            /*.nb00 =*/ nb00,
+            /*.nb01 =*/ nb01,
+            /*.nb02 =*/ nb02,
+            /*.nb03 =*/ nb03,
+            /*.ne10 =*/ ne10,
+            /*.ne11 =*/ ne11,
+            /*.ne12 =*/ ne12,
+            /*.nb10 =*/ sizeof(float),
+            /*.nb11 =*/ ob11,
+            /*.nb12 =*/ ob12,
+            /*.nb13 =*/ ob13,
+            /*.ne0  =*/ ne0,
+            /*.ne1  =*/ ne1,
+            /*.nr0  =*/ nr0,
+            /*.r2   =*/ r2,
+            /*.r3   =*/ r3,
+        };
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, bid_src0, 1);
+        ggml_metal_encoder_set_buffer  (enc, bid_w1,   2);
+        ggml_metal_encoder_set_buffer  (enc, bid_dst,  3);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, ((ne01 + nr0*nsg - 1)/(nr0*nsg)), ((ne11 + nr1 - 1)/nr1), ne12*ne13, 32, nsg, 1);
+    }
+
+    return 1;
+}
+
 int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
@@ -2047,6 +2160,10 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     ggml_metal_encoder_t enc = ctx->enc;
 
     const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
+
+    if (op->src[0]->type == GGML_TYPE_TQ3_4S) {
+        return ggml_metal_op_mul_mat_tq3_4s(ctx, idx);
+    }
 
     GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
     GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
@@ -2173,9 +2290,6 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         !ggml_is_transposed(op->src[1]) &&
         // for now the matrix-matrix multiplication kernel only works on A14+/M1+ SoCs
         // AMD GPU and older A-chips will reuse matrix-vector multiplication kernel
-        // TQ3_4S has no mat-mat kernel yet (the block-wide inverse RHT only lives
-        // in the mat-vec kernel), so force it through the mat-vec path below.
-        op->src[0]->type != GGML_TYPE_TQ3_4S &&
         props_dev->has_simdgroup_mm && ne00 >= 64 && ne11 > ne11_mm_min) {
         //GGML_LOG_INFO("matrix: ne00 = %6d, ne01 = %6d, ne02 = %6d, ne11 = %6d, ne12 = %6d\n", ne00, ne01, ne02, ne11, ne12);
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1207,6 +1207,10 @@ int ggml_metal_op_set_rows(ggml_metal_op_t ctx, int idx) {
     GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
 
     auto pipeline = ggml_metal_library_get_pipeline_set_rows(lib, op->src[1]->type, op->type);
+    if (!pipeline.pipeline) {
+        GGML_LOG_ERR("%s: missing set_rows pipeline for dst type %s and idx type %s\n", __func__, ggml_type_name(op->type), ggml_type_name(op->src[1]->type));
+        return 0;
+    }
 
     const int32_t nk0 = ne0/ggml_blck_size(op->type);
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -30,6 +30,9 @@ int ggml_metal_op_encode(ggml_metal_op_t ctx, int idx);
 // available ops:
 //
 
+// RHT-pre-transformed activation scratch for TQ3_4S mat-mul
+size_t ggml_metal_op_mul_mat_extra_w1(const struct ggml_tensor * op);
+
 // tokens per expert
 size_t ggml_metal_op_mul_mat_id_extra_tpe(const struct ggml_tensor * op);
 

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -215,6 +215,10 @@ static size_t ggml_backend_metal_buffer_type_get_alloc_size(ggml_backend_buffer_
 
     // some operations require additional memory for fleeting data:
     switch (tensor->op) {
+        case GGML_OP_MUL_MAT:
+            {
+                res += ggml_metal_op_mul_mat_extra_w1(tensor);
+            } break;
         case GGML_OP_MUL_MAT_ID:
             {
                 res += ggml_metal_op_mul_mat_id_extra_tpe(tensor);

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -9338,15 +9338,44 @@ kernel void kernel_mul_mv_mxfp4_f32(
     kernel_mul_mv_mxfp4_f32_impl<N_R0_MXFP4, constant ggml_metal_kargs_mul_mv &>(args, src0, src1, dst, shmem, tgpig, tiisg, sgitg);
 }
 
+// Pre-pass for TQ3_4S mat-mul: forward randomized Hadamard transform of the
+// activation, per 32-element block along K, written to a contiguous f32 buffer.
+// By RHT orthogonality, dot(W_dequant_row, x) == dot(centroid*scale, RHT_fwd(x)),
+// so after this pass the mat-vec needs only a local codebook lookup on the
+// weights (no per-weight butterfly), which frees the lane mapping to do fully
+// coalesced weight loads. One 32-element block maps to one 32-lane SIMD-group.
+kernel void kernel_tq3_4s_rht_f32(
+        constant ggml_metal_kargs_tq3_rht & args,
+        device const char * src1,
+        device       char * dst,
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiisg[[thread_index_in_simdgroup]]) {
+    const int    ib  = tgpig.x;            // 32-element block along K
+    const int    i11 = tgpig.y;            // activation column
+    const int    b   = tgpig.z;            // flattened batch (i12 + i13*ne12)
+    const int    i12 = b % args.ne12;
+    const int    i13 = b / args.ne12;
+    const ushort j   = tiisg;              // element within the block
+
+    device const float * y = (device const float *) (src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11) + ib*QK_TQ3_0 + j;
+
+    float v = y[0] * TQ3_0_SIGNS_M[j];
+    for (ushort step = 1; step < 32; step <<= 1) {
+        const float o = simd_shuffle_xor(v, step);
+        v = (j & step) ? (o - v) : (o + v);
+    }
+    v *= 1.0f / sqrt(32.0f);
+
+    device float * o = (device float *) (dst + i13*args.ob13 + i12*args.ob12 + i11*args.ob11) + ib*QK_TQ3_0 + j;
+    o[0] = v;
+}
+
 // Matrix-vector product for TQ3_4S weights.
 //
-// Uses the orthogonality of the randomized Hadamard transform (RHT): the
-// dequantized weight is w = SIGN * (1/sqrt(32)) * WHT(centroid*scale), so
-//   dot(w, y) = sum_j centroid_j*scale_j * RHT_forward(y)_j .
-// Therefore the (expensive) butterfly is applied ONCE per K-block to the
-// activation column (shared by all output rows of the SIMD-group), after which
-// each row only does a local codebook lookup + scale. One 32-element K-block
-// maps to the 32-lane SIMD-group; the WHT butterfly uses simd_shuffle_xor.
+// src1 here is the RHT-pre-transformed activation (see kernel_tq3_4s_rht_f32),
+// so the weights only need a local codebook lookup + per-group scale. Each lane
+// owns whole 32-element K-blocks, strided by the SIMD-group width, so the 32
+// lanes read 32 consecutive 16-byte blocks per step -> fully coalesced loads.
 template<int nr0, typename args_t>
 void kernel_mul_mv_tq3_4s_f32_impl(
         args_t args,
@@ -9374,30 +9403,37 @@ void kernel_mul_mv_tq3_4s_f32_impl(
     const uint64_t offset1 =        r1*args.nb11 + (i12        )*args.nb12 + (i13        )*args.nb13;
 
     device const char  * cx = src0 + offset0;
-    device const float * y  = (device const float *) (src1 + offset1);
-
-    const ushort j    = tiisg;      // lane == element index within a K-block
-    const ushort g    = j / 8;
-    const float  sign = TQ3_0_SIGNS_M[j];
-    const float  norm = 1.0f / sqrt(32.0f);
+    device const float * y  = (device const float *) (src1 + offset1); // RHT-pre-transformed activation
 
     float sumf[nr0] = {0.f};
 
-    for (int ib = 0; ib < nb; ++ib) {
-        // forward RHT of the activation block (shared across the nr0 rows)
-        float yf = y[ib*QK_TQ3_0 + j] * sign;
-        for (ushort step = 1; step < 32; step <<= 1) {
-            const float o = simd_shuffle_xor(yf, step);
-            yf = (j & step) ? (o - yf) : (o + yf);
-        }
-        yf *= norm;
+    for (int ib = tiisg; ib < nb; ib += 32) {
+        device const float * ya = y + ib*QK_TQ3_0; // 32 pre-transformed activations
 
         for (short row = 0; row < nr0; ++row) {
             device const uint4 * bp = (device const uint4 *) (cx + row*args.nb01) + ib;
             const uint4 raw = bp[0];
-            const uint8_t idx = tq3_4s_idx_from_block(raw, j);
-            const float c = TQ3_0_CENTROIDS_M[idx] * tq3_4s_scale_from_block(raw, g);
-            sumf[row] += c * yf;
+
+            const float s0 = tq3_4s_decode_scale((raw.x      ) & 0xffu);
+            const float s1 = tq3_4s_decode_scale((raw.x >>  8) & 0xffu);
+            const float s2 = tq3_4s_decode_scale((raw.x >> 16) & 0xffu);
+            const float s3 = tq3_4s_decode_scale((raw.x >> 24) & 0xffu);
+
+            // 24-bit packed indices per group of 8 (qs = raw.yzw, little-endian)
+            const uint p0 =  (raw.y                       ) & 0xFFFFFFu;
+            const uint p1 = ((raw.y >> 24) | (raw.z <<  8)) & 0xFFFFFFu;
+            const uint p2 = ((raw.z >> 16) | (raw.w << 16)) & 0xFFFFFFu;
+            const uint p3 =  (raw.w >>  8                 ) & 0xFFFFFFu;
+
+            float a0 = 0.f, a1 = 0.f, a2 = 0.f, a3 = 0.f;
+            for (short r = 0; r < 8; ++r) {
+                a0 += TQ3_0_CENTROIDS_M[(p0 >> (3*r)) & 7] * ya[     r];
+                a1 += TQ3_0_CENTROIDS_M[(p1 >> (3*r)) & 7] * ya[ 8 + r];
+                a2 += TQ3_0_CENTROIDS_M[(p2 >> (3*r)) & 7] * ya[16 + r];
+                a3 += TQ3_0_CENTROIDS_M[(p3 >> (3*r)) & 7] * ya[24 + r];
+            }
+
+            sumf[row] += s0*a0 + s1*a1 + s2*a2 + s3*a3;
         }
     }
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -140,6 +140,24 @@ static inline float tq3_4s_scale_from_block(uint4 raw, ushort g) {
     return tq3_4s_decode_scale((raw.x >> (8u * (uint) g)) & 0xffu);
 }
 
+// LOCAL dequant (codebook lookup * per-group scale, NO inverse RHT) for the GEMM
+// path. Valid only when the activation has been RHT-pre-transformed
+// (kernel_tq3_4s_rht_f32): dot(W_dequant, x) == dot(centroid*scale, RHT_fwd(x)).
+// Element ordering matches dequantize_q8_0 (contiguous: element 16*il + i).
+template <typename type4x4>
+void dequantize_tq3_4s(device const block_tq3_4s * xb, short il, thread type4x4 & reg) {
+    const uint4 raw = ((device const uint4 *) xb)[0];
+
+    float4x4 reg_f;
+    for (short i = 0; i < 16; ++i) {
+        const ushort e   = 16*il + i;
+        const ushort g   = e / 8;
+        const uint8_t idx = tq3_4s_idx_from_block(raw, e);
+        reg_f[i/4][i%4] = TQ3_0_CENTROIDS_M[idx] * tq3_4s_scale_from_block(raw, g);
+    }
+    reg = (type4x4) reg_f;
+}
+
 // NOTE: this is not dequantizing - we are simply fitting the template
 template <typename type4x4>
 void dequantize_f32(device const float4x4 * src, short il, thread type4x4 & reg) {
@@ -10455,6 +10473,7 @@ template [[host_name("kernel_mul_mm_q4_1_f32")]]    kernel mul_mm_t kernel_mul_m
 template [[host_name("kernel_mul_mm_q5_0_f32")]]    kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_0,    2,     dequantize_q5_0,    float,  float4x4,  float, float2x4>;
 template [[host_name("kernel_mul_mm_q5_1_f32")]]    kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_1,    2,     dequantize_q5_1,    float,  float4x4,  float, float2x4>;
 template [[host_name("kernel_mul_mm_q8_0_f32")]]    kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q8_0,    2,     dequantize_q8_0,    float,  float4x4,  float, float2x4>;
+template [[host_name("kernel_mul_mm_tq3_4s_f32")]]  kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_tq3_4s,  2,     dequantize_tq3_4s,  float,  float4x4,  float, float2x4>;
 template [[host_name("kernel_mul_mm_mxfp4_f32")]]   kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_mxfp4,   2,     dequantize_mxfp4,   float,  float4x4,  float, float2x4>;
 template [[host_name("kernel_mul_mm_q2_K_f32")]]    kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q2_K,    QK_NL, dequantize_q2_K,    float,  float4x4,  float, float2x4>;
 template [[host_name("kernel_mul_mm_q3_K_f32")]]    kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q3_K,    QK_NL, dequantize_q3_K,    float,  float4x4,  float, float2x4>;

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -119,18 +119,25 @@ static inline float tq3_4s_decode_scale(uint8_t sb) {
     return as_type<float>(bits);
 }
 
-// Extract the r-th (0..7) 3-bit index from a 3-byte group qp[0..2].
-static inline uint8_t tq3_4s_unpack3(device const uint8_t * qp, ushort r) {
-    switch (r) {
-        case 0:  return  qp[0]        & 7;
-        case 1:  return (qp[0] >> 3)  & 7;
-        case 2:  return ((qp[0] >> 6) | (qp[1] << 2)) & 7;
-        case 3:  return (qp[1] >> 1)  & 7;
-        case 4:  return (qp[1] >> 4)  & 7;
-        case 5:  return ((qp[1] >> 7) | (qp[2] << 1)) & 7;
-        case 6:  return (qp[2] >> 2)  & 7;
-        default: return (qp[2] >> 5)  & 7;
+// Fast path: a whole 16-byte block loaded as one aligned uint4 (avoids slow
+// byte-addressed loads). Layout: raw.x = d[0..3] (E3M5 scales), raw.yzw = qs[12].
+// Because each group packs 8 indices in exactly 3 bytes (24 bits), the index of
+// element j sits at bit 3*j of the 96-bit little-endian qs stream.
+static inline uint8_t tq3_4s_idx_from_block(uint4 raw, ushort j) {
+    const uint bitpos = 3u * (uint) j;
+    const uint w      = bitpos >> 5;   // qs word: 0,1,2
+    const uint off    = bitpos & 31u;
+    const uint cur = (w == 0u) ? raw.y : ((w == 1u) ? raw.z : raw.w);
+    uint v = cur >> off;
+    if (off > 29u && w < 2u) {         // 3-bit field straddles two words
+        const uint nxt = (w == 0u) ? raw.z : raw.w;
+        v |= nxt << (32u - off);
     }
+    return (uint8_t) (v & 7u);
+}
+
+static inline float tq3_4s_scale_from_block(uint4 raw, ushort g) {
+    return tq3_4s_decode_scale((raw.x >> (8u * (uint) g)) & 0xffu);
 }
 
 // NOTE: this is not dequantizing - we are simply fitting the template
@@ -9371,7 +9378,6 @@ void kernel_mul_mv_tq3_4s_f32_impl(
 
     const ushort j    = tiisg;      // lane == element index within a K-block
     const ushort g    = j / 8;
-    const ushort r3b  = j % 8;
     const float  sign = TQ3_0_SIGNS_M[j];
     const float  norm = 1.0f / sqrt(32.0f);
 
@@ -9387,12 +9393,10 @@ void kernel_mul_mv_tq3_4s_f32_impl(
         yf *= norm;
 
         for (short row = 0; row < nr0; ++row) {
-            device const block_tq3_4s * b = (device const block_tq3_4s *) (cx + row*args.nb01) + ib;
-            device const uint8_t * qp = b->qs + g*3;
-            // 8 indices of a group are (packed >> (3*r)) & 7, r = 0..7
-            const uint packed = (uint) qp[0] | ((uint) qp[1] << 8) | ((uint) qp[2] << 16);
-            const uint8_t idx = (packed >> (3*r3b)) & 7;
-            const float c = TQ3_0_CENTROIDS_M[idx] * tq3_4s_decode_scale(b->d[g]);
+            device const uint4 * bp = (device const uint4 *) (cx + row*args.nb01) + ib;
+            const uint4 raw = bp[0];
+            const uint8_t idx = tq3_4s_idx_from_block(raw, j);
+            const float c = TQ3_0_CENTROIDS_M[idx] * tq3_4s_scale_from_block(raw, g);
             sumf[row] += c * yf;
         }
     }
@@ -9446,15 +9450,14 @@ kernel void kernel_get_rows_tq3_4s(
     const int    nb   = args.ne00 / QK_TQ3_0; // 32-element blocks in the row
     const ushort j    = tiisg;                // lane == element index within block
     const ushort g    = j / 8;
-    const ushort r3b  = j % 8;
     const float  sign = TQ3_0_SIGNS_M[j];
     const float  norm = 1.0f / sqrt(32.0f);
 
     for (int ib = 0; ib < nb; ++ib) {
-        device const block_tq3_4s * b = psrc + ib;
+        const uint4 raw = ((device const uint4 *) psrc)[ib];
 
-        const uint8_t idx = tq3_4s_unpack3(b->qs + g*3, r3b);
-        float val = TQ3_0_CENTROIDS_M[idx] * tq3_4s_decode_scale(b->d[g]);
+        const uint8_t idx = tq3_4s_idx_from_block(raw, j);
+        float val = TQ3_0_CENTROIDS_M[idx] * tq3_4s_scale_from_block(raw, g);
 
         // inverse randomized Hadamard transform across the 32 lanes
         for (ushort step = 1; step < 32; step <<= 1) {

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -85,6 +85,54 @@ static inline float sum(float4 x) {
     return x[0] + x[1] + x[2] + x[3];
 }
 
+// ---------------------------------------------------------------------------
+// TurboQuant TQ3_4S (ggml type 46) helpers
+// block_tq3_4s (see ggml-common.h): uint8_t d[4] (E3M5 scales / group of 8)
+//                                   uint8_t qs[12] (32 x 3-bit packed indices)
+// Dequant = 8-level codebook lookup * per-group scale, then inverse randomized
+// Hadamard transform (sign flip + Walsh-Hadamard + 1/sqrt(32) norm) over the
+// 32-element block. Mirrors the CPU reference (ggml-quants.c) and the CUDA
+// kernel (ggml-cuda/convert.cu). The block size QK_TQ3_0 == 32 maps to one
+// 32-lane SIMD-group so the WHT butterfly is done with simd_shuffle_xor.
+// ---------------------------------------------------------------------------
+constant float TQ3_0_CENTROIDS_M[8] = {
+    -1.996684f, -1.291398f, -0.740341f, -0.247508f,
+     0.230106f,  0.725222f,  1.277503f,  1.988943f
+};
+
+constant float TQ3_0_SIGNS_M[32] = {
+    +1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+    -1.0f, +1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+};
+
+// E3M5 mini-float scale decode: scale = 2^((sb>>5)-9) * (1 + (sb&31)/32).
+// Implemented via direct IEEE-754 bit construction (matches CUDA MMQ path):
+//   exponent field = (sb>>5) + 118  (bias 127 => actual exp (sb>>5)-9)
+//   top 5 mantissa bits = (sb&31)
+static inline float tq3_4s_decode_scale(uint8_t sb) {
+    if (sb == 0) {
+        return 0.0f;
+    }
+    const uint bits = (((uint)(sb >> 5) + 118u) << 23) | ((uint)(sb & 31u) << 18);
+    return as_type<float>(bits);
+}
+
+// Extract the r-th (0..7) 3-bit index from a 3-byte group qp[0..2].
+static inline uint8_t tq3_4s_unpack3(device const uint8_t * qp, ushort r) {
+    switch (r) {
+        case 0:  return  qp[0]        & 7;
+        case 1:  return (qp[0] >> 3)  & 7;
+        case 2:  return ((qp[0] >> 6) | (qp[1] << 2)) & 7;
+        case 3:  return (qp[1] >> 1)  & 7;
+        case 4:  return (qp[1] >> 4)  & 7;
+        case 5:  return ((qp[1] >> 7) | (qp[2] << 1)) & 7;
+        case 6:  return (qp[2] >> 2)  & 7;
+        default: return (qp[2] >> 5)  & 7;
+    }
+}
+
 // NOTE: this is not dequantizing - we are simply fitting the template
 template <typename type4x4>
 void dequantize_f32(device const float4x4 * src, short il, thread type4x4 & reg) {
@@ -9281,6 +9329,141 @@ kernel void kernel_mul_mv_mxfp4_f32(
         ushort sgitg[[simdgroup_index_in_threadgroup]]) {
 
     kernel_mul_mv_mxfp4_f32_impl<N_R0_MXFP4, constant ggml_metal_kargs_mul_mv &>(args, src0, src1, dst, shmem, tgpig, tiisg, sgitg);
+}
+
+// Matrix-vector product for TQ3_4S weights.
+//
+// Uses the orthogonality of the randomized Hadamard transform (RHT): the
+// dequantized weight is w = SIGN * (1/sqrt(32)) * WHT(centroid*scale), so
+//   dot(w, y) = sum_j centroid_j*scale_j * RHT_forward(y)_j .
+// Therefore the (expensive) butterfly is applied ONCE per K-block to the
+// activation column (shared by all output rows of the SIMD-group), after which
+// each row only does a local codebook lookup + scale. One 32-element K-block
+// maps to the 32-lane SIMD-group; the WHT butterfly uses simd_shuffle_xor.
+template<int nr0, typename args_t>
+void kernel_mul_mv_tq3_4s_f32_impl(
+        args_t args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        threadgroup  char * shmem,
+        uint3  tgpig,
+        ushort tiisg,
+        ushort sgitg) {
+    const short NSG = FC_mul_mv_nsg;
+
+    const int nb = args.ne00 / QK_TQ3_0; // number of 32-element K-blocks
+
+    const int r0 = tgpig.x;
+    const int r1 = tgpig.y;
+    const int im = tgpig.z;
+
+    const int first_row = (r0 * NSG + sgitg) * nr0;
+
+    const uint i12 = im%FC_mul_mv_ne12;
+    const uint i13 = im/FC_mul_mv_ne12;
+
+    const uint64_t offset0 = first_row*args.nb01 + (i12/FC_mul_mv_r2)*args.nb02 + (i13/FC_mul_mv_r3)*args.nb03;
+    const uint64_t offset1 =        r1*args.nb11 + (i12        )*args.nb12 + (i13        )*args.nb13;
+
+    device const char  * cx = src0 + offset0;
+    device const float * y  = (device const float *) (src1 + offset1);
+
+    const ushort j    = tiisg;      // lane == element index within a K-block
+    const ushort g    = j / 8;
+    const ushort r3b  = j % 8;
+    const float  sign = TQ3_0_SIGNS_M[j];
+    const float  norm = 1.0f / sqrt(32.0f);
+
+    float sumf[nr0] = {0.f};
+
+    for (int ib = 0; ib < nb; ++ib) {
+        // forward RHT of the activation block (shared across the nr0 rows)
+        float yf = y[ib*QK_TQ3_0 + j] * sign;
+        for (ushort step = 1; step < 32; step <<= 1) {
+            const float o = simd_shuffle_xor(yf, step);
+            yf = (j & step) ? (o - yf) : (o + yf);
+        }
+        yf *= norm;
+
+        for (short row = 0; row < nr0; ++row) {
+            device const block_tq3_4s * b = (device const block_tq3_4s *) (cx + row*args.nb01) + ib;
+            device const uint8_t * qp = b->qs + g*3;
+            // 8 indices of a group are (packed >> (3*r)) & 7, r = 0..7
+            const uint packed = (uint) qp[0] | ((uint) qp[1] << 8) | ((uint) qp[2] << 16);
+            const uint8_t idx = (packed >> (3*r3b)) & 7;
+            const float c = TQ3_0_CENTROIDS_M[idx] * tq3_4s_decode_scale(b->d[g]);
+            sumf[row] += c * yf;
+        }
+    }
+
+    device float * dst_f32 = (device float *) dst + (int64_t)im*args.ne0*args.ne1 + (int64_t)r1*args.ne0;
+
+    for (int row = 0; row < nr0 && first_row + row < args.ne0; ++row) {
+        const float sum_all = simd_sum(sumf[row]);
+        if (tiisg == 0) {
+            dst_f32[first_row + row] = sum_all;
+        }
+    }
+}
+
+[[host_name("kernel_mul_mv_tq3_4s_f32")]]
+kernel void kernel_mul_mv_tq3_4s_f32(
+        constant ggml_metal_kargs_mul_mv & args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+
+    kernel_mul_mv_tq3_4s_f32_impl<N_R0_TQ3_4S, constant ggml_metal_kargs_mul_mv &>(args, src0, src1, dst, nullptr, tgpig, tiisg, sgitg);
+}
+
+// Custom get_rows for TQ3_4S: the generic template dequantizes per-thread which
+// cannot do the block-wide inverse RHT. Dispatched as one 32-lane SIMD-group per
+// gathered row (see ggml_metal_op_get_rows); the simd-group loops over the row's
+// 32-element blocks and applies the inverse RHT via simd_shuffle_xor.
+kernel void kernel_get_rows_tq3_4s(
+        constant ggml_metal_kargs_get_rows & args,
+        device const void * src0,
+        device const void * src1,
+        device       void * dst,
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiisg[[thread_index_in_simdgroup]]) {
+    const int32_t i10 = tgpig.x;
+    const int32_t i11 = tgpig.y;
+    const int32_t i12 = tgpig.z;
+
+    const int32_t r = ((const device int32_t *) ((const device char *) src1 + i12*args.nb12 + i11*args.nb11 + i10*args.nb10))[0];
+
+    const int32_t i02 = i11;
+    const int32_t i03 = i12;
+
+    device const block_tq3_4s * psrc = (device const block_tq3_4s *) ((const device char *) src0 + i03*args.nb03 + i02*args.nb02 + r*args.nb01);
+    device       float        * pdst = (device       float        *) ((      device char *) dst  + i12*args.nb3  + i11*args.nb2  + i10*args.nb1);
+
+    const int    nb   = args.ne00 / QK_TQ3_0; // 32-element blocks in the row
+    const ushort j    = tiisg;                // lane == element index within block
+    const ushort g    = j / 8;
+    const ushort r3b  = j % 8;
+    const float  sign = TQ3_0_SIGNS_M[j];
+    const float  norm = 1.0f / sqrt(32.0f);
+
+    for (int ib = 0; ib < nb; ++ib) {
+        device const block_tq3_4s * b = psrc + ib;
+
+        const uint8_t idx = tq3_4s_unpack3(b->qs + g*3, r3b);
+        float val = TQ3_0_CENTROIDS_M[idx] * tq3_4s_decode_scale(b->d[g]);
+
+        // inverse randomized Hadamard transform across the 32 lanes
+        for (ushort step = 1; step < 32; step <<= 1) {
+            const float o = simd_shuffle_xor(val, step);
+            val = (j & step) ? (o - val) : (o + val);
+        }
+
+        pdst[ib*QK_TQ3_0 + j] = val * sign * norm;
+    }
 }
 
 template<typename block_q, short nl, void (*dequantize_func)(device const block_q *, short, thread float4x4 &)>

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2408,6 +2408,7 @@ struct test_set_rows : public test_case {
 
     double max_nmse_err() override {
         if (type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q4_1 || type == GGML_TYPE_IQ4_NL ||
+            type == GGML_TYPE_TQ3_4S ||
             type == GGML_TYPE_Q5_0 || type == GGML_TYPE_Q5_1 || type == GGML_TYPE_Q8_0) {
             // estimate what the max nmse error would be if one quantized value is
             // off by one. The test values are distributed in [-1,1], so it'll be
@@ -7792,6 +7793,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_F32, GGML_TYPE_I64, { 1, 8, 1, 3 }, { 1, 1 }, 2, false));
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_F32, GGML_TYPE_I32, { 1, 8, 1, 3 }, { 1, 1 }, 2, false));
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_Q8_0, GGML_TYPE_I32, { 256, 5, 1, 3 }, { 1, 1, }, 1, false));
+    test_cases.emplace_back(new test_set_rows(GGML_TYPE_TQ3_4S, GGML_TYPE_I64, { 256, 5, 1, 3 }, { 1, 1, }, 1, false));
+    test_cases.emplace_back(new test_set_rows(GGML_TYPE_TQ3_4S, GGML_TYPE_I32, { 256, 5, 1, 3 }, { 1, 1, }, 1, false));
     for (ggml_type type : all_types) {
         for (int b : {1, 7}) {
             for (bool v : {false, true}) {


### PR DESCRIPTION
Clean replacement for PR #39, rebased onto current main and reduced to the Metal TQ3_4S implementation only.

Scope:
- Adds Metal TQ3_4S get_rows / mat-vec support.
- Adds RHT activation pre-pass for coalesced mat-vec.
- Adds Metal TQ3_4S GEMM path for batched eval.
- Adds docs/backend/Metal-TQ3.md.

Excluded from the old PR:
- Historical sync commits.
- CUDA/server/chat changes.
- Artifacts, scratch files, and unrelated scripts.

Validation run locally on Linux:
- cmake -S . -B build-pr39-clean-cpu -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=OFF -DGGML_METAL=OFF
- cmake --build build-pr39-clean-cpu --target llama-cli test-backend-ops -j 8

Metal runtime validation still needs Apple Silicon hardware.