### PR TITLE
cuda: real tq3_0 strided to_fp16 converter — fix FAULT-008 at the root

### DIFF
--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -645,6 +645,67 @@ static void dequantize_row_tq3_0_cuda(const void * vx, dst_t * y, const int64_t 
     dequantize_block_tq3_0<<<nb, 32, 0, stream>>>(vx, y, nb);
 }
 
+// Strided (non-contiguous) tq3_0 -> fp16 converter for the FA MMA/TILE path.
+// s01/s02/s03 are in units of tq3_0 blocks (matching the generic nc convention).
+template<typename dst_t>
+static __global__ void dequantize_block_tq3_0_nc(const void * __restrict__ vx, dst_t * __restrict__ y,
+        const int64_t ne00, const int64_t ne01,
+        const int64_t ne0203, const uint3 ne02_fdv,
+        const int64_t s01, const int64_t s02, const int64_t s03) {
+    const int64_t i00 = (int64_t)blockDim.x*blockIdx.x + threadIdx.x;
+    if (i00 >= ne00) {
+        return;
+    }
+
+    for (int64_t i01 = blockIdx.y; i01 < ne01; i01 += gridDim.y) {
+        for (int64_t i0203 = blockIdx.z; i0203 < ne0203; i0203 += gridDim.z) {
+            const uint2 dm = fast_div_modulo((uint32_t)i0203, ne02_fdv);
+            const int64_t i02 = dm.y;
+            const int64_t i03 = dm.x;
+
+            const int64_t ibx0 = i03*s03 + i02*s02 + i01*s01;
+            const int64_t ib   = ibx0 + i00/QK_TQ3_0;
+            const int     j    = i00 % QK_TQ3_0;
+
+            const block_tq3_0 * xb = (const block_tq3_0 *) vx + ib;
+            const float d = __half2float(xb->d);
+
+            // No-WHT: direct centroid * d (V-only KV cache, stored without rotation)
+            const int g = j / 8;
+            const int r = j % 8;
+            const uint8_t * qp = xb->qs + g*3;
+            uint8_t idx;
+            switch (r) {
+                case 0: idx =  qp[0]       & 7; break;
+                case 1: idx = (qp[0] >> 3) & 7; break;
+                case 2: idx = ((qp[0] >> 6) | (qp[1] << 2)) & 7; break;
+                case 3: idx = (qp[1] >> 1) & 7; break;
+                case 4: idx = (qp[1] >> 4) & 7; break;
+                case 5: idx = ((qp[1] >> 7) | (qp[2] << 1)) & 7; break;
+                case 6: idx = (qp[2] >> 2) & 7; break;
+                default: idx = (qp[2] >> 5) & 7; break;
+            }
+
+            const int64_t iy = (i0203*ne01 + i01)*ne00 + i00;
+            y[iy] = ggml_cuda_cast<dst_t>(tq3_0_centroids_cuda[idx] * d);
+        }
+    }
+}
+
+template<typename dst_t>
+static void dequantize_row_tq3_0_nc_cuda(const void * vx, dst_t * y,
+        const int64_t ne00, const int64_t ne01, const int64_t ne02, const int64_t ne03,
+        const int64_t s01, const int64_t s02, const int64_t s03, cudaStream_t stream) {
+    const int64_t ne0203 = ne02*ne03;
+    const uint3 ne02_fdv = init_fastdiv_values(ne02);
+    const dim3 num_blocks(
+        (ne00 + CUDA_DEQUANTIZE_BLOCK_SIZE - 1) / CUDA_DEQUANTIZE_BLOCK_SIZE,
+        (int)std::min(ne01,    (int64_t)65535),
+        (int)std::min(ne0203,  (int64_t)65535));
+    dequantize_block_tq3_0_nc<<<num_blocks, CUDA_DEQUANTIZE_BLOCK_SIZE, 0, stream>>>
+        (vx, y, ne00, ne01, ne0203, ne02_fdv, s01, s02, s03);
+}
+
 template<typename dst_t>
 static __global__ void dequantize_block_tq3_1s(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb) {
     const int i = blockIdx.x;
@@ -1129,6 +1190,8 @@ to_fp16_nc_cuda_t ggml_get_to_fp16_nc_cuda(ggml_type type) {
             return dequantize_block_cuda<QK5_1, QR5_1, dequantize_q5_1>;
         case GGML_TYPE_Q8_0:
             return dequantize_block_cuda<QK8_0, QR8_0, dequantize_q8_0>;
+        case GGML_TYPE_TQ3_0:
+            return dequantize_row_tq3_0_nc_cuda;
         case GGML_TYPE_BF16:
             return convert_unary_cuda<nv_bfloat16>;
         default:

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -477,7 +477,6 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         if (!asymm_tq3_ok && !is_kv_compat(K->type) && !is_kv_compat(V->type)) {
             return BEST_FATTN_KERNEL_NONE;
         }
-        // tq3_0-V asymmetric path must stay on VEC (not MMA) — handled below
     }
 #endif // GGML_CUDA_FA_ALL_QUANTS
 
@@ -505,15 +504,10 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
             break;
     }
 
