### PR TITLE
cuda: force VEC FA kernel for all tq3_0 KV combos (FAULT-008)

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -506,9 +506,12 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     }
 
     // Asymmetric tq3_0 V (K=q8_0/q4_0, V=tq3_0): native vector path for decode.
+    // tq3_0 V has no GPU to_fp16 conversion, so the MMA_F16/TILE paths dereference
+    // a null function pointer for ANY batch size. Force the VEC kernel unconditionally
+    // (FAULT-008: segfault on multi-slot decode when Q->ne[1] > 4).
     const bool asymm_tq3_v = (K->type == GGML_TYPE_Q8_0 || K->type == GGML_TYPE_Q4_0) &&
                               V->type == GGML_TYPE_TQ3_0;
-    if (asymm_tq3_v && Q->ne[1] <= 4) {
+    if (asymm_tq3_v) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
     }
 
@@ -517,6 +520,12 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     const bool asymm_turbo_v = (V->type == GGML_TYPE_TURBO3_0 || V->type == GGML_TYPE_TURBO4_0) &&
                                K->type != V->type;
     if (asymm_turbo_v) {
+        return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
+    }
+
+    // tq3_0 K or V of any combination (same-type tq3_0/tq3_0, TURBO4_0 K, or tq3_0 K):
+    // same null to_fp16 hazard on MMA_F16/TILE. Force VEC (FAULT-008).
+    if (K->type == GGML_TYPE_TQ3_0 || V->type == GGML_TYPE_TQ3_0) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
     }
 


### PR DESCRIPTION
## Problem

llama-server with a tq3_0 V KV cache (-ctv tq3_0, FA on or off) segfaults the moment 2+ slots decode concurrently:

llama-server: segfault at 0 ip 0000000000000000 sp ... error 14

gdb backtrace (4 concurrent decodes, -ctk q8_0 -ctv tq3_0, -np 4, RTX 3090):

#0 0x0000000000000000                    <- call through NULL
#1 launch_fattn<256,8,8>
#2 ggml_cuda_flash_attn_ext_mma_f16_case<256,256,8,8>   <- MMA_F16 path

## Root cause

tq3_0 V has no GPU to_fp16 conversion, so the MMA_F16/TILE flash-attention paths call a NULL dequant kernel pointer. The existing asymm_tq3_v guard only forced the safe VEC kernel when Q->ne[1] <= 4 — i.e. at most 4 concurrent sequences. Multi-slot decode batches more than that and falls through to BEST_FATTN_KERNEL_MMA_F16. Same hazard already documented in the adjacent turbo-V guard.

## Fix

- Remove the Q->ne[1] <= 4 cap from the asymm tq3_0-V guard (force VEC for any batch size).
- Add a catch-all forcing VEC for any K/V combination involving tq3_0 (same-type tq3_0/tq3_0, tq3_0-K, TURBO4_0+TQ3_0), mirroring the turbo-V handling.

## Verification (RTX 3090)

- pre-fix: 4 concurrent decodes with -ctv tq3_0 -np 4 -> SIGSEGV (ip=0)
- post-fix: 4/4 requests OK, server healthy after burst
- single-slot tq3_0 unaffected (already took VEC via the old <=4 guard)