### PR TITLE
server: enable RS-rollback for MTP speculative decoding (44.9 -> 61.7 tok/s)

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -384,16 +384,9 @@ struct common_params_speculative {
     }
 
     uint32_t need_n_rs_seq() const {
-        bool has_mtp = std::any_of(types.begin(), types.end(), [&](auto t) {
-            return t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP;
-        });
-
-        if (has_mtp) {
-            return 0u; // MTP path: match old preserved binary behavior (0 rs_seq)
-        }
-
         bool needs_rs_seq = std::any_of(types.begin(), types.end(), [&](auto t) {
-            return t == COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3 || t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
+            return t == COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3 || t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH ||
+                   t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK || t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP;
         });
 
         return needs_rs_seq ? draft.n_max : 0u;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -476,6 +476,10 @@ static constexpr __host__ __device__ int calc_rows_per_block(int ncols_dst, int 
                 return small_k ? nwarps : 1;
             case 2:
             case 3:
+                // TQ3_4S large-K (MTP verify batches): extend the batch-1 small_k
+                // win (rows_per_block = nwarps) to the 2-3 wide verify path instead
+                // of leaving it hardcoded at 2.
+                return small_k ? nwarps : 2;
             case 4:
             case 5:
             case 6:
@@ -992,8 +996,11 @@ static void mul_mat_vec_q_switch_ncols_dst(
             use = false;
         }
 
-        if (GGML_CUDA_CC_IS_NVIDIA(cc) && type == GGML_TYPE_TQ3_4S && c_ncols_dst == 1) {
-            // 27B-class widths benefit from 2 rows/block; smaller models do not.
+        if (GGML_CUDA_CC_IS_NVIDIA(cc) && type == GGML_TYPE_TQ3_4S && c_ncols_dst >= 1 && c_ncols_dst <= 3) {
+            // 27B-class widths benefit from nwarps rows/block; smaller models do not.
+            // Extended from ncols_dst==1 to 2-3 to also cover MTP verify batches
+            // (n_max=2 -> ncols_dst up to 3), which previously fell back to the
+            // hardcoded rows_per_block=2 path and never got this win.
             constexpr int large_k_threshold_blocks = 144;
             if (blocks_per_row_x >= large_k_threshold_blocks) {
                 use = true;
@@ -1039,19 +1046,35 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 2: {
             constexpr int c_ncols_dst = 2;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
-            mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
-                 channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
-                 sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
-                 dims.first, dims.second, 0, ids_stride, stream);
+            bool use_small_k = should_use_small_k(c_ncols_dst);
+            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id, use_small_k);
+            if (use_small_k) {
+                mul_mat_vec_q_switch_fusion<type, c_ncols_dst, true>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
+                     channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
+                     sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
+                     dims.first, dims.second, 0, ids_stride, stream);
+            } else {
+                mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
+                     channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
+                     sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
+                     dims.first, dims.second, 0, ids_stride, stream);
+            }
         } break;
         case 3: {
             constexpr int c_ncols_dst = 3;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
-            mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
-                 channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
-                 sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
-                 dims.first, dims.second, 0, ids_stride, stream);
+            bool use_small_k = should_use_small_k(c_ncols_dst);
+            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id, use_small_k);
+            if (use_small_k) {
+                mul_mat_vec_q_switch_fusion<type, c_ncols_dst, true>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
+                     channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
+                     sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
+                     dims.first, dims.second, 0, ids_stride, stream);
+            } else {
+                mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
+                     channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
+                     sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
+                     dims.first, dims.second, 0, ids_stride, stream);
+            }
         } break;
         case 4: {
             constexpr int c_ncols_dst = 4;


### PR DESCRIPTION
## Summary

MTP was excluded from `n_rs_seq` in `need_n_rs_seq()` ('match old preserved binary behavior'), forcing the target context into FULL-seq-rm mode on hybrid SSM+attention models (qwen35). That triggered a full state checkpoint save every speculative step — measured **14.96 ms/step** on Qwen3.6-27B-MTP-TQ3_4S / RTX 3090, capping MTP decode at ~45 tok/s with 23% GPU idle.

## Fix

One-line change: give MTP the same bounded per-token recurrent snapshots (`n_rs_seq = n_max`) that EAGLE3/DFLASH/DSPARK already use. Target becomes RS-mode, `use_ckpt_tgt` is skipped, checkpoint save drops to **0.00 ms/step**.

## Measured (deterministic greedy, 300 tokens, RTX 3090, -c 8192)

| Config | tok/s |
|---|---:|
| before (FULL checkpoint mode) | 44.87 |
| **after (RS mode)** | **61.19-62.22** (4 runs) |

- Output **byte-identical** to no-drafter greedy baseline (md5 match) — lossless
- Hard86: 80/86 with reasoning budget 256 (58 first-pass without budget flag was a config artifact; 22/24 recovered with `--reasoning-budget 256`)
- Internal speed suite: GEN TOK/S 62.29, speed score 75.6 (9/9)

## n_max sweep — warm, realistic shape (1024-in / 4096-out, reasoning OFF, warmup discarded + mean of 3)

| n_max | tok/s mean | runs | acceptance | tokens/step | ms/step |
|---:|---:|---|---:|---:|---:|
| **2** | **59.0** | 58.7/59.0/59.4 | 0.734 | 2.47 | 41.8 |
| 3 | 52.1 | 52.6/52.9/50.6 | 0.620 | 2.86 | 54.9 |
| 4 | 47.5 | 46.1/47.5/48.9 | 0.553 | 3.21 | 67.6 |
| 5 | 43.1 | 43.1/43.1/43.2 | 0.454 | 3.27 | 75.8 |

**n_max=2 is optimal for this model** — it carries a single MTP head (`nextn_predict_layers = 1`), so deeper chains are sequential self-predictions and acceptance collapses 0.734 → 0.454 while step time grows linearly. The honest warm-shape ceiling is **59.0 tok/s**, up from the 44.4 tok/s pre-fix on the same shape — and it beats the old 57.9 tok/s fork high measured the same way.

Note: short-prompt (300-token) acceptance is ~0.95 giving 61-62 tok/s; the 59.0 figure is the defensible one for long agentic outputs.