### PR TITLE
quantize: keep hybrid-SSM state gates (ssm_alpha/ssm_beta) in f32 by default

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -448,6 +448,21 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
         return std::make_pair(i_layer, n_layer);
     };
 
+    // Hybrid SSM (e.g. DeltaNet / qwen3next): keep the recurrent state-update gates in f32 by default.
+    // These tensors participate multiplicatively in the carried recurrent state, so quantization error
+    // compounds along the sequence instead of staying local to one matmul. Measured on Qwen3.8-27B
+    // (48 DeltaNet + 17 attention layers): quantizing ssm_alpha/ssm_beta to tq3_4s collapses long
+    // reasoning (17k-64k reasoning chars, structural codegen bugs); forcing f32 restores full depth
+    // (33k-120k) and eliminates the structural failure mode. Cost is small: ~12 MiB per family on the
+    // 27B model. Rule: tensors that participate multiplicatively in recurrent state updates stay f32;
+    // readouts and projections may be quantized. Override with --tensor-type or --pure.
+    // NOTE: can't use LLM_TN here because the layer number is not known
+    if (name.find("ssm_alpha") != std::string::npos ||
+        name.find("ssm_beta")  != std::string::npos ||
+        name.find("ssm_ba")    != std::string::npos) {
+        return GGML_TYPE_F32;
+    }
+
     // for arches that share the same tensor between the token embeddings and the output, we quantize the token embeddings
     // with the quantization of the output tensor
     if (category == tensor_category::OUTPUT || (qs.has_tied_embeddings && category == tensor_category::TOKEN_EMBD)) {


### PR DESCRIPTION
## Summary

Hybrid SSM architectures (DeltaNet / qwen3next) carry a recurrent state whose update is multiplicative in `ssm_alpha`/`ssm_beta`. Quantization error on these tensors compounds along the sequence instead of staying local to one matmul, so they should stay f32 by default.

## Evidence (Qwen3.8-27B, 48 DeltaNet + 17 attention layers)

Multi-sample one-shot codegen comparison (garden three.js prompt, xhigh effort, same prompt/sampling/gate, 6 samples per arm):

| ssm_alpha/ssm_beta type | reasoning depth (chars) | result |
|---|---|---|
| tq3_4s (quantized) | 17k–64k (collapsed) | structural planning bugs, 0/9 clean |
| **f32 (this default)** | 33k–120k (restored) | structural bugs eliminated |

The failure mode with quantized gates is long-recurrent drift: shallow reasoning + structural codegen bugs (bake-order errors, lost track of earlier declarations). With f32 gates the model plans at full depth again.

## Cost

~12 MiB per family on the 27B model (~24 MiB total) — negligible against the multi-GB model size.

## Behavior

- Default: `ssm_alpha*`/`ssm_beta*`/`ssm_ba*` tensors → f32 for all ftypes
- `--tensor-type <pattern>=<type>` manual overrides still take precedence (verified)
- `--pure` quantizes everything as before (verified)
- Other SSM tensors already handled: `ssm_conv1d` stays unquantized via the existing exclusion; `ssm_a`/`ssm_dt` are tiny and already f32

## Rule

Tensors participating multiplicatively in recurrent state updates stay f32; readouts and projections may be quantized.

Note: this restores reasoning depth and eliminates structural bugs, but does not make tq3_4s match K-quants on one-shot codegen (a ternary typo-rate floor remains — separate issue, see investigation notes).