### PR TITLE
mtmd: only temporal-merge frames with empty ids (fix multi-image drop)

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -88,17 +88,6 @@ static int ffs(int x) {
 #include <strings.h>
 #endif
 
-// Portable ffs (find first set bit) for Windows/MSVC compatibility
-#if defined(_MSC_VER)
-#include <intrin.h>
-static int ffs(int x) {
-    unsigned long i;
-    return _BitScanForward(&i, (unsigned long)x) ? (int)(i + 1) : 0;
-}
-#else
-#include <strings.h>
-#endif
-
 // precomputed f32 table for f16 (256 KB) (simd-mappings.h)
 float ggml_table_f32_f16[1 << 16];
 

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -958,7 +958,13 @@ struct mtmd_tokenizer {
                 if (i + 1 < parts.size() && parts[i + 1].bitmap != nullptr) {
                     const mtmd_bitmap * bm_a = parts[i].bitmap;
                     const mtmd_bitmap * bm_b = parts[i + 1].bitmap;
-                    if (bm_a->can_merge_with(*bm_b)) {
+                    // Temporal merge is only valid for frames of the SAME video stream.
+                    // Video frames (produced by the lazy video reader) carry no id, while
+                    // standalone images loaded via mtmd_helper always get a non-empty id
+                    // (FNV hash of the file). Merging two independent same-size images
+                    // collapses the second into the first at identical decoder positions,
+                    // making the second image invisible to the model (FAULT-005).
+                    if (bm_a->can_merge_with(*bm_b) && bm_a->id.empty() && bm_b->id.empty()) {
                         LOG_DBG("%s: merging 2 frames at part index %zu and %zu\n", __func__, i, i + 1);
                         merged_bitmaps.push_back({bm_a, bm_b});
                         parts.erase(parts.begin() + i + 1); // collapse the second bitmap part


### PR DESCRIPTION
## Problem (FAULT-005)

With a qwen3vl_merger mmproj, sending **two consecutive same-size images** in
one message made the model see only the first image.

Repro: two 300x300 solid-color PNGs in one chat message. Model reports a
single image. Server debug log shows `n_chunks = 1` for two images and both
halves decoded at identical token positions (`non-consecutive token position
11 after 11 ... 512 new tokens`). Different-size or text-separated images
worked because they could not be merged.

## Root cause

The `[QWEN_VIDEO]` temporal frame merge in `mtmd_tokenizer::tokenize()` fused
any two consecutive same-size bitmaps into a single image chunk, collapsing
the second (`parts.erase`). The merged chunk decodes as one image at a single
position base, so the second image is invisible to the model. Temporal merging
is only valid for frames of the **same video stream**.

## Fix

Video frames produced by the lazy video reader (`read_next_frame` →
`mtmd_bitmap_init`) carry **no id**, while standalone images loaded via
`mtmd_helper_bitmap_init_from_buf/from_file` always get a non-empty id
(FNV hash of the file). Gate the merge on both bitmaps having empty ids:

```cpp
if (bm_a->can_merge_with(*bm_b) && bm_a->id.empty() && bm_b->id.empty())
```

Real videos keep merging; independent images no longer collapse.

## Verification (fork build, UD-Q4_K_M GGUF, qwen3vl_merger mmproj)

| test | before | after |
|---|---|---|
| same-size adjacent | one image seen | **two images (red + teal)** |
| different-size adjacent | two images | two images |
| text-between | two images | two images |

Upstream attribution: reproduces on clean upstream master (byte-identical
path); upstream TODO at clip.cpp already flags the merge logic for refactor.