-    // Asymmetric tq3_0 V (K=q8_0/q4_0, V=tq3_0): native vector path for decode.
-    // tq3_0 V has no GPU to_fp16 conversion, so the MMA_F16/TILE paths dereference
-    // a null function pointer for ANY batch size. Force the VEC kernel unconditionally
-    // (FAULT-008: segfault on multi-slot decode when Q->ne[1] > 4).
-    const bool asymm_tq3_v = (K->type == GGML_TYPE_Q8_0 || K->type == GGML_TYPE_Q4_0) &&
-                              V->type == GGML_TYPE_TQ3_0;
-    if (asymm_tq3_v) {
-        return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
-    }
+    // tq3_0 KV (all combos incl. q8_0/q4_0 K + tq3_0 V): to_fp16_nc now has a real
+    // tq3_0 converter, so normal selection applies — VEC for small-batch decode
+    // (native dequant, no pre-conversion), MMA_F16 for larger batches.
+    // (supersedes the FAULT-008 forced-VEC workaround)
 
     // Asymmetric turbo V (K != V type): turbo types have no GPU to_fp16 conversion,
     // so the MMA_F16 tile path would dereference a null function pointer. Force VEC.
@@ -523,9 +517,13 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
     }
 
-    // tq3_0 K or V of any combination (same-type tq3_0/tq3_0, TURBO4_0 K, or tq3_0 K):
-    // same null to_fp16 hazard on MMA_F16/TILE. Force VEC (FAULT-008).
-    if (K->type == GGML_TYPE_TQ3_0 || V->type == GGML_TYPE_TQ3_0) {
+    // tq3_0 K or V of any combination now has a real to_fp16_nc converter, so normal
+    // selection applies (VEC for small-batch decode, MMA_F16 for larger batches).
+    // EXCEPTION: turbo-K + tq3_0-V — turbo K types have no to_fp16_nc converter, so
+    // MMA_F16/TILE pre-conversion would still dereference nullptr. Keep those on VEC.
+    const bool turbo_k_tq3_v = (K->type == GGML_TYPE_TURBO4_0 || K->type == GGML_TYPE_TURBO3_0 ||
+                                K->type == GGML_TYPE_TURBO2_0) && V->type == GGML_TYPE_TQ3_0;
+    if (turbo_k_tq3_v) {
         return can_use_vector_kernel ? BEST_FATTN_KERNEL_VEC : BEST_FATTN_KERNEL_NONE;
     }
 


### PR DESCRIPTION
## FAULT-008 root-cause fix (supersedes the forced-VEC workaround from PR #76)

**Root cause:** the FA MMA/TILE path pre-converts strided KV-cache views via `ggml_get_to_fp16_nc_cuda`, which had **no TQ3_0 entry → nullptr function-pointer dereference** on multi-slot decode (the FAULT-008 segfault). PR #76 papered over this by force-pinning all tq3_0 KV to the slow VEC kernel — correct but slow for concurrent serving.

## Changes
- `convert.cu`: `dequantize_block_tq3_0_nc` + `dequantize_row_tq3_0_nc_cuda` — strided (non-contiguous) tq3_0 → fp16 converter. Same no-WHT centroid×d math as the existing contiguous kernel and the FA VEC dequant path.
- `convert.cu`: registered in `ggml_get_to_fp16_nc_cuda`.
- `fattn.cu`: removed both forced-VEC tq3_0 pins. Normal kernel selection now applies — VEC for small-batch decode (native dequant, zero pre-conversion overhead), MMA_F16 for larger batches. Kept the narrow exception: turbo-K + tq3_0-V stays on VEC (turbo K types still lack to_fp16_nc).

## Verified on local 3090 (RTX 3090, cc 86), Qwen3.8-27B-TQ3_4S-v2, `-ctk q8_0 -ctv tq3_0 -np 4`
- 6 concurrent requests: all OK (previously SIGSEGV)
- counting output under 4-slot load: exact 1..30 (bitwise correct)
- 8 concurrent × 512 tok: **77.9 tok/s aggregate**, no errors
- single-stream decode: VEC path selection unchanged (45 tok/s, same as before)

Single-stream tq3_0 serving remains on VEC (native dequant beats the MMA pre-conversion at batch 1); multi-slot now gets MMA.