### PR TITLE
fix: MTP shared-model load — save 2.9 GB VRAM, +7.7% tok/s

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1184,14 +1184,6 @@ private:
             }
         }
 
-        if (spec_mtp) {
-            string_parse_kv_override("llama.nomtp_trunk_only=bool:true", params_base.kv_overrides);
-            if (params_base.kv_overrides.empty() || params_base.kv_overrides.back().key[0] != 0) {
-                params_base.kv_overrides.emplace_back();
-                params_base.kv_overrides.back().key[0] = 0;
-            }
-        }
-
         // attach a progress callback
         {
             params_base.load_progress_callback = load_progress_callback;
@@ -1267,41 +1259,11 @@ private:
             params_base.speculative.draft.ctx_tgt = ctx_tgt;
             params_base.speculative.draft.ctx_dft = ctx_dft.get();
         } else if (spec_mtp) {
-            char trunk_arch[64] = {0};
-            llama_model_meta_val_str(model_tgt, "general.architecture", trunk_arch, sizeof(trunk_arch));
+            // no new model load: the MTP draft context shares the target model weights
+            load_progress_callback(0.0f, &load_progress_spec);
 
-            const char * mtp_arch = nullptr;
-            if (std::string(trunk_arch) == "qwen35" || std::string(trunk_arch) == "qwen35moe") {
-                mtp_arch = "qwen35_mtp";
-            } else {
-                SRV_ERR("MTP not supported for trunk architecture '%s'\n", trunk_arch);
-                return false;
-            }
-
-            SRV_TRC("loading MTP head from '%s' (override_arch=%s)\n",
-                    params_base.model.path.c_str(), mtp_arch);
-
-            auto params_mtp = params_base;
-            params_mtp.kv_overrides.erase(
-                    std::remove_if(params_mtp.kv_overrides.begin(), params_mtp.kv_overrides.end(), [](const llama_model_kv_override & ovrd) {
-                        return ovrd.key[0] == 0 ||
-                               std::strcmp(ovrd.key, "llama.nomtp_trunk_only") == 0 ||
-                               std::strcmp(ovrd.key, "llama.mtp_only") == 0;
-                    }),
-                    params_mtp.kv_overrides.end());
-            string_parse_kv_override("llama.mtp_only=bool:true", params_mtp.kv_overrides);
-            if (params_mtp.kv_overrides.empty() || params_mtp.kv_overrides.back().key[0] != 0) {
-                params_mtp.kv_overrides.emplace_back();
-                params_mtp.kv_overrides.back().key[0] = 0;
-            }
-
-            auto mparams_mtp = common_model_params_to_llama(params_mtp);
-
-            model_dft.reset(llama_model_load_from_file(params_base.model.path.c_str(), mparams_mtp));
-            if (model_dft == nullptr) {
-                SRV_ERR("failed to load MTP head from '%s'\n", params_base.model.path.c_str());
-                return false;
-            }
+            SRV_TRC("creating MTP draft context against the target model '%s'\n",
+                    params_base.model.path.c_str());
 
             auto cparams_mtp = common_context_params_to_llama(params_base);
             cparams_mtp.ctx_type      = LLAMA_CONTEXT_TYPE_MTP;
@@ -1311,7 +1273,7 @@ private:
             cparams_mtp.n_outputs_max = params_base.n_parallel;
             cparams_mtp.ctx_other     = ctx_tgt;
 
-            ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams_mtp));
+            ctx_dft.reset(llama_init_from_model(model_tgt, cparams_mtp));
             if (ctx_dft == nullptr) {
                 SRV_ERR("%s", "failed to create MTP context\n");
                 return false;


### PR DESCRIPTION
## Problem

The fork loaded the GGUF **twice** for MTP speculative decoding (split-load with `nomtp_trunk_only` + `mtp_only` KV overrides), duplicating all model weights in VRAM. This caused:

- **+2.9 GB unnecessary VRAM** usage (reported in #60)
- 752 unused-tensor warnings at startup
- On 16 GB cards (e.g. 4070 Ti Super), MTP pushed VRAM over the limit → paging → slowdown

Upstream loads the model **once** and shares the target model for the MTP draft context.

## Fix

Remove the second model load. The MTP draft context is created directly from `model_tgt` instead of a separately-loaded `model_dft`. The memory-reservation block already assumed this design (comment: *"MTP draft context lives on the target model, only context+compute are new"*), so only the load path was inconsistent.

**1 file changed, +5 / −43 lines.**

## Benchmark (RTX 3090, Qwen3.6-27B-MTP-TQ3_4S)

Reporter's exact flags: `-c 15000 -ngl 99 -fa on -np 1 -ctk/-ctv q8_0 --spec-type draft-mtp --spec-draft-n-max 2`, temp 0, 300 tokens × 3 runs.

| Metric | Before (split-load) | After (shared model) | Delta |
|---|---|---|---|
| Idle VRAM | 17,364 MiB | 14,450 MiB | **−2,914 MiB** |
| Peak VRAM | 17,396 MiB | 14,482 MiB | −2,914 MiB |
| Avg tok/s | 34.27 | 36.90 | **+7.7%** |
| Draft acceptance | 0.9238 (194/210) | 0.9238 (194/210) | identical |
| Mean draft len | 2.85 | 2.85 | identical |
| Startup warnings | 752 | **0** | eliminated |
| Output | coherent | coherent | ✓ |

On the reporter's 16 GB 4070 Ti Super, this drops MTP VRAM from ~17.8 GB → ~14.9 GB — under the 16 GB limit, eliminating the paging that caused their slowdown.

Fixes #60