### PR TITLE
fix: MTP draft state is per-sequence, and roll back draft KV with a single head

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1493,6 +1493,27 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
             auto * mem_dft = llama_get_memory(ctx_dft);
 
+            // Drop any draft KV at or after this batch's start position, for
+            // every sequence in the batch.
+            //
+            // This used to happen only under `chain_heads`. With a single MTP
+            // head (`--spec-draft-n-max 1`) chain_heads is false, so nothing
+            // rolled the draft cache back -- and when the server reuses a slot
+            // for a new task via LCP prompt-cache similarity, the draft context
+            // still holds KV past the new prompt's start. llama_decode then
+            // rejects the batch with "the last position stored in the memory
+            // module ... is X" / "starting position of Y" where X >= Y, and the
+            // request fails with "failed to process speculative batch".
+            //
+            // The target context is trimmed on slot reuse; the draft context
+            // has to be trimmed to match it. See issue #78.
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (i_batch_beg[seq_id] < 0) {
+                    continue;
+                }
+                llama_memory_seq_rm(mem_dft, seq_id, batch_in.pos[i_batch_beg[seq_id]], -1);
+            }
+
             bool ok = true;
             for (int head = 0; head < n_mtp_layers; ++head) {
                 if (chain_heads) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1326,8 +1326,8 @@ void llama_context::set_mtp(llama_context * ctx_mtp_in) {
         mtp.hook_tokens.clear();
     }
 
-    mtp.ctx_mtp     = ctx_mtp_in;
-    mtp.pending_pos = -1;
+    mtp.ctx_mtp = ctx_mtp_in;
+    mtp.reset();
 
     if (mtp.ctx_mtp) {
         const int32_t n_ub   = (int32_t) cparams.n_ubatch;
@@ -1349,110 +1349,137 @@ void llama_context::set_mtp(llama_context * ctx_mtp_in) {
 #endif
         mtp.hook_tokens.assign(n_ub, LLAMA_TOKEN_NULL);
         mtp.hook_batch.token = mtp.hook_tokens.data();
-        mtp.pending_h.assign(n_embd, 0.0f);
+        // per-sequence carryover is allocated lazily on first use per seq_id
         LLAMA_LOG_INFO("%s: MTP draft head registered (ctx_mtp=%p, n_ubatch=%d, n_embd=%d)\n",
                        __func__, (const void *) mtp.ctx_mtp, n_ub, n_embd);
     } else {
         mtp.hook_tokens.clear();
         mtp.hook_tokens.shrink_to_fit();
-        mtp.pending_h.clear();
-        mtp.pending_h.shrink_to_fit();
+        mtp.reset();
         LLAMA_LOG_INFO("%s: MTP draft head unregistered\n", __func__);
     }
 }
 
 void llama_context::handle_mtp_for_ubatch(
-        int32_t              n_tokens,
-        const llama_token  * tokens,
-        const llama_pos    * positions,
+        const llama_ubatch & ubatch,
         struct ggml_tensor * t,
         bool                 decode_mtp) {
-    if (mtp.ctx_mtp == nullptr || n_tokens == 0 || t == nullptr) {
+    if (mtp.ctx_mtp == nullptr || ubatch.n_tokens == 0 || t == nullptr) {
         return;
     }
-    if (t->ne[1] != (int64_t) n_tokens) {
+    if (t->ne[1] != (int64_t) ubatch.n_tokens) {
+        return;
+    }
+    if (ubatch.token == nullptr || ubatch.pos == nullptr || ubatch.seq_id == nullptr) {
         return;
     }
 
-    const int64_t n_embd = model.hparams.n_embd;
+    const int64_t n_embd    = model.hparams.n_embd;
+    const size_t  row_bytes = (size_t) n_embd * sizeof(float);
     GGML_ASSERT(t->ne[0] == n_embd);
 
-    const int       n_rows    = (int) n_tokens;
-    const llama_pos pos_start = positions[0];
-
-    const llama_pos pos_max_mtp = llama_memory_seq_pos_max(llama_get_memory(mtp.ctx_mtp), 0);
-    if (pos_start <= pos_max_mtp) {
-        llama_memory_seq_rm(llama_get_memory(mtp.ctx_mtp), 0, pos_start, -1);
-        if (mtp.pending_pos >= pos_start) {
-            mtp.pending_pos = -1;
-        }
-    }
-
-    synchronize();
-
-    const bool pending_continues = mtp.pending_pos >= 0 && mtp.pending_pos + 1 == pos_start;
-    if (mtp.pending_pos >= 0 && !pending_continues) {
-        mtp.pending_pos = -1;
-    }
-
-    const size_t row_bytes = (size_t) n_embd * sizeof(float);
-    const int    n_out     = (pending_continues ? 1 : 0) + (n_rows - 1);
-
-    if (decode_mtp && n_out > 0) {
-        int out_idx = 0;
-        if (pending_continues) {
-            std::memcpy(mtp.hook_batch.embd + (size_t) out_idx * n_embd, mtp.pending_h.data(), row_bytes);
-            mtp.hook_batch.token[out_idx]     = tokens[0];
-            mtp.hook_batch.pos[out_idx]       = pos_start;
-            mtp.hook_batch.n_seq_id[out_idx]  = 1;
-            mtp.hook_batch.seq_id[out_idx][0] = 0;
-            mtp.hook_batch.logits[out_idx]    = 0;
-            ++out_idx;
-        }
-        if (n_rows > 1) {
-            ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
-            GGML_ASSERT(backend_t != nullptr);
-
-            ggml_backend_tensor_get_2d_async(
-                backend_t,
-                t,
-                mtp.hook_batch.embd + (size_t) out_idx * n_embd,
-                0,
-                row_bytes,
-                (size_t) n_rows - 1,
-                row_bytes,
-                row_bytes);
-        }
-        for (int k = 0; k + 1 < n_rows; ++k) {
-            mtp.hook_batch.token[out_idx]     = tokens[k + 1];
-            mtp.hook_batch.pos[out_idx]       = positions[k + 1];
-            mtp.hook_batch.n_seq_id[out_idx]  = 1;
-            mtp.hook_batch.seq_id[out_idx][0] = 0;
-            mtp.hook_batch.logits[out_idx]    = 0;
-            ++out_idx;
-        }
-        GGML_ASSERT(out_idx == n_out);
-        mtp.hook_batch.n_tokens = n_out;
-
-        synchronize();
-
-        const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
-        if (rc_dec != 0) {
-            LLAMA_LOG_ERROR("%s: llama_decode(ctx_mtp) failed rc=%d (pos=%d, n=%d)\n",
-                            __func__, (int) rc_dec, (int) pos_start, n_out);
-        }
-    }
+    const int n_rows_total = (int) ubatch.n_tokens;
 
     ggml_backend_t backend_t = ggml_backend_sched_get_tensor_backend(sched.get(), t);
     GGML_ASSERT(backend_t != nullptr);
 
-    ggml_backend_tensor_get_async(
-        backend_t,
-        t,
-        mtp.pending_h.data(),
-        (size_t) (n_rows - 1) * row_bytes,
-        row_bytes);
-    mtp.pending_pos = pos_start + n_rows - 1;
+    // Pull every hidden-state row to the host once.
+    //
+    // The previous implementation fetched rows [0, n_rows-1) with a single
+    // strided copy, which is only valid when the whole ubatch belongs to one
+    // sequence. Under -np > 1 a ubatch may mix sequences, and a sequence's rows
+    // need not be contiguous, so the rows are staged here and distributed
+    // per sequence below.
+    mtp.host_h.resize((size_t) n_rows_total * n_embd);
+    ggml_backend_tensor_get_async(backend_t, t, mtp.host_h.data(), 0, (size_t) n_rows_total * row_bytes);
+
+    synchronize();
+
+    // Group the ubatch rows by sequence, preserving order within each sequence.
+    // A token may belong to several sequences (shared prefixes); the MTP draft
+    // state follows seq_id[0], which is what the single-sequence code did
+    // implicitly.
+    std::unordered_map<llama_seq_id, std::vector<int>> rows_by_seq;
+    for (int i = 0; i < n_rows_total; ++i) {
+        if (ubatch.n_seq_id != nullptr && ubatch.n_seq_id[i] <= 0) {
+            continue;
+        }
+        if (ubatch.seq_id[i] == nullptr) {
+            continue;
+        }
+        rows_by_seq[ubatch.seq_id[i][0]].push_back(i);
+    }
+
+    for (auto & entry : rows_by_seq) {
+        const llama_seq_id seq_id = entry.first;
+        const std::vector<int> & rows = entry.second;
+
+        const int n_rows = (int) rows.size();
+        if (n_rows == 0) {
+            continue;
+        }
+
+        auto & st = mtp.seq[seq_id];
+        if (st.pending_h.size() != (size_t) n_embd) {
+            st.pending_h.assign((size_t) n_embd, 0.0f);
+            st.pending_pos = -1;
+        }
+
+        const llama_pos pos_start = ubatch.pos[rows[0]];
+
+        // Roll back this sequence's draft KV only -- never another slot's.
+        const llama_pos pos_max_mtp = llama_memory_seq_pos_max(llama_get_memory(mtp.ctx_mtp), seq_id);
+        if (pos_start <= pos_max_mtp) {
+            llama_memory_seq_rm(llama_get_memory(mtp.ctx_mtp), seq_id, pos_start, -1);
+            if (st.pending_pos >= pos_start) {
+                st.pending_pos = -1;
+            }
+        }
+
+        const bool pending_continues = st.pending_pos >= 0 && st.pending_pos + 1 == pos_start;
+        if (st.pending_pos >= 0 && !pending_continues) {
+            st.pending_pos = -1;
+        }
+
+        const int n_out = (pending_continues ? 1 : 0) + (n_rows - 1);
+
+        if (decode_mtp && n_out > 0) {
+            int out_idx = 0;
+            if (pending_continues) {
+                std::memcpy(mtp.hook_batch.embd + (size_t) out_idx * n_embd, st.pending_h.data(), row_bytes);
+                mtp.hook_batch.token[out_idx]     = ubatch.token[rows[0]];
+                mtp.hook_batch.pos[out_idx]       = pos_start;
+                mtp.hook_batch.n_seq_id[out_idx]  = 1;
+                mtp.hook_batch.seq_id[out_idx][0] = seq_id;
+                mtp.hook_batch.logits[out_idx]    = 0;
+                ++out_idx;
+            }
+            for (int k = 0; k + 1 < n_rows; ++k) {
+                std::memcpy(mtp.hook_batch.embd + (size_t) out_idx * n_embd,
+                            mtp.host_h.data() + (size_t) rows[k] * n_embd,
+                            row_bytes);
+                mtp.hook_batch.token[out_idx]     = ubatch.token[rows[k + 1]];
+                mtp.hook_batch.pos[out_idx]       = ubatch.pos[rows[k + 1]];
+                mtp.hook_batch.n_seq_id[out_idx]  = 1;
+                mtp.hook_batch.seq_id[out_idx][0] = seq_id;
+                mtp.hook_batch.logits[out_idx]    = 0;
+                ++out_idx;
+            }
+            GGML_ASSERT(out_idx == n_out);
+            mtp.hook_batch.n_tokens = n_out;
+
+            const int32_t rc_dec = llama_decode(mtp.ctx_mtp, mtp.hook_batch);
+            if (rc_dec != 0) {
+                LLAMA_LOG_ERROR("%s: llama_decode(ctx_mtp) failed rc=%d (seq=%d, pos=%d, n=%d)\n",
+                                __func__, (int) rc_dec, (int) seq_id, (int) pos_start, n_out);
+            }
+        }
+
+        std::memcpy(st.pending_h.data(),
+                    mtp.host_h.data() + (size_t) rows[n_rows - 1] * n_embd,
+                    row_bytes);
+        st.pending_pos = ubatch.pos[rows[n_rows - 1]];
+    }
 }
 
 void llama_context::set_causal_attn(bool value) {
@@ -2288,7 +2315,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
         }
 
         if (mtp.ctx_mtp != nullptr && t_h_nextn != nullptr && ubatch.token != nullptr && ubatch.pos != nullptr) {
-            handle_mtp_for_ubatch((int32_t) ubatch.n_tokens, ubatch.token, ubatch.pos, t_h_nextn, true);
+            handle_mtp_for_ubatch(ubatch, t_h_nextn, true);
         }
 
         // Copy backend sampling output if this ubatch produced any sampling tensors.

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -278,10 +278,11 @@ private:
     // that differs from the layer it belongs to (usually due to missing backend support)
     void resolve_fused_ops(const llama_memory_context_i * mctx, uint32_t n_seqs);
 
+    // note: takes the whole ubatch because the MTP carryover state is per
+    //       sequence -- tokens/positions alone cannot say which sequence a row
+    //       belongs to, which is what broke under -np > 1 (issue #78).
     void handle_mtp_for_ubatch(
-            int32_t              n_tokens,
-            const llama_token  * tokens,
-            const llama_pos    * positions,
+            const llama_ubatch & ubatch,
             struct ggml_tensor * t_h_pre_norm,
             bool                 decode_mtp);
 

--- a/src/llama-mtp.h
+++ b/src/llama-mtp.h
@@ -3,6 +3,7 @@
 #include "llama.h"
 #include "../ggml/include/ggml-backend.h"
 
+#include <unordered_map>
 #include <vector>
 
 struct llama_mtp {
@@ -12,6 +13,30 @@ struct llama_mtp {
     std::vector<llama_token> hook_tokens;
 
     // Cross-ubatch carryover for the final hidden-state row.
-    std::vector<float> pending_h;   // [n_embd]
-    llama_pos          pending_pos = -1;
+    //
+    // This is PER SEQUENCE. It used to be a single pending_h/pending_pos pair,
+    // which is correct only while one sequence is ever in flight. With -np > 1
+    // the server interleaves slots, so slot B's ubatch would consume the
+    // carryover slot A had left behind and MTP would decode with a hidden state
+    // belonging to a different conversation at a position from a third one --
+    // surfacing as "sequence 0 positions are decreasing" and the M-RoPE
+    // "X < Y" assertion. See issue #78.
+    struct seq_state {
+        std::vector<float> pending_h;   // [n_embd]
+        llama_pos          pending_pos = -1;
+    };
+
+    std::unordered_map<llama_seq_id, seq_state> seq;
+
+    // Staging buffer for one ubatch worth of hidden-state rows.
+    // Rows belonging to a single sequence are not necessarily contiguous within
+    // a ubatch, so the rows are pulled to the host once and then distributed
+    // per sequence, rather than fetched with a per-sequence strided copy.
+    std::vector<float> host_h;
+
+    void reset() {
+        seq.clear();
+        host_h.clear();
+        host_h.shrink_to_fit();
+    }
 };


### PR DESCRIPTION
Fixes #78

Two independent bugs made `--spec-type draft-mtp` unusable with `-np > 1`. Both are position-management errors that only appear once more than one slot is live.

## Bug 1: `handle_mtp_for_ubatch()` hardcoded sequence 0

`seq_pos_max`, `seq_rm` and both `seq_id` writes used literal 0, and the cross-ubatch carryover (`pending_h`/`pending_pos`) was a single pair shared by every slot. With `-np 4` the server interleaves slots, so slot B's ubatch consumed the carryover slot A had left behind.

Carryover is now keyed by `seq_id`, and the draft KV rollback targets the correct sequence.

## Bug 2: Draft KV never rolled back with single MTP head

In `common/speculative.cpp` the `llama_memory_seq_rm` on the draft context only ran under `chain_heads`, which is `n_mtp_layers > 1 && !is_mem_shared`. With `--spec-draft-n-max 1` that's false.

When the server reuses a slot via LCP prompt-cache similarity it trims the target context but not the draft one, so `llama_decode` rejects the batch.

Draft KV rollback now runs unconditionally.

## Measured on Qwen3.5-9B-MTP, 8 concurrent requests

```
                                    before   after
handle_mtp_for_ubatch errors          74       0
"positions are decreasing"             6       0
"inconsistent sequence positions"     69       0
"llama_decode: failed"                75       0
non-empty responses                  4/8     8/8
```

Speculative decoding stays lossless — greedy output is byte-identical with `--spec-type draft-mtp` and `--spec-type none`. Draft acceptance stays at 0.64–0.86.