### PR TITLE
ggml-cpu : remove duplicate ffs() definition (fixes MSVC C2084)

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -88,17 +88,6 @@ static int ffs(int x) {
 #include <strings.h>
 #endif
 
-// Portable ffs (find first set bit) for Windows/MSVC compatibility
-#if defined(_MSC_VER)
-#include <intrin.h>
-static int ffs(int x) {
-    unsigned long i;
-    return _BitScanForward(&i, (unsigned long)x) ? (int)(i + 1) : 0;
-}
-#else
-#include <strings.h>
-#endif
-
 // precomputed f32 table for f16 (256 KB) (simd-mappings.h)
 float ggml_table_f32_f16[1 << 16];
 


### PR DESCRIPTION
Fixes #66

The portable `ffs()` MSVC-compat block was accidentally committed twice in `ggml/src/ggml-cpu/ggml-cpu.c` (lines 91-100 are a verbatim duplicate of 80-89 — a rebase-checkpoint artifact from commit 562a26af2). MSVC rejects the second definition:

```
error C2084: function 'int ffs(int)' already has a body
```

**Change:** delete the duplicated block; one definition remains, and the sole call site (`ffs((int) super->mask) - 1` in the promoted-slot lookup) still resolves. The separate `ffs()` in `ggml-quants.c` is a different translation unit and is untouched.

**Verified:** `ggml-cpu` target builds clean (GCC, local build).

(Note for maintainers: this was first pushed directly to the stale `master` branch in error — that branch has been reverted to main's tip, and this PR is the proper path. My apologies for the direct push.)